### PR TITLE
[RFC] require delete method for ts identifier

### DIFF
--- a/cwms_radar_api/src/main/java/cwms/radar/api/TimeSeriesIdentifierDescriptorController.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/api/TimeSeriesIdentifierDescriptorController.java
@@ -327,8 +327,7 @@ public class TimeSeriesIdentifierDescriptorController implements CrudHandler {
             queryParams = {
                     @OpenApiParam(name = OFFICE, required = true, description = "Specifies the "
                             + "owning office of the timeseries to be deleted."),
-                    @OpenApiParam(name = METHOD,  description = "Specifies the delete method used."
-                            + "Default: DELETE_ALL",
+                    @OpenApiParam(name = METHOD,  required = true, description = "Specifies the delete method used.",
                             type = TimeSeriesIdentifierDescriptorDao.DeleteMethod.class)
             },
             description = "Deletes requested timeseries identifier",
@@ -338,7 +337,7 @@ public class TimeSeriesIdentifierDescriptorController implements CrudHandler {
     public void delete(@NotNull Context ctx, @NotNull String timeseriesId) {
 
         TimeSeriesIdentifierDescriptorDao.DeleteMethod method = ctx.queryParamAsClass(METHOD,
-                        TimeSeriesIdentifierDescriptorDao.DeleteMethod.class).allowNullable().get();
+                        TimeSeriesIdentifierDescriptorDao.DeleteMethod.class).get();
 
         String office = ctx.queryParam(OFFICE);
 

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesIdentifierDescriptorDao.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesIdentifierDescriptorDao.java
@@ -172,10 +172,6 @@ public class TimeSeriesIdentifierDescriptorDao extends JooqDao<TimeSeriesIdentif
     }
 
     public void delete(String office, String timeseriesId, DeleteMethod method) {
-        if (method == null) {
-            method = DeleteMethod.DELETE_ALL;
-        }
-
         switch (method) {
             case DELETE_KEY:
                 deleteKey(office, timeseriesId);
@@ -189,7 +185,6 @@ public class TimeSeriesIdentifierDescriptorDao extends JooqDao<TimeSeriesIdentif
             default:
                 throw new IllegalArgumentException("Unknown delete method: " + method);
         }
-
     }
 
 


### PR DESCRIPTION
incorrectly leaving off the delete method may result in unintended data deletion