### PR TITLE
add store, patch (rename), and delete for specified levels

### DIFF
--- a/cwms_radar_api/build.gradle
+++ b/cwms_radar_api/build.gradle
@@ -141,7 +141,7 @@ dependencies {
     testImplementation 'org.testcontainers:database-commons:1.17.3'
     testImplementation "org.testcontainers:jdbc:1.17.3"
     testImplementation "org.testcontainers:junit-jupiter:1.17.3"
-    testImplementation 'mil.army.usace.hec:testcontainers-cwms:1.0.6'
+    testImplementation 'mil.army.usace.hec:testcontainers-cwms:1.0.7'
 
     testImplementation "org.apache.commons:commons-csv:1.9.0"
     testImplementation 'mil.army.usace.hec.cwms.auth:cwms-tomcat-auth-api:1.1.0'

--- a/cwms_radar_api/src/main/java/cwms/radar/ApiServlet.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/ApiServlet.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package cwms.radar;
 
 import static io.javalin.apibuilder.ApiBuilder.get;
@@ -11,7 +35,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.flogger.FluentLogger;
-
 import cwms.radar.api.BasinController;
 import cwms.radar.api.BlobController;
 import cwms.radar.api.CatalogController;
@@ -202,7 +225,7 @@ public class ApiServlet extends HttpServlet {
                     ctx.status(HttpServletResponse.SC_BAD_REQUEST).json(re);
                 })
                 .exception(InvalidItemException.class, (e, ctx) -> {
-                    RadarError re = new RadarError("Not Found.");
+                    RadarError re = new RadarError("Bad Request.");
                     logger.atInfo().withCause(e).log(re.toString(), e);
                     ctx.status(HttpServletResponse.SC_BAD_REQUEST).json(re);
                 })

--- a/cwms_radar_api/src/main/java/cwms/radar/ApiServlet.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/ApiServlet.java
@@ -36,6 +36,7 @@ import cwms.radar.api.TimeZoneController;
 import cwms.radar.api.UnitsController;
 import cwms.radar.api.enums.UnitSystem;
 import cwms.radar.api.errors.FieldException;
+import cwms.radar.api.errors.InvalidItemException;
 import cwms.radar.api.errors.JsonFieldsException;
 import cwms.radar.api.errors.NotFoundException;
 import cwms.radar.api.errors.RadarError;
@@ -197,6 +198,11 @@ public class ApiServlet extends HttpServlet {
                 })
                 .exception(IllegalArgumentException.class, (e, ctx) -> {
                     RadarError re = new RadarError("Bad Request");
+                    logger.atInfo().withCause(e).log(re.toString(), e);
+                    ctx.status(HttpServletResponse.SC_BAD_REQUEST).json(re);
+                })
+                .exception(InvalidItemException.class, (e, ctx) -> {
+                    RadarError re = new RadarError("Not Found.");
                     logger.atInfo().withCause(e).log(re.toString(), e);
                     ctx.status(HttpServletResponse.SC_BAD_REQUEST).json(re);
                 })

--- a/cwms_radar_api/src/main/java/cwms/radar/api/SpecifiedLevelController.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/api/SpecifiedLevelController.java
@@ -1,3 +1,27 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package cwms.radar.api;
 
 import static com.codahale.metrics.MetricRegistry.name;
@@ -6,17 +30,22 @@ import static cwms.radar.data.dao.JooqDao.getDslContext;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import cwms.radar.api.errors.RadarError;
 import cwms.radar.data.dao.SpecifiedLevelDao;
 import cwms.radar.data.dto.SpecifiedLevel;
 import cwms.radar.formatters.ContentType;
 import cwms.radar.formatters.Formats;
+import cwms.radar.formatters.json.JsonV2;
 import io.javalin.apibuilder.CrudHandler;
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import java.util.List;
 import java.util.logging.Level;
