### PR TITLE
fix location groups returning with null ids

### DIFF
--- a/cwms_radar_api/src/test/java/cwms/radar/api/DataApiTestIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/DataApiTestIT.java
@@ -1,5 +1,6 @@
 package cwms.radar.api;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.ZoneId;
@@ -7,6 +8,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 
 import org.apache.commons.io.IOUtils;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -16,6 +20,8 @@ import cwms.radar.data.dto.Location;
 import fixtures.RadarApiSetupCallback;
 import fixtures.TestAccounts;
 import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
+
+import usace.cwms.db.jooq.codegen.packages.CWMS_ENV_PACKAGE;
 
 /**
  * Helper class to manage cycling tests multiple times against a database.
@@ -287,5 +293,11 @@ public class DataApiTestIT {
                 throw new RuntimeException(ex);
             }
         },"cwms_20");
+    }
+
+    protected static DSLContext dslContext(Connection connection, String officeId) {
+        DSLContext dsl = DSL.using(connection, SQLDialect.ORACLE11G);
+        CWMS_ENV_PACKAGE.call_SET_SESSION_OFFICE_ID(dsl.configuration(), officeId);
+        return dsl;
     }
 }

--- a/cwms_radar_api/src/test/java/cwms/radar/data/dao/LocationGroupDaoTestIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/data/dao/LocationGroupDaoTestIT.java
@@ -1,0 +1,59 @@
+package cwms.radar.data.dao;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import cwms.radar.api.DataApiTestIT;
+import cwms.radar.data.dto.LocationGroup;
+import fixtures.RadarApiSetupCallback;
+import java.util.List;
+import java.util.Optional;
+import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("integration")
+class LocationGroupDaoTestIT extends DataApiTestIT {
+
+    @BeforeAll
+    public static void load_data() throws Exception {
+        loadSqlDataFromResource("cwms/radar/data/sql/store_loc_groups.sql");
+    }
+
+    @AfterAll
+    public static void deload_data() throws Exception {
+        loadSqlDataFromResource("cwms/radar/data/sql/store_loc_groups.sql");
+    }
+
+    @Test
+    void testGetAllWithoutAssignedLocations() throws Exception {
+        CwmsDatabaseContainer<?> db = RadarApiSetupCallback.getDatabaseLink();
+        db.connection(c -> {
+            try {
+                LocationGroupDao dao = new LocationGroupDao(dslContext(c, "SPK"));
+                List<LocationGroup> groups = dao.getLocationGroups("SPK");
+                Optional<LocationGroup> group = groups.stream()
+                    .filter(g -> "Test Group1".equals(g.getId()))
+                    .findFirst();
+                assertTrue(group.isPresent());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    void testGetOneWithoutAssignedLocations() throws Exception {
+        CwmsDatabaseContainer<?> db = RadarApiSetupCallback.getDatabaseLink();
+        db.connection(c -> {
+            try {
+                LocationGroupDao dao = new LocationGroupDao(dslContext(c, "SPK"));
+                Optional<LocationGroup> group = dao.getLocationGroup("SPK", "Test Category2", "Test Group2");
+                assertTrue(group.isPresent());
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+}

--- a/cwms_radar_api/src/test/resources/cwms/radar/data/sql/delete_loc_groups.sql
+++ b/cwms_radar_api/src/test/resources/cwms/radar/data/sql/delete_loc_groups.sql
@@ -1,0 +1,13 @@
+begin
+
+    -- create a location group at SPK
+    cwms_loc.delete_loc_group ('Test Category2',
+                               'Test Group2',
+                               'SPK'
+        );
+    cwms_loc.delete_loc_cat ('Test Category2',
+                               'F',
+                               'SPK'
+        );
+
+end;

--- a/cwms_radar_api/src/test/resources/cwms/radar/data/sql/store_loc_groups.sql
+++ b/cwms_radar_api/src/test/resources/cwms/radar/data/sql/store_loc_groups.sql
@@ -1,0 +1,14 @@
+begin
+
+    -- create a location group at SPK
+    cwms_loc.store_loc_group ('Test Category2',
+                     'Test Group2',
+                     'For Testing',
+                     'F',
+                     'T',
+                     null,
+                     null,
+                     'SPK'
+        );
+
+end;


### PR DESCRIPTION
the left join was using the group_id and category_id columns from the assigned locations view instead of the location group view this caused the columns to display null when there weren't any assigned locations in for the location group