### PR TITLE
Bugfix/timeseries retrieve performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 **/.project
 **/.settings
 **/bin
+gradle.properties

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,19 @@ Now you're ready to [clone the repository](https://help.github.com/articles/clon
 
 If you are editing an existing file please be consistent with the style in the file.
 
-Otherwise normal Java formatting should be used.
+Otherwise use the defined checkstyle format for new code.
 
-A defined styles and checks will be defined at a later date.
+#### SQL Coding
+
+1. Use the JOOQ wrapper. Generally the wrapper provides sufficiently reasonable query generation. 
+However, *DO NOT* be afraid to say, "that looks terrible", and tweak it until it generates something better.
+    a. If the query you're making has nested queries name the queries. Example        
+       ```sql
+       select a.* from (select col1,col2 from a_table) a;
+       ```
+       Otherwise JOOQ creates a new name each time the query is run which can starved the shared memory.
+
+2. Joins are your friend. They are a much better friend IF you let the database do them for you. Do not pull data into java just to do a join. Write the appropriate SQL.
 
 ## Submitting an Issue
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,5 +52,7 @@ subprojects {
         }
     }
 
-
+    checkstyleMain {
+        enabled = gradle.startParameter.taskNames.contains('checkstyleMain')
+    }
 }

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
@@ -48,17 +48,22 @@ import cwms.radar.data.dto.catalog.TimeseriesCatalogEntry;
 import cwms.radar.helpers.DateUtils;
 
 import org.jetbrains.annotations.NotNull;
+import org.jooq.CommonTableExpression;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
 import org.jooq.Record1;
+import org.jooq.Record10;
 import org.jooq.Record3;
+import org.jooq.Record7;
 import org.jooq.Record8;
 import org.jooq.Result;
+import org.jooq.ResultQuery;
 import org.jooq.SQL;
 import org.jooq.SelectConditionStep;
 import org.jooq.SelectHavingStep;
+import org.jooq.SelectJoinStep;
 import org.jooq.SelectQuery;
 import org.jooq.SelectSelectStep;
 import org.jooq.Table;
@@ -85,6 +90,12 @@ import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.max;
 import static org.jooq.impl.DSL.partitionBy;
 import static org.jooq.impl.DSL.condition;
+import static org.jooq.impl.DSL.name;
+import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.selectFrom;
+import static org.jooq.impl.DSL.inline;
+
+
 import static usace.cwms.db.jooq.codegen.tables.AV_CWMS_TS_ID2.AV_CWMS_TS_ID2;
 import static usace.cwms.db.jooq.codegen.tables.AV_TS_EXTENTS_UTC.AV_TS_EXTENTS_UTC;
 
@@ -138,7 +149,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 		}
 		return LocalDateTime.from(beginParsed).atZone(fallbackZone);
 	}