@@ -27,7 +56,13 @@ import org.jooq.DSLContext;
 
 
 public class SpecifiedLevelController implements CrudHandler {
+    static final String OFFICE = "office";
+    static final String TEMPLATE_ID_MASK = "template-id-mask";
+    static final String SPECIFIED_LEVEL_ID = "specified-level-id";
+    static final String FAIL_IF_EXISTS = "fail-if-exists";
+
     private static final Logger logger = Logger.getLogger(SpecifiedLevelController.class.getName());
+    private static final String TAG = "Specified Levels";
     private final MetricRegistry metrics;
 
     private final Histogram requestResultSize;
@@ -51,11 +86,11 @@ public class SpecifiedLevelController implements CrudHandler {
 
     @OpenApi(
             queryParams = {
-                    @OpenApiParam(name = "office", description = "Specifies the owning office of "
+                    @OpenApiParam(name = OFFICE, description = "Specifies the owning office of "
                             + "the Specified Levels whose data is to be included in the response."
                             + " If this field is not specified, matching rating information from "
                             + "all offices shall be returned."),
-                    @OpenApiParam(name = "template-id-mask", description = "Mask that specifies "
+                    @OpenApiParam(name = TEMPLATE_ID_MASK, description = "Mask that specifies "
                             + "the IDs to be included in the response. If this field is not "
                             + "specified, all specified levels shall be returned."),
             },
@@ -66,16 +101,16 @@ public class SpecifiedLevelController implements CrudHandler {
                                             SpecifiedLevel.class)
                             }
                     )},
-            tags = {"Specified Levels"}
+            tags = {TAG}
     )
     @Override
     public void getAll(Context ctx) {
-        String office = ctx.queryParam("office");
-        String templateIdMask = ctx.queryParam("template-id-mask");
+        String office = ctx.queryParam(OFFICE);
+        String templateIdMask = ctx.queryParam(TEMPLATE_ID_MASK);
 
         String formatHeader = ctx.header(Header.ACCEPT);
         ContentType contentType = Formats.parseHeaderAndQueryParm(formatHeader, "");
-        try (final Timer.Context timeContext = markAndTime("getAll");
+        try (Timer.Context timeContext = markAndTime("getAll");
              DSLContext dsl = getDslContext(ctx)) {
             SpecifiedLevelDao dao = getDao(dsl);
             List<SpecifiedLevel> levels = dao.getSpecifiedLevels(office, templateIdMask);
@@ -102,26 +137,95 @@ public class SpecifiedLevelController implements CrudHandler {
         // generated methods, choose Tools | Specs.
     }
 
-
-    @OpenApi(ignore = true)
-    @Override
+    @OpenApi(
+        description = "Create new SpecifiedLevel",
+        requestBody = @OpenApiRequestBody(
+            content = {
+                @OpenApiContent(from = SpecifiedLevel.class, type = Formats.JSONV2)
+            },
+            required = true),
+        queryParams = {
+            @OpenApiParam(name = FAIL_IF_EXISTS, type = Boolean.class,
+                description = "Create will fail if provided ID already exists. Default: true")
+        },
+        method = HttpMethod.POST,
+        tags = {TAG}
+    )
     public void create(Context ctx) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of
-        // generated methods, choose Tools | Specs.
+        try (Timer.Context ignored = markAndTime("create");
+             DSLContext dsl = getDslContext(ctx)) {
+            String reqContentType = ctx.req.getContentType();
+            String formatHeader = reqContentType != null ? reqContentType : Formats.JSONV2;
+            String body = ctx.body();
+            SpecifiedLevel deserialize = deserialize(body, formatHeader);
+            SpecifiedLevelDao dao = getDao(dsl);
+            boolean failIfExists = ctx.queryParamAsClass(FAIL_IF_EXISTS, Boolean.class).getOrDefault(true);
+            dao.create(deserialize, failIfExists);
+            ctx.status(HttpServletResponse.SC_CREATED);
+        } catch (JsonProcessingException ex) {
+            RadarError re = new RadarError("Failed to process create request");
+            logger.log(Level.SEVERE, re.toString(), ex);
+            ctx.status(HttpServletResponse.SC_INTERNAL_SERVER_ERROR).json(re);
+        }
     }
 
-    @OpenApi(ignore = true)
-    @Override
-    public void update(Context ctx, String locationCode) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of
-        // generated methods, choose Tools | Specs.
+    @OpenApi(
+        description = "Renames the requested specified level id",
+        pathParams = {
+            @OpenApiParam(name = SPECIFIED_LEVEL_ID, description = "The specified level id to be renamed"),
+        },
+        queryParams = {
+            @OpenApiParam(name = OFFICE, required = true, description = "Specifies the "
+                + "owning office of the timeseries identifier to be renamed"),
+            @OpenApiParam(name = SPECIFIED_LEVEL_ID, description = "The new specified level id.")
+        },
+        method = HttpMethod.PATCH,
+        tags = {TAG}
+    )
+    public void update(Context ctx, String oldSpecifiedLevelId) {
+        try (Timer.Context ignored = markAndTime("update");
+             DSLContext dsl = getDslContext(ctx)) {
+            SpecifiedLevelDao dao = getDao(dsl);
+            String newSpecifiedLevelId = ctx.queryParam(SPECIFIED_LEVEL_ID);
+            String office = ctx.queryParam(OFFICE);
+            dao.update(oldSpecifiedLevelId, newSpecifiedLevelId, office);
+            ctx.status(HttpServletResponse.SC_NO_CONTENT);
+        }
     }
 
-    @OpenApi(ignore = true)
-    @Override
-    public void delete(Context ctx, String locationCode) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of
-        // generated methods, choose Tools | Specs.
+
+
+    @OpenApi(
+        description = "Deletes requested specified level id",
+        pathParams = {
+            @OpenApiParam(name = SPECIFIED_LEVEL_ID, description = "The specified level id to be deleted"),
+        },
+        queryParams = {
+            @OpenApiParam(name = OFFICE, required = true, description = "Specifies the "
+                + "owning office of the timeseries identifier to be deleted"),
+        },
+        method = HttpMethod.DELETE,
+        tags = {TAG}
+    )
+    public void delete(Context ctx, String specifiedLevelId) {
+        try (Timer.Context ignored = markAndTime("update");
+             DSLContext dsl = getDslContext(ctx)) {
+            SpecifiedLevelDao dao = getDao(dsl);
+            String office = ctx.queryParam(OFFICE);
+            dao.delete(specifiedLevelId, office);
+            ctx.status(HttpServletResponse.SC_NO_CONTENT);
+        }
+    }
+
+    private static SpecifiedLevel deserialize(String body, String format) throws JsonProcessingException {
+        SpecifiedLevel retval;
+        if (ContentType.equivalent(Formats.JSONV2, format)) {
+            ObjectMapper om = JsonV2.buildObjectMapper();
+            retval = om.readValue(body, SpecifiedLevel.class);
+        } else {
+            throw new IllegalArgumentException("Unsupported format: " + format);
+        }
+        return retval;
     }
 
 }

--- a/cwms_radar_api/src/main/java/cwms/radar/api/TimeSeriesIdentifierDescriptorController.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/api/TimeSeriesIdentifierDescriptorController.java
@@ -51,6 +51,7 @@ public class TimeSeriesIdentifierDescriptorController implements CrudHandler {
     public static final String ACTIVE = "active";
     public static final String INTERVAL_OFFSET = "interval-offset";
     public static final String METHOD = "method";
+    public static final String FAIL_IF_EXISTS = "fail-if-exists";
     private static final int DEFAULT_PAGE_SIZE = 500;
 
     private final MetricRegistry metrics;
@@ -211,7 +212,7 @@ public class TimeSeriesIdentifierDescriptorController implements CrudHandler {
                     },
                     required = true),
             queryParams = {
-                    @OpenApiParam(name = "fail-if-exists", type = Boolean.class,
+                    @OpenApiParam(name = FAIL_IF_EXISTS, type = Boolean.class,
                             description = "Create will fail if provided ID already exists. Default: true")
             },
             method = HttpMethod.POST,
@@ -234,10 +235,8 @@ public class TimeSeriesIdentifierDescriptorController implements CrudHandler {
             boolean versioned = false;
             Number numForwards = null;
             Number numBackwards = null;
-            boolean failIfExists = false;
-
+            boolean failIfExists = ctx.queryParamAsClass(FAIL_IF_EXISTS, Boolean.class).getOrDefault(true);
             dao.create(tsid, versioned, numForwards, numBackwards, failIfExists);
-
             ctx.status(HttpServletResponse.SC_CREATED);
         } catch (JsonProcessingException ex) {
             RadarError re = new RadarError("Failed to process create request");
@@ -315,7 +314,6 @@ public class TimeSeriesIdentifierDescriptorController implements CrudHandler {
 
                 dao.update(office, timeseriesId, intervalOffset, forward, backward, active);
             }
-
         }
 
     }

--- a/cwms_radar_api/src/main/java/cwms/radar/api/errors/InvalidItemException.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/api/errors/InvalidItemException.java
@@ -1,0 +1,45 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.radar.api.errors;
+
+public class InvalidItemException extends RuntimeException {
+    public InvalidItemException(String message) {
+        super(message);
+    }
+
+    public InvalidItemException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidItemException(Throwable cause) {
+        super(cause);
+    }
+
+    public InvalidItemException() {
+        super();
+    }
+
+
+}

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/SpecifiedLevelDao.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/SpecifiedLevelDao.java
@@ -8,10 +8,10 @@ import java.util.List;
 import java.util.logging.Logger;
 import org.jooq.DSLContext;
 import usace.cwms.db.dao.util.OracleTypeMap;
+import usace.cwms.db.jooq.codegen.packages.CWMS_LEVEL_PACKAGE;
 import usace.cwms.db.jooq.dao.CwmsDbLevelJooq;
 
-public class SpecifiedLevelDao extends JooqDao<SpecifiedLevel> {
-    private static final Logger logger = Logger.getLogger(SpecifiedLevelDao.class.getName());
+public final class SpecifiedLevelDao extends JooqDao<SpecifiedLevel> {
     public static final String OFFICE_ID = "OFFICE_ID";
     public static final String SPECIFIED_LEVEL_ID = "SPECIFIED_LEVEL_ID";
     public static final String DESCRIPTION = "DESCRIPTION";
@@ -42,5 +42,22 @@ public class SpecifiedLevelDao extends JooqDao<SpecifiedLevel> {
         });
 
         return retval;
+    }
+
+    public void create(SpecifiedLevel specifiedLevel, boolean failIfExists) {
+        CWMS_LEVEL_PACKAGE.call_STORE_SPECIFIED_LEVEL(dsl.configuration(),
+            specifiedLevel.getId(), specifiedLevel.getDescription(), OracleTypeMap.formatBool(failIfExists),
+            specifiedLevel.getOfficeId());
+    }
+
+    public void update(String oldSpecifiedLevelId, String newSpecifiedLevelId, String officeId) {
+        CWMS_LEVEL_PACKAGE.call_RENAME_SPECIFIED_LEVEL(dsl.configuration(),
+            oldSpecifiedLevelId, newSpecifiedLevelId, officeId);
+    }
+
+    public void delete(String specifiedLevelId, String office) {
+        String failIfNotFound = OracleTypeMap.formatBool(true);
+        CWMS_LEVEL_PACKAGE.call_DELETE_SPECIFIED_LEVEL(dsl.configuration(), specifiedLevelId, failIfNotFound,
+            office);
     }
 }

--- a/cwms_radar_api/src/test/java/cwms/radar/api/SpecifiedLevelIdIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/SpecifiedLevelIdIT.java
@@ -52,12 +52,12 @@ public class SpecifiedLevelIdIT extends DataApiTestIT {
         ObjectMapper om = JsonV2.buildObjectMapper();
         TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
         SpecifiedLevel specifiedLevel = new SpecifiedLevel("TestCRD" + Instant.now().getEpochSecond(), OFFICE, "CDA Integration Test");
-        String serializedTs = om.writeValueAsString(specifiedLevel);
+        String serializedLevel = om.writeValueAsString(specifiedLevel);
         //Create
         given()
             .accept(Formats.JSONV2)
             .contentType(Formats.JSONV2)
-            .body(serializedTs)
+            .body(serializedLevel)
             .header("Authorization", user.toHeaderValue())
             .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
             .when()
@@ -127,13 +127,13 @@ public class SpecifiedLevelIdIT extends DataApiTestIT {
         TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
         long epochSeconds = Instant.now().getEpochSecond();
         SpecifiedLevel specifiedLevel = new SpecifiedLevel("TestUpdate" + epochSeconds, OFFICE, "CDA Integration Test");
-        String serializedTs = om.writeValueAsString(specifiedLevel);
+        String serializedLevel = om.writeValueAsString(specifiedLevel);
         String newId = "Test" + (epochSeconds + 1);
         //Create
         given()
             .accept(Formats.JSONV2)
             .contentType(Formats.JSONV2)
-            .body(serializedTs)
+            .body(serializedLevel)
             .header("Authorization", user.toHeaderValue())
             .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
             .when()

--- a/cwms_radar_api/src/test/java/cwms/radar/api/SpecifiedLevelIdIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/SpecifiedLevelIdIT.java
@@ -1,0 +1,221 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.radar.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import cwms.radar.data.dto.SpecifiedLevel;
+import cwms.radar.formatters.Formats;
+import cwms.radar.formatters.json.JsonV2;
+import fixtures.RadarApiSetupCallback;
+import fixtures.TestAccounts;
+import java.time.Instant;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("integration")
+@ExtendWith(RadarApiSetupCallback.class)
+public class SpecifiedLevelIdIT extends DataApiTestIT {
+
+    public static final String OFFICE = "SPK";
+
+    @Test
+    public void test_create_read_delete() throws JsonProcessingException {
+        ObjectMapper om = JsonV2.buildObjectMapper();
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+        SpecifiedLevel specifiedLevel = new SpecifiedLevel("TestCRD" + Instant.now().getEpochSecond(), OFFICE, "CDA Integration Test");
+        String serializedTs = om.writeValueAsString(specifiedLevel);
+        //Create
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .body(serializedTs)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/specified-levels/")
+            .then()
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED));
+
+        //Read
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam("office", OFFICE)
+            .queryParam(SpecifiedLevelController.TEMPLATE_ID_MASK, specifiedLevel.getId())
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/specified-levels/")
+            .then()
+            .assertThat()
+            .log().body().log().everything(true)
+            .body("[0].id", equalTo(specifiedLevel.getId()))
+            .body("[0].office-id", equalTo(specifiedLevel.getOfficeId()))
+            .body("[0].description", equalTo(specifiedLevel.getDescription()))
+            .statusCode(is(HttpServletResponse.SC_OK));
+        //Delete
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam("office", OFFICE)
+            .queryParam(SpecifiedLevelController.TEMPLATE_ID_MASK, specifiedLevel.getId())
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/specified-levels/" + specifiedLevel.getId())
+            .then()
+            .assertThat()
+            .log().body().log().everything(true)
+            .statusCode(is(HttpServletResponse.SC_NO_CONTENT));
+
+        //Read Empty
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam("office", OFFICE)
+            .queryParam(SpecifiedLevelController.TEMPLATE_ID_MASK, specifiedLevel.getId())
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/specified-levels/")
+            .then()
+            .assertThat()
+            .log().body().log().everything(true)
+            .body("size()", is(0))
+            .statusCode(is(HttpServletResponse.SC_OK));
+    }
+
+
+    @Test
+    public void test_update() throws JsonProcessingException {
+        ObjectMapper om = JsonV2.buildObjectMapper();
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+        long epochSeconds = Instant.now().getEpochSecond();
+        SpecifiedLevel specifiedLevel = new SpecifiedLevel("TestUpdate" + epochSeconds, OFFICE, "CDA Integration Test");
+        String serializedTs = om.writeValueAsString(specifiedLevel);
+        String newId = "Test" + (epochSeconds + 1);
+        //Create
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .body(serializedTs)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/specified-levels/")
+            .then()
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED));
+        //Update
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
+            .queryParam(SpecifiedLevelController.SPECIFIED_LEVEL_ID, newId)
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .patch("/specified-levels/" + specifiedLevel.getId())
+            .then()
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NO_CONTENT));
+
+        //Read
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam("office", OFFICE)
+            .queryParam(SpecifiedLevelController.TEMPLATE_ID_MASK, newId)
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/specified-levels/")
+            .then()
+            .assertThat()
+            .log().body().log().everything(true)
+            .body("[0].id", equalTo(newId))
+            .statusCode(is(HttpServletResponse.SC_OK));
+    }
+
+
+    @Test
+    public void test_update_does_not_exist() throws JsonProcessingException {
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+        long epochSeconds = Instant.now().getEpochSecond();
+        SpecifiedLevel specifiedLevel = new SpecifiedLevel("BadUpdate" + epochSeconds, OFFICE, "CDA Integration Test");
+        //Update
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
+            .queryParam(SpecifiedLevelController.SPECIFIED_LEVEL_ID, specifiedLevel.getId())
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .patch("/specified-levels/" + specifiedLevel.getId())
+            .then()
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+    }
+
+
+    @Test
+    public void test_delete_does_not_exist() throws JsonProcessingException {
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+        long epochSeconds = Instant.now().getEpochSecond();
+        SpecifiedLevel specifiedLevel = new SpecifiedLevel("TestBadDelete" + epochSeconds, OFFICE, "CDA Integration Test");
+        //Update
+        given()
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(SpecifiedLevelController.OFFICE, OFFICE)
+            .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/specified-levels/" + specifiedLevel.getId())
+            .then()
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
fixes: #273 

I added a global exception handler for ORA-20019 INVALID_ITEM since that is what the specified level rename routine throws if the original specified level id isn't found. This is routed to 400 error code. I didn't like returning a 404 for INVALID_ITEM. I could make a Jira ticket for the schema if we want the package procedure to throw a _NOT_FOUND error instead.