### PR TITLE
[timeseries] update begin/end logic.

### DIFF
--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDao.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDao.java
@@ -1,6 +1,8 @@
 package cwms.radar.data.dao;
 
 import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,8 +21,8 @@ public interface TimeSeriesDao
 
 	void delete(String office, String tsId);
 
-	TimeSeries getTimeseries(String cursor, int pageSize, String names, String office, String unit, String datum, String begin, String end, String timezone);
-	String getTimeseries(String format, String names, String office, String unit, String datum, String begin, String end, String timezone);
+	TimeSeries getTimeseries(String cursor, int pageSize, String names, String office, String unit, String datum, ZonedDateTime begin, ZonedDateTime end, ZoneId timezone);
+	String getTimeseries(String format, String names, String office, String unit, String datum, ZonedDateTime begin, ZonedDateTime end, ZoneId timezone);
 
 
 

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
@@ -45,6 +45,8 @@ import cwms.radar.data.dto.TsvId;
 import cwms.radar.data.dto.VerticalDatumInfo;
 import cwms.radar.data.dto.catalog.CatalogEntry;
 import cwms.radar.data.dto.catalog.TimeseriesCatalogEntry;
+import cwms.radar.helpers.DateUtils;
+
 import org.jetbrains.annotations.NotNull;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -97,30 +99,22 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 		super(dsl);
 	}
 
-	public String getTimeseries(String format, String names, String office, String units, String datum, String begin,
-								String end, String timezone) {
+	public String getTimeseries(String format, String names, String office, String units, String datum,
+								ZonedDateTime begin, ZonedDateTime end, ZoneId timezone) {
 		return CWMS_TS_PACKAGE.call_RETRIEVE_TIME_SERIES_F(dsl.configuration(),
-				names, format, units, datum, begin, end, timezone, office);
+				names, format, units, datum,
+				begin.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+				end.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+				timezone.getId(), office);
 	}
 
 
-	public TimeSeries getTimeseries(String page, int pageSize, String names, String office, String units, String datum, String begin, String end, String timezone) {
+	public TimeSeries getTimeseries(String page, int pageSize, String names, String office,
+									String units, String datum,
+									ZonedDateTime begin, ZonedDateTime end, ZoneId timezone) {
 		// Looks like the datum field is currently being ignored by this method.
 		// Should we warn if the datum is not null?
-		ZoneId zone;
-		if(timezone == null)
-		{
-			zone = ZoneOffset.UTC.normalized();
-		}
-		else
-		{
-			zone = ZoneId.of(timezone);
-		}
-
-		ZonedDateTime beginTime = getZonedDateTime(begin, zone, ZonedDateTime.now().minusDays(1));
-		ZonedDateTime endTime = getZonedDateTime(end, beginTime.getZone(), ZonedDateTime.now());
-
-		return getTimeseries(page, pageSize, names, office, units, beginTime, endTime);
+		return getTimeseries(page, pageSize, names, office, units, begin, end);
 	}
 
 	public ZonedDateTime getZonedDateTime(String begin, ZoneId fallbackZone, ZonedDateTime beginFallback)

--- a/cwms_radar_api/src/test/java/cwms/radar/api/TimeSeriesControllerTest.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/TimeSeriesControllerTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNotNull;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -63,7 +64,7 @@ public class TimeSeriesControllerTest extends ControllerTest {
         when(
                 dao.getTimeseries(eq(""), eq(500), eq(tsId), eq(officeId), eq("EN"),
                         isNull(),
-                        isNull(), isNull(), isNull())).thenReturn(expected);
+                        isNotNull(), isNotNull(), isNotNull())).thenReturn(expected);
 
 
         // build mock request and response
@@ -109,7 +110,7 @@ public class TimeSeriesControllerTest extends ControllerTest {
         // Check that the controller accessed our mock dao in the expected way
         verify(dao, times(1)).
                 getTimeseries(eq(""), eq(500), eq(tsId), eq(officeId), eq("EN"),
-                        isNull(), isNull(), isNull(), isNull());
+                        isNull(), isNotNull(), isNotNull(), isNotNull());
 
         // Make sure controller thought it was happy
         verify(response).setStatus(200);


### PR DESCRIPTION
Updated DAO to always take a ZonedDateTime for begin and end and a
ZoneId for timezone. The controller will be responsible for default
behavoirs and avoiding ambiguity.