### PR TITLE
Fix office controller get one

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 allprojects {
     group = 'mil.army.usace.hec.cwms'
-    version = '2.1.0'    
+    version = '2.1.1'    
 }
 
 ext.dropwizard_version="4.1.2"

--- a/cwms_radar_tomcat/src/main/java/cwms/radar/ApiServlet.java
+++ b/cwms_radar_tomcat/src/main/java/cwms/radar/ApiServlet.java
@@ -80,7 +80,7 @@ public class ApiServlet extends HttpServlet {
                 .routes( () -> {      
                     //get("/", ctx -> { ctx.result("welcome to the CWMS REST APi").contentType("text/plain");});              
                     crud("/locations/:location_code", new LocationController(metrics));
-                    crud("/offices/:office_name", new OfficeController(metrics));
+                    crud("/offices/:office", new OfficeController(metrics));
                     crud("/units/:unit_name", new UnitsController(metrics));
                     crud("/parameters/:param_name", new ParametersController(metrics));
                     crud("/timezones/:zone", new TimeZoneController(metrics));

--- a/cwms_radar_tomcat/src/main/webapp/swagger-config.yaml
+++ b/cwms_radar_tomcat/src/main/webapp/swagger-config.yaml
@@ -411,36 +411,36 @@ paths:
           description: unexpected error
           schema:
             $ref: '#/definitions/errorModel'
-  /offices:
-    get:
-      description: The offices URI allows access to CWMS office data.
-      operationId: findOffices
-      produces:
-        - application/json
-        - application/xml
-        - text/xml
-        - text/html
-        - text/csv
-      parameters:
-        - name: format
-          in: query
-          description:  |
-            Specifies specifies the encoding format of the response.  Valid values for the format field for this URI are: 
-                1.	tab
-                2.	csv
-                3.	xml            
-                4.	json           
-          required: false
-          type: string
-          enum: ["tab", "csv", "xml", "json"]
-      responses:
-        '200':
-          description: office response
-          schema:
-            type: string
-        default:
-          description: unexpected error
-          schema:
+  # /offices:
+  #   get:
+  #     description: The offices URI allows access to CWMS office data.
+  #     operationId: findOffices
+  #     produces:
+  #       - application/json
+  #       - application/xml
+  #       - text/xml
+  #       - text/html
+  #       - text/csv
+  #     parameters:
+  #       - name: format
+  #         in: query
+  #         description:  |
+  #           Specifies specifies the encoding format of the response.  Valid values for the format field for this URI are: 
+  #               1.	tab
+  #               2.	csv
+  #               3.	xml            
+  #               4.	json           
+  #         required: false
+  #         type: string
+  #         enum: ["tab", "csv", "xml", "json"]
+  #     responses:
+  #       '200':
+  #         description: office response
+  #         schema:
+  #           type: string
+  #       default:
+  #         description: unexpected error
+  #         schema:
             $ref: '#/definitions/errorModel'        
   /timezones:
     get:


### PR DESCRIPTION
Discovered some issues with the way OpenAPI works, the parameter name in the annotation has to have the same name as the crud handler parameter or it thinks there's two different parameter.