### PR TITLE
Cleanup build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+---
 name: Build CWMS RADAR
 on:
   push:
@@ -86,16 +87,34 @@ jobs:
           asset_path: warfile/${{ needs.build.outputs.thewar}}
           asset_name: ${{ steps.get_version.outputs.WAR_FILE_NAME}}
           asset_content_type: application/x-webarchive
+      - name: Login to Alt Registry
+        uses: docker/login-action@v2.0.0
+        id: login-alt
+        with:
+          registry: ${{ secrets.ALT_REGISTRY }}
+          username: $${ secrets.ALT_REG_USER }}
+          password: $${ secrets.ALT_REG_PASSWORD }}
+      - name: Build docker image
+        run: |
+          ./gradlew dockerBuild
+          docker tag cwms-rest-api:$IMAGE_TAG $ALT_REGISTRY/cwms/radar-api:$IMAGE_TAG
+          docker tag cwms-rest-api:$IMAGE_TAG $ALT_REGISTRY/cwms/radar-api:latest
+          docker push $ALT_REGISTRY/cwms/radar-api:$IMAGE_TAG
+          docker push $ALT_REGISTRY/cwms/radar-api:latest
+      - name: Logout of ALT registry
+        if: ${{ always() }}
+        run: docker logout ${{ steps.login-alt.outputs.registry }}
+
 
   publish:
-    if: github.event_name == 'push' && startsWith(github.ref,'refs/heads/release/')
+    if: github.event_name == 'push' && startsWith(github.ref,'refs/heads/develop')
     name: API Container Image
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: build
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - name: setup java
         uses: actions/setup-java@v1
@@ -116,19 +135,34 @@ jobs:
         if: ${{ success() }}
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
+      - name: Login to Alt Registry
+        uses: docker/login-action@v2.0.0
+        id: login-alt
+        with:
+          registry: ${{ secrets.ALT_REGISTRY }}
+          username: $${ secrets.ALT_REG_USER }}
+          password: $${ secrets.ALT_REG_PASSWORD }}
       - name: Build, tag, and push image to Amazon ECR (midas-api)
         if: ${{ success() }}
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: cwms-radar-api
           IMAGE_TAG: ${{steps.get_version.outputs.VERSION}}
+          ALT_REGISTRY: ${{ steps.login-alt.outputs.registry }}
         run: |
           ./gradlew :cwms_radar_api:build --init-script init.gradle
-          ./gradlew prepareDocker --init-script init.gradle
-          cd cwms_radar_standalone/build/docker
+          ./gradlew dockerBuild --init-script init.gradle
           docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+          docker tag cwms-rest-api:$IMAGE_TAG $ALT_REGISTRY/cwms/radar-api:$IMAGE_TAG
+          docker tag cwms-rest-api:$IMAGE_TAG $ALT_REGISTRY/cwms/radar-api:latest-dev
+          docker push $ALT_REGISTRY/cwms/radar-api:$IMAGE_TAG
+          docker push $ALT_REGISTRY/cwms/radar-api:latest-dev
       - name: Logout of Amazon ECR
         if: ${{ always() }}
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
+      - name: Logout of ALT registry
+        if: ${{ always() }}
+        run: docker logout ${{ steps.login-alt.outputs.registry }}

--- a/cwms_radar_api/build.gradle
+++ b/cwms_radar_api/build.gradle
@@ -25,9 +25,17 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-jdk14:1.7.36'
 
-    implementation "mil.army.usace.hec:hec-monolith:2.0.2"
+    implementation( "mil.army.usace.hec:hec-monolith:2.0.2" ) {
+        //exclude group: "org.python", module: "jython-standalone"
+        //exclude group: "mil.army.usace.hec.swingx"
+        exclude group: "*"
+    }
     implementation "mil.army.usace.hec:hec-nucleus-metadata:1.0.33"
-    implementation 'mil.army.usace.hec:hec-cwms-ratings-core:1.0.0'
+    implementation( 'mil.army.usace.hec:hec-cwms-ratings-core:1.0.0' ) {
+        //exclude group: "org.python", module: "jython-standalone"
+        //exclude group: "mil.army.usace.hec.swingx"
+        exclude group: "*"
+    }
 
     implementation('org.jooq.pro:jooq:3.11.2') {
         exclude group: "com.oracle", module: "*"
@@ -235,7 +243,7 @@ task prepareDockerBuild(type: Copy, dependsOn: war) {
     from(war.outputs.files.singleFile) {
         //include "${project.name}-${project.version}.jar"
         into "radar/webapps"
-        rename(".*\\.war", "ROOT.war")
+        rename(".*\\.war", "cwms-data.war")
     }
 }
 

--- a/cwms_radar_api/src/docker/server.xml
+++ b/cwms_radar_api/src/docker/server.xml
@@ -60,8 +60,8 @@
         <!-- Access log processes all example.
              Documentation at: /docs/config/valve.html
              Note: The pattern used is equivalent to using pattern="common" -->
-        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
-               prefix="localhost_access_log" suffix=".txt"
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="/dev"
+               prefix="stdout" suffix="" buffered="false" rotatable="false" fileDateFormat=""
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
       </Host>

--- a/cwms_radar_api/src/main/java/cwms/radar/ApiServlet.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/ApiServlet.java
@@ -132,7 +132,7 @@ public class ApiServlet extends HttpServlet {
             config.defaultContentType = "application/json";
             config.contextPath = context;
             config.registerPlugin(new OpenApiPlugin(getOpenApiOptions()));
-            config.enableDevLogging();
+            //config.enableDevLogging();
             config.requestLogger( (ctx,ms) -> logger.finest(ctx.toString()));
             config.accessManager(accessManager);
         })


### PR DESCRIPTION
exclude transient deps to reduce war size.
update build.yml for new scheme. (current dev and "release")
will be updated for dev/test/release later.
Access logs to standard out in docker file.

disable dev logging.