-
+	@SuppressWarnings("deprecated")
 	protected TimeSeries getTimeseries(String page, int pageSize, String names, String office, String units,
 									 ZonedDateTime beginTime, ZonedDateTime endTime)
 	{
@@ -176,81 +187,141 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 		{
 			Field<String> officeId = CWMS_UTIL_PACKAGE.call_GET_DB_OFFICE_ID(office != null ? DSL.val(office) : CWMS_UTIL_PACKAGE.call_USER_OFFICE_ID());
 			Field<String> tsId = CWMS_TS_PACKAGE.call_GET_TS_ID__2(DSL.val(names), officeId);
-			Field<BigDecimal> tsCode = CWMS_TS_PACKAGE.call_GET_TS_CODE__2(tsId, officeId);
-			Field<String> unit = units.compareToIgnoreCase("SI") == 0 || units.compareToIgnoreCase(
-					"EN") == 0 ? CWMS_UTIL_PACKAGE.call_GET_DEFAULT_UNITS(CWMS_TS_PACKAGE.call_GET_BASE_PARAMETER_ID(tsCode), DSL.val(units, String.class)) : DSL.val(units,
-					String.class);
+			Field<BigDecimal> tsCode = CWMS_TS_PACKAGE.call_GET_TS_CODE__2(DSL.val(names), officeId);
+			
+
+			Table<Record3<BigDecimal,String,String>> validTs = 
+				select(					
+						tsCode.as("tscode"),
+						tsId.as("tsid"),
+						officeId.as("office_id")				
+				).asTable("validts");
+
+			Field<String> loc = CWMS_UTIL_PACKAGE.call_SPLIT_TEXT(validTs.field("tsid",String.class),
+				DSL.val(BigInteger.valueOf(1L)), DSL.val("."),
+				DSL.val(BigInteger.valueOf(6L)));
+			Field<String> param = DSL.upper(CWMS_UTIL_PACKAGE.call_SPLIT_TEXT(validTs.field("tsid",String.class),
+				DSL.val(BigInteger.valueOf(2L)), DSL.val("."),
+				DSL.val(BigInteger.valueOf(6L))));
+
+				Field<String> unit = units.compareToIgnoreCase("SI") == 0 
+									 || 
+									 units.compareToIgnoreCase(
+									 "EN") == 0 
+									 ? 
+									 CWMS_UTIL_PACKAGE.call_GET_DEFAULT_UNITS(
+										CWMS_TS_PACKAGE.call_GET_BASE_PARAMETER_ID(tsCode),
+										DSL.val(units, String.class)
+										) 
+									 :
+									 DSL.val(units, String.class);
+
+			CommonTableExpression<Record7<BigDecimal,String,String,String,String,BigDecimal,String>> valid = 
+				name("valid").fields("tscode","tsid","office_id","loc_part","units","interval","parm_part")
+				.as(
+					select(						
+						validTs.field("tscode",BigDecimal.class).as("tscode"),
+						validTs.field("tsid",String.class).as("tsid"),
+						validTs.field("office_id",String.class).as("office_id"),
+						loc.as("loc_part"),
+						unit.as("units"),
+						
+						CWMS_TS_PACKAGE.call_GET_INTERVAL(validTs.field("tsid",String.class)).as("interval"),
+						param.as("parm_part")
+
+					).from(validTs)
+				);
+			/*DSL.with(valid)
+			   .select()
+			   .from(valid);
+			*/
+			Field<Timestamp> dateTimeCol 	  = DSL.field("DATE_TIME", Timestamp.class).as("DATE_TIME");
+			Field<Double> valueCol 		  = DSL.field("VALUE", Double.class).as("VALUE");
+			Field<Integer> qualityCol = DSL.field("QUALITY_CODE",Integer.class).as("QUALITY");
 
 			// This code assumes the database timezone is in UTC (per Oracle recommendation)
 			// Wrap in table() so JOOQ can parse the result
-			@SuppressWarnings("deprecated") SQL retrieveTable = DSL.sql(
-					"table(" + CWMS_TS_PACKAGE.call_RETRIEVE_TS_OUT_TAB(tsId, unit, CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(DSL.val(beginTime.toInstant().toEpochMilli())),
+			@SuppressWarnings("deprecated") 
+			SelectJoinStep<Record3<Timestamp, Double, Integer>> retrieveSelectCount = DSL.select(	
+					dateTimeCol,valueCol,qualityCol
+				).from(DSL.sql( "table( " +
+						CWMS_TS_PACKAGE.call_RETRIEVE_TS_OUT_TAB(
+							valid.field("tsid",String.class),
+					valid.field("units",String.class),
+							
+							CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(DSL.val(beginTime.toInstant().toEpochMilli())),
 							CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(DSL.val(endTime.toInstant().toEpochMilli())),
 							DSL.inline("UTC", String.class),
 							// All times are sent as UTC to the database, regardless of requested timezone.
-							null, null, null, null, null, null, null, officeId) + ")");
+							null, null, null, null, null, null, null, 
+							valid.field("office_id",String.class))
+							+")"
+			))
+			;
 
-			Field<String> loc = CWMS_UTIL_PACKAGE.call_SPLIT_TEXT(tsId,
-					DSL.val(BigInteger.valueOf(1L)), DSL.val("."),
-					DSL.val(BigInteger.valueOf(6L)));
-			Field<String> param = DSL.upper(CWMS_UTIL_PACKAGE.call_SPLIT_TEXT(tsId,
-					DSL.val(BigInteger.valueOf(2L)), DSL.val("."),
-					DSL.val(BigInteger.valueOf(6L))));
+			SQL retrieveSelectData = DSL.sql( "table(" +
+				CWMS_TS_PACKAGE.call_RETRIEVE_TS_OUT_TAB(
+					tsId,
+					unit,
+					CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(DSL.val(beginTime.toInstant().toEpochMilli())),
+					CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(DSL.val(endTime.toInstant().toEpochMilli())),
+					DSL.inline("UTC", String.class),
+					// All times are sent as UTC to the database, regardless of requested timezone.
+					null, null, null, null, null, null, null, 
+					officeId)
+				+")"
+			);
 
-			// What is the syntax for selecting tzName and offsetField from the same subquery?
-			// It works when each field comes from its own subquery.
-			// This didn't work.
-			//			Field<?>[] fields = DSL.select(AV_CWMS_TS_ID2.INTERVAL_UTC_OFFSET.as("INTERVAL_UTC_OFFSET"),
-			//					AV_CWMS_TS_ID2.TIME_ZONE_ID.as("TIME_ZONE_ID"))
-			//					.from(AV_CWMS_TS_ID2).where(AV_CWMS_TS_ID2.CWMS_TS_ID.eq(tsId))
-			//					.fields();
-			//			Field<BigDecimal> offsetField = (Field<BigDecimal>) fields[0];
-			//			Field<String> tzName = (Field<String>) fields[1];
+						
+			Field<String> tzName = this.getDbVersion() >= Dao.CWMS_21_1_1 ?
+								    AV_CWMS_TS_ID2.TIME_ZONE_ID
+									:
+									DSL.inline(null,SQLDataType.VARCHAR);
 
-			Field<BigDecimal> offsetField = DSL.select(AV_CWMS_TS_ID2.INTERVAL_UTC_OFFSET.as("INTERVAL_UTC_OFFSET"))
-					.from(AV_CWMS_TS_ID2).where(AV_CWMS_TS_ID2.CWMS_TS_ID.eq(tsId)
-							.and(AV_CWMS_TS_ID2.ALIASED_ITEM.isNull()))
-					.asField();
-			Field<String> tzName;
-			if( this.getDbVersion() >= Dao.CWMS_21_1_1) {
-				tzName = DSL.select(AV_CWMS_TS_ID2.TIME_ZONE_ID).from(AV_CWMS_TS_ID2).where(
-						AV_CWMS_TS_ID2.CWMS_TS_ID.eq(tsId)
-								.and(AV_CWMS_TS_ID2.ALIASED_ITEM.isNull())
-				).asField("TIME_ZONE_ID");
-			} else {
-				tzName = DSL.val((String) null).as("TIME_ZONE_ID");
-			}
-
-			SelectSelectStep< ? extends Record> metadataQuery = dsl.select(
-					tsId.as("NAME"),
-					officeId.as("OFFICE_ID"),
-					unit.as("UNITS"),
-					CWMS_TS_PACKAGE.call_GET_INTERVAL(tsId).as("INTERVAL"),
-					loc.as("LOC_PART"),
-					param.as("PARM_PART"),
-					DSL.choose(param)
-							.when("ELEV", CWMS_LOC_PACKAGE.call_GET_VERTICAL_DATUM_INFO_F__2(loc, unit, officeId))
+			SelectJoinStep<?> metadataQuery = 
+				dsl.with(valid)
+				   .select(
+					valid.field("tsid",String.class).as("NAME"),
+					valid.field("office_id",String.class).as("office_id"),
+					valid.field("units",String.class).as("units"),
+					valid.field("interval",BigDecimal.class).as("interval"),
+					valid.field("loc_part", String.class).as("loc_part"),
+					valid.field("parm_part",String.class).as("parm_part"),
+					DSL.choose(valid.field("parm_part",String.class))
+							.when(
+								"ELEV",
+								CWMS_LOC_PACKAGE.call_GET_VERTICAL_DATUM_INFO_F__2(
+									valid.field("loc_part",String.class),
+									valid.field("units",String.class),
+									valid.field("office_id",String.class)))
 							.otherwise("")
 							.as("VERTICAL_DATUM"),
 					// If we don't know the total, fetch it from the database (only for first fetch).
 					// Total is only an estimate, as it can change if fetching current data, or the timeseries otherwise changes between queries.
-					total != null ? DSL.val(total).as("TOTAL") : DSL.selectCount().from(retrieveTable).asField("TOTAL"),
-					offsetField,
-					tzName
-			);
+					total != null ? DSL.val(total).as("TOTAL") : DSL.selectCount().from(DSL.table(retrieveSelectCount)).asField("TOTAL"),
+					AV_CWMS_TS_ID2.INTERVAL_UTC_OFFSET,
+					AV_CWMS_TS_ID2.TIME_ZONE_ID
+					)
+				   .from(valid)
+				   .leftOuterJoin(AV_CWMS_TS_ID2)
+				   		.on(
+							AV_CWMS_TS_ID2.DB_OFFICE_ID.eq(valid.field("office_id",String.class))
+							.and(AV_CWMS_TS_ID2.TS_CODE.eq(valid.field("tscode",BigDecimal.class)))
+							.and(AV_CWMS_TS_ID2.ALIASED_ITEM.isNull())
+				   		);
 
-			logger.finest(() -> metadataQuery.getSQL(ParamType.INLINED));
-
+			logger.info(() -> metadataQuery.getSQL(ParamType.INLINED));
+			
 			TimeSeries timeseries = metadataQuery.fetchOne(tsMetadata -> {
 				String vert = (String)tsMetadata.getValue("VERTICAL_DATUM");
 				VerticalDatumInfo verticalDatumInfo= parseVerticalDatumInfo(vert);
 
 				return new TimeSeries(recordCursor, recordPageSize, tsMetadata.getValue("TOTAL", Integer.class),
-						tsMetadata.getValue("NAME", String.class), tsMetadata.getValue("OFFICE_ID", String.class),
-						beginTime, endTime, tsMetadata.getValue("UNITS", String.class),
-						Duration.ofMinutes(tsMetadata.get("INTERVAL") == null ? 0 : tsMetadata.getValue("INTERVAL", Long.class)),
+						tsMetadata.getValue("NAME", String.class), tsMetadata.getValue("office_id", String.class),
+						beginTime, endTime, tsMetadata.getValue("units", String.class),
+						Duration.ofMinutes(tsMetadata.get("interval") == null ? 0 : tsMetadata.getValue("interval", Long.class)),
 						verticalDatumInfo,
-						tsMetadata.getValue(offsetField).longValue(),
+						tsMetadata.getValue(AV_CWMS_TS_ID2.INTERVAL_UTC_OFFSET).longValue(),
 						tsMetadata.getValue(tzName)
 				);
 			});
@@ -259,10 +330,10 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 			{
 				SelectConditionStep<Record3<Timestamp, Double, BigDecimal>> query = dsl.select(
 						DSL.field("DATE_TIME", Timestamp.class).as("DATE_TIME"),
-						CWMS_ROUNDING_PACKAGE.call_ROUND_DD_F(DSL.field("VALUE", Double.class), DSL.inline("5567899996"), DSL.inline('T')).as("VALUE"),
+						DSL.field("VALUE", Double.class).as("VALUE"),
 					CWMS_TS_PACKAGE.call_NORMALIZE_QUALITY(DSL.nvl(DSL.field("QUALITY_CODE", Integer.class), DSL.inline(5))).as("QUALITY_CODE")
 			)
-					.from(retrieveTable)
+					.from(retrieveSelectData)
 					.where(DSL.field("DATE_TIME", Timestamp.class)
 							.greaterOrEqual(CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(
 									DSL.nvl(DSL.val(tsCursor == null ? null : tsCursor.toInstant().toEpochMilli()),
@@ -274,7 +345,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 				if(pageSize > 0)
 					query.limit(DSL.val(pageSize + 1));
 
-				logger.finest(() -> query.getSQL(ParamType.INLINED));
+				logger.info(() -> query.getSQL(ParamType.INLINED));
 
 				query.fetchInto(tsRecord -> timeseries.addValue(
 								tsRecord.getValue("DATE_TIME", Timestamp.class),

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
@@ -307,7 +307,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 							.and(AV_CWMS_TS_ID2.ALIASED_ITEM.isNull())
 				   		);
 
-			logger.info(() -> metadataQuery.getSQL(ParamType.INLINED));
+			logger.fine(() -> metadataQuery.getSQL(ParamType.INLINED));
 			
 			TimeSeries timeseries = metadataQuery.fetchOne(tsMetadata -> {
 				String vert = (String)tsMetadata.getValue("VERTICAL_DATUM");
@@ -343,7 +343,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 				if(pageSize > 0)
 					query.limit(DSL.val(pageSize + 1));
 
-				logger.info(() -> query.getSQL(ParamType.INLINED));
+				logger.fine(() -> query.getSQL(ParamType.INLINED));
 
 				query.fetchInto(tsRecord -> timeseries.addValue(
 								tsRecord.getValue(dateTimeCol),

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
@@ -266,7 +266,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 					// All times are sent as UTC to the database, regardless of requested timezone.
 					null, null, null, null, null, null, null, 
 					officeId)
-				+")"
+				+") retrieveTs"
 			);
 
 						
@@ -331,7 +331,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 						valueCol,
 						qualityNormCol
 					)
-					.from(retrieveSelectData)
+					.from(retrieveSelectData) 
 					.where(dateTimeCol
 							.greaterOrEqual(CWMS_UTIL_PACKAGE.call_TO_TIMESTAMP__2(
 									DSL.nvl(DSL.val(tsCursor == null ? null : tsCursor.toInstant().toEpochMilli()),
@@ -343,7 +343,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 				if(pageSize > 0)
 					query.limit(DSL.val(pageSize + 1));
 
-				logger.fine(() -> query.getSQL(ParamType.INLINED));
+				logger.info(() -> query.getSQL(ParamType.INLINED));
 
 				query.fetchInto(tsRecord -> timeseries.addValue(
 								tsRecord.getValue(dateTimeCol),

--- a/user_test/README.md
+++ b/user_test/README.md
@@ -1,0 +1,1 @@
+This contains things that are difficult to automate but useful for regression testing.

--- a/user_test/test_spk_perf.py
+++ b/user_test/test_spk_perf.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+
+import json, http.client as httplib, urllib.parse as urllib
+from ssl import SSLError
+import time,sys
+
+import urllib.request as urllib2
+import socket
+import ssl
+
+# For internal CAs
+context = ssl._create_unverified_context()
+
+HOST="localhost:8443"
+
+def test(host: str, path:str, tsname):
+	query = f"/{path}/timeseries?"
+	params = urllib.urlencode( {
+		"name": tsname,
+		"timezone": "PST8PDT",
+		"pageSize": -1,					# always fetch all results
+                "office": "SPK"
+	})
+	print("Fetching: %s" % host+query+params)
+	conn = None
+	headers = { 'Accept': "application/json;version=2" }
+
+	try:
+		conn = httplib.HTTPSConnection( host, context=context)
+		conn.request("GET", query+params, None, headers )
+	except SSLError as err:
+		print(type(err).__name__ + " : " + str(err))
+		print("Falling back to non-SSL")
+		# SSL not supported (could be standalone instance)
+		conn = httplib.HTTPConnection( host )
+		conn.request("GET", query+params, None, headers )
+
+	r1 = conn.getresponse()
+	data = r1.read()
+	
+	if r1.status != 200:
+		print("HTTP Error " + str(r1.status) + ": " + str(data))
+		return
+
+	data_dict = None
+
+	try:
+		data_dict = json.loads(data)
+		#print(repr(data_dict));
+	except json.JSONDecodeError as err:
+		print(str(err))
+		print(repr(data))
+
+def test2(host: str, path:str):
+	query = f"/{path}/offices/SPK?"
+	params = urllib.urlencode( {
+		"pageSize": -1,					# always fetch all results
+	})
+	print("Fetching: %s" % host+query+params)
+	conn = None
+	headers = { 'Accept': "application/json;version=2" }
+
+	try:
+		conn = httplib.HTTPSConnection( host, context=context )
+		conn.request("GET", query+params, None, headers )
+	except SSLError as err:
+		print(type(err).__name__ + " : " + str(err))
+		print("Falling back to non-SSL")
+		# SSL not supported (could be standalone instance)
+		conn = httplib.HTTPConnection( host )
+		conn.request("GET", query+params, None, headers )
+
+	r1 = conn.getresponse()
+	data = r1.read()
+	
+	if r1.status != 200:
+		print("HTTP Error " + str(r1.status) + ": " + str(data))
+		return
+
+	data_dict = None
+
+	try:
+		data_dict = json.loads(data)
+		print(repr(data_dict));
+	except json.JSONDecodeError as err:
+		print(str(err))
+		print(repr(data))
+
+def runtest(path: str):
+	tsnames = [
+		"Black Butte-Pool.Elev.Inst.1Hour.0.Calc-val",
+		"Black Butte-Pool.Stor.Inst.1Hour.0.Calc-val",
+		"Black Butte.Flow-Res Out.Ave.1Hour.1Hour.Calc-val",
+		"Black Butte-Outflow.Stage.Inst.1Hour.0.Calc-val",
+		"Black Butte-Outflow.Flow.Ave.1Hour.1Hour.Calc-val",
+		"Black Butte-South Diversion Canal.Stage.Inst.1Hour.0.Calc-val",
+		"Black Butte-South Diversion Canal.Flow.Ave.1Hour.1Hour.Calc-val",
+		"Black Butte-South Diversion Canal.Flow-Sontek.Ave.1Hour.1Hour.Calc-val",
+		"Black Butte-Wackerman.Flow.Ave.1Hour.1Hour.Calc-val",
+		"Black Butte.Flow-Res In.Ave.1Hour.1Hour.Calc-val",
+		"Noel Springs.Depth-SWE.Inst.1Hour.0.Calc-val",
+		"Noel Springs.Depth-SWE INC.Inst.1Hour.0.Calc-val",
+	]
+	
+	# Do one request untimed to "grease the pipe", and get the connection pool ready
+	test(HOST, path, tsnames[0])
+
+	start = time.time();
+
+	for x in range(12):
+		test(HOST, path, tsnames[x])
+
+	end = time.time();
+	print("Total time: %.3f s\n" % (end - start))
+
+def runtest2(path: str):
+	# Do one request untimed to "grease the pipe", and get the connection pool ready
+	test2(HOST, path)
+
+	start = time.time();
+
+	for x in range(10):
+		test2(HOST, path)
+
+	end = time.time();
+	print("Total time: %.3f s\n" % (end - start))
+
+if __name__ == "__main__":
+	if len(sys.argv) > 1:
+		HOST = sys.argv[0]
+	runtest("cwms-data")
+	time.sleep(0.5)
+#	runtest("spk-data-dev")
+
+	# Note, /offices/ doesn't exhibit this behavior
+	# Uncomment the following lines to test that
+	#time.sleep(1)
+	#runtest2("spk-data")
+	#time.sleep(0.5)
+	#runtest2("spk-data-dev")
+
+# vim: ts=4 ai sw=4 noexpandtab
+


### PR DESCRIPTION
Closes #180.

The meta data query AV_CWMS_TS_ID2 subquery were causing an excessive delay in results. While likely a minor config issue with index the query was rewritten to take advantage of common table expression and appropriate joins to speed up the results.

primary changes are in the first commit, the remaining 3 commits are formatting and documentation updates.