### PR TITLE
RatingTemplates that don't have any rating_ids were being skipped in …

### DIFF
--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingTemplates.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingTemplates.java
@@ -56,14 +56,17 @@ public class RatingTemplates extends CwmsDTOPaginated {
             return this;
         }
 
-        private int getRatingCount() {
+        private int getCount() {
             int count = 0;
 
-            if(templates != null) {
+            if (templates != null) {
                 for (RatingTemplate template : templates) {
                     List<String> ratingIds = template.getRatingIds();
-                    if (ratingIds != null) {
+                    if (ratingIds != null && !ratingIds.isEmpty()) {
                         count += ratingIds.size();
+                    } else {
+                        // for purposes of paging a null or empty list counts as a row
+                        count++;
                     }
                 }
             }
@@ -74,7 +77,7 @@ public class RatingTemplates extends CwmsDTOPaginated {
         public RatingTemplates build() {
             RatingTemplates retval = new RatingTemplates(offset, pageSize, total, templates);
 
-            int count = getRatingCount();
+            int count = getCount();
             if (count >= this.pageSize) {
                 String cursor = Integer.toString(retval.offset + count);
                 retval.nextPage = encodeCursor(cursor, retval.pageSize, retval.total);


### PR DESCRIPTION
…the count used for paging.

This was causing next-page to not show up before the end of the list was reached.