### PR TITLE
Fix release build

### DIFF
--- a/.github/workflows/get_version.sh
+++ b/.github/workflows/get_version.sh
@@ -1,4 +1,4 @@
-VERSION=`./gradlew properties -q | grep "version:" | awk '{ print $2}'`
+VERSION=`./gradlew properties -q | grep "^version:" | awk '{ print $2}'`
 WARFILE="cwms_radar_tomcat/build/libs/cwms_radar_tomcat-$VERSION.war"
 echo "::set-output name=VERSION::$VERSION"
 echo "::set-output name=WAR_FILE::$WARFILE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,7 @@ jobs:
           ECR_REPOSITORY: cwms-radar-api
           IMAGE_TAG: ${{steps.get_version.outputs.VERSION}}
         run: |
+          ./gradlew :cwms_radar_api:build
           ./gradlew prepareDocker
           cd cwms_radar_standlone/build/docker
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .


### PR DESCRIPTION
Found a few minor problems with the release build and support scripts. Still a few things to fix (like way the standalone subproject isn't building the api jar) but this is good enough for now.