### PR TITLE
Throw an exception if accept-header and query arg are both specified.

### DIFF
--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/Formats.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/Formats.java
@@ -173,6 +173,13 @@ public class Formats {
      */
     public static ContentType parseHeaderAndQueryParm(String header, String queryParam){
         if( queryParam != null && !queryParam.isEmpty() ){
+            if(header != null && !header.isEmpty()){
+                // If the user supplies an accept header and also a format= parameter, which should we use?
+                // The older format= query parameters don't give us the option to supply a version the
+                // way that the accept header does.
+                throw new FormattingException("Accept header and query parameter are both present, this is not supported.");
+            }
+
             String val = typeMap.get(queryParam);
             if( val != null ){
                 return new ContentType(val);

--- a/cwms_radar_api/src/test/java/cwms/radar/formatters/FormatsTest.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/formatters/FormatsTest.java
@@ -1,0 +1,121 @@
+package cwms.radar.formatters;
+
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class FormatsTest
+{
+
+	@Test
+	public void testParseHeaderAndQueryParmJSON(){
+		ContentType contentType =Formats.parseHeaderAndQueryParm("application/json", null);
+
+		assertNotNull(contentType);
+		assertEquals("application/json", contentType.getType());
+		Map<String, String> parameters = contentType.getParameters();
+		assertTrue(parameters == null || parameters.isEmpty());
+
+	}
+
+	@Test
+	public void testParseHeaderAndQueryParmJSONv2()
+	{
+		ContentType contentType = Formats.parseHeaderAndQueryParm("application/json;version=2", null);
+
+		assertNotNull(contentType);
+		assertEquals("application/json", contentType.getType());
+		Map<String, String> parameters = contentType.getParameters();
+		assertNotNull(parameters);
+		assertFalse(parameters.isEmpty());
+		assertTrue(parameters.containsKey("version"));
+		assertEquals("2", parameters.get("version"));
+	}
+
+	@Test
+	public void testParseNullNull()
+	{
+		RuntimeException thrown = Assertions.assertThrows(FormattingException.class, () -> {
+			Formats.parseHeaderAndQueryParm(null, null);
+		});
+	}
+
+	@Test
+	public void testParseEmptyHeader(){
+
+		ContentType contentType =Formats.parseHeaderAndQueryParm("", "json");
+
+		assertNotNull(contentType);
+		assertEquals("application/json", contentType.getType());
+		Map<String, String> parameters = contentType.getParameters();
+		assertTrue(parameters == null || parameters.isEmpty());
+	}
+
+	@Test
+	public void testParseNullHeader(){
+
+		ContentType contentType =Formats.parseHeaderAndQueryParm(null, "json");
+
+		assertNotNull(contentType);
+		assertEquals("application/json", contentType.getType());
+		Map<String, String> parameters = contentType.getParameters();
+		assertTrue(parameters == null || parameters.isEmpty());
+
+
+
+	}
+
+
+	@Test
+	public void testParseHeaderAndQueryParmXML(){
+		RuntimeException thrown = Assertions.assertThrows(FormattingException.class, () -> {
+			Formats.parseHeaderAndQueryParm(null, null);
+		});
+
+		ContentType contentType =Formats.parseHeaderAndQueryParm("application/xml", null);
+
+		assertNotNull(contentType);
+		assertEquals("application/xml", contentType.getType());
+		Map<String, String> parameters = contentType.getParameters();
+		assertTrue(parameters == null || parameters.isEmpty());
+
+
+		contentType =Formats.parseHeaderAndQueryParm("application/xml;version=2", null);
+
+		assertNotNull(contentType);
+		assertEquals("application/xml", contentType.getType());
+		parameters = contentType.getParameters();
+		assertNotNull(parameters);
+		assertFalse(parameters.isEmpty());
+		assertTrue(parameters.containsKey("version"));
+		assertEquals("2", parameters.get("version"));
+
+	}
+
+	@Test
+	public void testParseBoth(){
+		RuntimeException thrown = Assertions.assertThrows(FormattingException.class, () -> {
+			Formats.parseHeaderAndQueryParm("application/json", "json");
+		});
+
+
+	}
+
+	@Test
+	public void testParseBothv2(){
+		RuntimeException thrown = Assertions.assertThrows(FormattingException.class, () -> {
+			Formats.parseHeaderAndQueryParm("application/json;version=2", "json");
+		});
+
+
+
+	}
+
+}


### PR DESCRIPTION
Closes #72 