### PR TITLE
update hec-cwms-data-access libraries

### DIFF
--- a/cwms_radar_api/build.gradle
+++ b/cwms_radar_api/build.gradle
@@ -29,8 +29,7 @@ dependencies {
         exclude group: "log4j", module: "log4j"
         exclude group: "org.slf4j", module: "slf4j-log4j12"
     }
-
-    implementation( "mil.army.usace.hec:cwms-db-dao:9.8.0") {
+    implementation('mil.army.usace.hec:cwms-db-jooq-codegen:7.0.0-SNAPSHOT') {
         exclude group: "com.oracle", module: "*"
         exclude group: "com.oracle.database.jdbc", module: "*"
         exclude group: "org.jooq.pro", module: "*"

--- a/cwms_radar_api/build.gradle
+++ b/cwms_radar_api/build.gradle
@@ -15,14 +15,14 @@ dependencies {
     implementation "javax.xml.bind:jaxb-api:2.3.1"
     implementation "com.sun.xml.bind:jaxb-impl:3.0.2"
     implementation "com.sun.xml.bind:jaxb-core:3.0.2"
-    implementation( "mil.army.usace.hec:cwms-db-dao:9.3.5") {
+    implementation( "mil.army.usace.hec:cwms-db-dao:9.8.0") {
         exclude group: "com.oracle", module: "*"
         exclude group: "com.oracle.database.jdbc", module: "*"
         exclude group: "org.jooq.pro", module: "*"
         exclude group: "log4j", module: "log4j"
         exclude group: "org.slf4j", module: "slf4j-log4j12"
     }
-    implementation( "mil.army.usace.hec:cwms-db-jooq:9.3.5"){
+    implementation( "mil.army.usace.hec:cwms-db-jooq:9.8.0"){
         exclude group: "com.oracle", module: "*"
         exclude group: "com.oracle.database.jdbc", module: "*"
         exclude group: "org.jooq.pro", module: "*"
@@ -30,7 +30,7 @@ dependencies {
         exclude group: "org.slf4j", module: "slf4j-log4j12"
     }
 
-    implementation( "mil.army.usace.hec:cwms-db-dao:9.3.5") {
+    implementation( "mil.army.usace.hec:cwms-db-dao:9.8.0") {
         exclude group: "com.oracle", module: "*"
         exclude group: "com.oracle.database.jdbc", module: "*"
         exclude group: "org.jooq.pro", module: "*"


### PR DESCRIPTION
need null pointer bug fix from: https://bitbucket.hecdev.net/projects/CWMS/repos/hec-cwms-data-access/pull-requests/102 so that we can store a null ts item mask (which defaults to -1)