### PR TITLE
use -1 for default tsItemMask so that delete actually happens

### DIFF
--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/TimeSeriesDaoImpl.java
@@ -1007,7 +1007,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
             private boolean endTimeInclusive = true;
             private Date versionDate;
             private Boolean maxVersion = null;
-            private Integer tsItemMask = null;
+            private Integer tsItemMask = -1;
             private String overrideProtection;
 
             public Builder withStartTime(Date startTime) {

--- a/cwms_radar_api/src/test/java/cwms/radar/api/TimeseriesControllerTestIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/TimeseriesControllerTestIT.java
@@ -1,34 +1,24 @@
 package cwms.radar.api;
 
-import static io.restassured.RestAssured.given;
-import static io.restassured.config.JsonConfig.jsonConfig;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.closeTo;
-
-import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-
 import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import cwms.radar.data.dto.Location;
 import cwms.radar.formatters.Formats;
-import fixtures.RadarApiSetupCallback;
 import fixtures.TestAccounts;
 import fixtures.TestAccounts.KeyUser;
 import io.restassured.RestAssured;
 import io.restassured.path.json.config.JsonPathConfig;
-import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.JsonConfig.jsonConfig;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 
 @Tag("integration")
 public class TimeseriesControllerTestIT extends DataApiTestIT {
@@ -156,5 +146,78 @@ public class TimeseriesControllerTestIT extends DataApiTestIT {
         } catch( SQLException ex) {
             throw new RuntimeException("Unable to create location for TS",ex);
         }
+    }
+
+    @Test
+    public void test_delete_ts() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        String tsData = IOUtils.toString(this.getClass().getResourceAsStream("/cwms/radar/api/lrl/1day_offset.json"),"UTF-8");
+
+        JsonNode ts = mapper.readTree(tsData);
+        String location = ts.get("name").asText().split("\\.")[0];
+        String officeId = ts.get("office-id").asText();
+        createLocation(location,true,officeId);
+
+        KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+
+        // inserting the time series
+        given()
+            .log().everything(true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .body(tsData)
+            .header("Authorization",user.toHeaderValue())
+            .queryParam("office",officeId)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/timeseries/")
+        .then()
+            .log().body().log().everything(true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK));
+
+        given()
+            .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
+            .log().everything(true)
+            .accept(Formats.JSONV2)
+            .header("Authorization",user.toHeaderValue())
+            .queryParam("office",officeId)
+            .queryParam("begin","2023-02-02T11:00:00+00:00")
+            .queryParam("end","2023-02-02T11:00:00+00:00")
+            .queryParam("start-time-inclusive","true")
+            .queryParam("end-time-inclusive","true")
+            .queryParam("override-protection","true")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/timeseries/" + ts.get("name").asText())
+        .then()
+            .log().body().log().everything(true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK));
+
+        // get it back
+        given()
+            .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
+            .log().everything(true)
+            .accept(Formats.JSONV2)
+            .body(tsData)
+            .header("Authorization",user.toHeaderValue())
+            .queryParam("office",officeId)
+            .queryParam("units","F")
+            .queryParam("name",ts.get("name").asText())
+            .queryParam("begin","2023-02-02T11:00:00+00:00")
+            .queryParam("end","2023-02-03T11:00:00+00:00")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/timeseries/")
+        .then()
+            .log().body().log().everything(true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("values[0][1]",nullValue());
     }
 }


### PR DESCRIPTION
add delete_ts test


Maybe someone can explain to me why this is needed? This should be defaulting to `cwms_util.ts_all`: https://bitbucket.hecdev.net/projects/CWMS/repos/cwms_database/browse/schema/src/cwms/cwms_ts_pkg_body.sql#7082

This is defined as `-1`: https://bitbucket.hecdev.net/projects/CWMS/repos/cwms_database/browse/schema/src/cwms/cwms_util_pkg.sql#131 so I wouldn't think this is needed.