### PR TITLE
Migration to office-id in DTO abstract class.

### DIFF
--- a/cwms_radar_api/src/main/java/cwms/radar/api/ClobController.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/api/ClobController.java
@@ -253,7 +253,7 @@ public class ClobController implements CrudHandler {
             try {
                 Clob clob = deserialize(ctx.body(), formatHeader);
 
-                if (clob.getOffice() == null) {
+                if (clob.getOfficeId() == null) {
                     throw new FormattingException("An officeId is required when creating a clob");
                 }
 
@@ -341,7 +341,7 @@ public class ClobController implements CrudHandler {
             try {
                 Clob clob = deserialize(ctx.body(), formatHeader);
 
-                if (clob.getOffice() == null) {
+                if (clob.getOfficeId() == null) {
                     throw new HttpResponseException(HttpCode.BAD_REQUEST.getStatus(),
                     "An office is required in the request body when updating a clob");
                 }
@@ -371,13 +371,13 @@ public class ClobController implements CrudHandler {
     private Clob fillOutClob(Clob clob, String reqId) {
         Clob retval = clob;
 
-        if (clob != null && (clob.getId() == null || clob.getOffice() == null)) {
+        if (clob != null && (clob.getId() == null || clob.getOfficeId() == null)) {
             String id = clob.getId();
             if (id == null) {
                 id = reqId;
             }
 
-            retval = new Clob(id, clob.getOffice(), clob.getDescription(), clob.getValue());
+            retval = new Clob(id, clob.getOfficeId(), clob.getDescription(), clob.getValue());
         }
 
         return retval;

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dao/ClobDao.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dao/ClobDao.java
@@ -210,7 +210,7 @@ public class ClobDao extends JooqDao<Clob> {
                 clob.getId(),
                 clob.getDescription(),
                 pFailIfExists,
-                clob.getOffice()
+                clob.getOfficeId()
         );
 
     }
@@ -240,7 +240,7 @@ public class ClobDao extends JooqDao<Clob> {
                 clob.getId(),
                 clob.getDescription(),
                 p_ignore_nulls,
-                clob.getOffice()
+                clob.getOfficeId()
         );
     }
 }

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/AssignedLocation.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/AssignedLocation.java
@@ -26,7 +26,7 @@ package cwms.radar.data.dto;
 
 import cwms.radar.api.errors.FieldException;
 
-public class AssignedLocation implements CwmsDTO
+public class AssignedLocation implements CwmsDTOBase
 {
 	private String locationId;
 	private String officeId;

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/AssignedTimeSeries.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/AssignedTimeSeries.java
@@ -27,7 +27,7 @@ package cwms.radar.data.dto;
 import cwms.radar.api.errors.FieldException;
 import java.math.BigDecimal;
 
-public class AssignedTimeSeries implements CwmsDTO
+public class AssignedTimeSeries implements CwmsDTOBase
 {
 	private String timeseriesId;
 	private BigDecimal tsCode;

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/Blob.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/Blob.java
@@ -1,13 +1,13 @@
 package cwms.radar.data.dto;
 
+import org.checkerframework.checker.units.qual.s;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import cwms.radar.api.errors.FieldException;
 
-public class Blob implements CwmsDTO
+public class Blob extends CwmsDTO
 {
-	@JsonProperty(required=true)
-	private String office;
 	@JsonProperty(required=true)
 	private String id;
 	private String description;
@@ -16,16 +16,11 @@ public class Blob implements CwmsDTO
 
 	public Blob(String office, String id, String description, String type, byte[] value)
 	{
-		this.office = office;
+		super(office);
 		this.id = id;
 		this.description = description;
 		this.mediaTypeId = type;
 		this.value = value;
-	}
-
-	public String getOffice()
-	{
-		return office;
 	}
 
 	public String getId()
@@ -51,7 +46,7 @@ public class Blob implements CwmsDTO
 	@Override
 	public String toString(){
 		StringBuilder builder = new StringBuilder();
-		builder.append(getOffice()).append("/").append(id).append(";description=").append(description);
+		builder.append(getOfficeId()).append("/").append(id).append(";description=").append(description);
 		return builder.toString();
 	}
 

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/Clob.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/Clob.java
@@ -9,9 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "clob")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class Clob implements CwmsDTO {
-    @JsonProperty(required = true)
-    private String office;
+public class Clob extends CwmsDTO {
     @JsonProperty(required = true)
     private String id;
     private String description;
@@ -19,17 +17,14 @@ public class Clob implements CwmsDTO {
 
     @SuppressWarnings("unused")
     private Clob() {
+        super(null);
     }
 
     public Clob(String office, String id, String description, String value) {
-        this.office = office;
+        super(office);
         this.id = id;
         this.description = description;
         this.value = value;
-    }
-
-    public String getOffice() {
-        return office;
     }
 
     public String getId() {
@@ -47,7 +42,7 @@ public class Clob implements CwmsDTO {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append(getOffice()).append("/").append(id).append(";description=").append(description);
+        builder.append(getOfficeId()).append("/").append(id).append(";description=").append(description);
         return builder.toString();
     }
 

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/CwmsDTO.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/CwmsDTO.java
@@ -1,7 +1,28 @@
 package cwms.radar.data.dto;
 
-import cwms.radar.api.errors.FieldException;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
 
-public interface CwmsDTO {
-    public void validate() throws FieldException; // additional validation logic.
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Base class for any DTO owned specifically by an office
+ * to enforce consistency and the available to set the session
+ * correctly.
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public abstract class CwmsDTO implements CwmsDTOBase {
+    @Schema(description = "Owning office of object.")
+    @JsonProperty(required = true)
+    private String officeId; // ALL DTOs require an office field
+
+    protected CwmsDTO(String office) {
+        this.officeId = office;
+    }
+
+    public String getOfficeId() {
+        return officeId;
+    }
 }

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/CwmsDTOBase.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/CwmsDTOBase.java
@@ -1,0 +1,12 @@
+package cwms.radar.data.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import cwms.radar.api.errors.FieldException;
+/*
+ * Suitable base for objects not owned by an office, like a list of locations.
+ * Or parameters, or the list of offices themselves.
+ */
+public interface CwmsDTOBase {
+    public  void validate() throws FieldException; // additional validation logic.
+}

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/CwmsDTOPaginated.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/CwmsDTOPaginated.java
@@ -26,7 +26,7 @@ import kotlin.jvm.functions.Function1;
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlAccessorOrder(XmlAccessOrder.ALPHABETICAL)
-public abstract class CwmsDTOPaginated implements CwmsDTO {
+public abstract class CwmsDTOPaginated implements CwmsDTOBase {
     private static final Logger logger = Logger.getLogger(CwmsDTOPaginated.class.getName());
 
     @Schema(

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/Location.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/Location.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 @JsonDeserialize(builder = Location.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class Location implements CwmsDTO {
+public final class Location extends CwmsDTO {
     @JsonProperty(required = true)
     private final String name;
     private final Double latitude;
@@ -44,9 +44,9 @@ public final class Location implements CwmsDTO {
     private final Double elevation;
     private final String mapLabel;
     private final String boundingOfficeId;
-    private final String officeId;
 
     private Location(Builder builder) {
+        super(builder.officeId);
         this.name = builder.name;
         this.latitude = builder.latitude;
         this.longitude = builder.longitude;
@@ -68,7 +68,6 @@ public final class Location implements CwmsDTO {
         this.elevation = builder.elevation;
         this.mapLabel = builder.mapLabel;
         this.boundingOfficeId = builder.boundingOfficeId;
-        this.officeId = builder.officeId;
     }
 
     public String getName() {
@@ -155,10 +154,6 @@ public final class Location implements CwmsDTO {
         return boundingOfficeId;
     }
 
-    public String getOfficeId() {
-        return officeId;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -224,7 +219,7 @@ public final class Location implements CwmsDTO {
                 + ", elevation=" + elevation
                 + ", mapLabel='" + mapLabel + '\''
                 + ", boundingOfficeId='" + boundingOfficeId + '\''
-                + ", officeId='" + officeId + '\''
+                + ", officeId='" + getOfficeId() + '\''
                 + '}';
     }
 

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/LocationCategory.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/LocationCategory.java
@@ -34,22 +34,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Schema(description = "A representation of a location category")
 @XmlRootElement(name="location_category")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class LocationCategory implements CwmsDTO
+public class LocationCategory extends CwmsDTO
 {
-	private final String officeId;
 	private final String id;
 	private final String description;
 
 	public LocationCategory(@JsonProperty("office-id") String catDbOfficeId, @JsonProperty("id") String locCategoryId, @JsonProperty("description") String locCategoryDesc)
 	{
-		this.officeId = catDbOfficeId;
+		super(catDbOfficeId);
 		this.id = locCategoryId;
 		this.description = locCategoryDesc;
-	}
-
-	public String getOfficeId()
-	{
-		return officeId;
 	}
 
 	public String getId()

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/LocationGroup.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/LocationGroup.java
@@ -35,11 +35,10 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Schema(description = "A representation of a location group")
 @XmlRootElement(name="location_group")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class LocationGroup implements CwmsDTO
+public class LocationGroup extends CwmsDTO
 {
 	private String id;
 	private LocationCategory locationCategory;
-	private String officeId;
 	private String description;
 
 	private String sharedLocAliasId;
@@ -50,14 +49,15 @@ public class LocationGroup implements CwmsDTO
 
 	public LocationGroup()
 	{
-
+		// Should be unused
+		super(null);
 	}
 
 	public LocationGroup(LocationCategory cat, String grpOfficeId, String grpId, String grpDesc,
 						 String sharedLocAliasId, String sharedRefLocationId, Number locGroupAttribute)
 	{
+		super(grpOfficeId);
 		this.locationCategory = cat;
-		this.officeId = grpOfficeId;
 		this.id = grpId;
 		this.description = grpDesc;
 		this.sharedLocAliasId = sharedLocAliasId;
@@ -67,23 +67,21 @@ public class LocationGroup implements CwmsDTO
 
 	public LocationGroup(LocationGroup group, List<AssignedLocation> locs){
 		this(group);
-		if(locs != null && !locs.isEmpty())
-		{
+		if (locs != null && !locs.isEmpty()) {
 			this.assignedLocations = new ArrayList<>(locs);
 		}
 	}
 
-	public LocationGroup(LocationGroup group){
+	public LocationGroup(LocationGroup group) {
+		super(group.getOfficeId());
 		this.locationCategory = group.getLocationCategory();
-		this.officeId = group.getOfficeId();
 		this.id = group.getId();
 		this.description = group.getDescription();
 		this.sharedLocAliasId = group.getSharedLocAliasId();
 		this.sharedRefLocationId = group.getSharedRefLocationId();
 		this.locGroupAttribute = group.getLocGroupAttribute();
 		List<AssignedLocation> locs = group.getAssignedLocations();
-		if(locs != null && !locs.isEmpty())
-		{
+		if (locs != null && !locs.isEmpty()) {
 			this.assignedLocations = new ArrayList<>(locs);
 		}
 	}
@@ -96,11 +94,6 @@ public class LocationGroup implements CwmsDTO
 	public LocationCategory getLocationCategory()
 	{
 		return locationCategory;
-	}
-
-	public String getOfficeId()
-	{
-		return officeId;
 	}
 
 	public String getDescription()

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/LocationLevel.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/LocationLevel.java
@@ -35,13 +35,10 @@ import rma.util.RMAConst;
 @JsonDeserialize(builder = LocationLevel.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class LocationLevel implements CwmsDTO {
+public final class LocationLevel extends CwmsDTO {
     @JsonProperty(required = true)
     @Schema(description = "Name of the location level")
     private final String locationLevelId;
-    @JsonProperty(required = true)
-    @Schema(description = "Owning office of the level")
-    private final String officeId;
     @Schema(description = "Timeseries ID (e.g. from the times series catalog) to use as the "
             + "location level. Mutually exclusive with seasonalValues and "
             + "siParameterUnitsConstantValue")
@@ -88,6 +85,7 @@ public final class LocationLevel implements CwmsDTO {
     private final String attributeComment;
 
     private LocationLevel(Builder builder) {
+        super(builder.officeId);
         seasonalTimeSeriesId = builder.seasonalTimeSeriesId;
         seasonalValues = builder.seasonalValues;
         specifiedLevelId = builder.specifiedLevelId;
@@ -109,7 +107,6 @@ public final class LocationLevel implements CwmsDTO {
         attributeDurationId = builder.attributeDurationId;
         attributeComment = builder.attributeComment;
         locationLevelId = builder.locationId;
-        officeId = builder.officeId;
     }
 
     public String getSeasonalTimeSeriesId() {
@@ -194,10 +191,6 @@ public final class LocationLevel implements CwmsDTO {
 
     public String getLocationLevelId() {
         return locationLevelId;
-    }
-
-    public String getOfficeId() {
-        return officeId;
     }
 
     @JsonPOJOBuilder

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/Office.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/Office.java
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "A representation of a CWMS office")
 @XmlRootElement(name="office")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class Office implements CwmsDTO{
+public class Office implements CwmsDTOBase {
     private static final HashMap<String,String> office_types = new HashMap<String,String>(){
         /**
          *

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/Pool.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/Pool.java
@@ -7,8 +7,7 @@ import cwms.radar.api.errors.FieldException;
 import usace.cwms.db.dao.ifc.pool.PoolNameType;
 import usace.cwms.db.dao.ifc.pool.PoolType;
 
-public class Pool extends PoolType implements CwmsDTO
-{
+public class Pool extends PoolType implements CwmsDTOBase {
 	private final Number attribute;
 	private final String description;
 	private final String clobText;

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/RecentValue.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/RecentValue.java
@@ -2,7 +2,7 @@ package cwms.radar.data.dto;
 
 import cwms.radar.api.errors.FieldException;
 
-public class RecentValue implements CwmsDTO
+public class RecentValue implements CwmsDTOBase
 {
 	String id;
 	TsvDqu dqu;

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/SpecifiedLevel.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/SpecifiedLevel.java
@@ -2,32 +2,26 @@ package cwms.radar.data.dto;
 
 import cwms.radar.api.errors.FieldException;
 
-public class SpecifiedLevel implements CwmsDTO
+public class SpecifiedLevel extends CwmsDTO
 {
 	private String id;
-	private String officeId;
 	private String description;
 
 	public SpecifiedLevel()
 	{
-
+		super(null);
 	}
 
 	public SpecifiedLevel(String id, String officeId, String description)
 	{
+		super(officeId);
 		this.id = id;
-		this.officeId = officeId;
 		this.description = description;
 	}
 
 	public String getId()
 	{
 		return id;
-	}
-
-	public String getOfficeId()
-	{
-		return officeId;
 	}
 
 	public String getDescription()
@@ -76,5 +70,3 @@ public class SpecifiedLevel implements CwmsDTO
 
 	}
 }
-
-

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/TimeSeriesCategory.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/TimeSeriesCategory.java
@@ -34,27 +34,21 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Schema(description = "A representation of a TimeSeries category")
 @XmlRootElement(name="timeseries-category")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class TimeSeriesCategory implements CwmsDTO
+public class TimeSeriesCategory extends CwmsDTO
 {
-	private String officeId;
 	private String id;
 	private String description;
 
 	public TimeSeriesCategory(@JsonProperty("office-id") String catOfficeId,
 							  @JsonProperty("id") String catId, @JsonProperty("description") String catDesc)
 	{
-		this.officeId = catOfficeId;
+		super(catOfficeId);
 		this.id = catId;
 		this.description = catDesc;
 	}
 
 	public TimeSeriesCategory(TimeSeriesCategory other){
 		this(other.getOfficeId(), other.getId(), other.getDescription());
-	}
-
-	public String getOfficeId()
-	{
-		return officeId;
 	}
 
 	public String getId()

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/TimeSeriesGroup.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/TimeSeriesGroup.java
@@ -36,11 +36,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 @Schema(description = "A representation of a timeseries group")
 @XmlRootElement(name="timeseries-group")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class TimeSeriesGroup implements CwmsDTO
-{
+public class TimeSeriesGroup extends CwmsDTO {
 	private String id;
 	private TimeSeriesCategory timeSeriesCategory;
-	private String officeId;
 	private String description;
 
 	private String sharedAliasId;
@@ -51,13 +49,14 @@ public class TimeSeriesGroup implements CwmsDTO
 
 
 	public TimeSeriesGroup() {
+		super(null);
 	}
 
 	public TimeSeriesGroup(TimeSeriesCategory cat, String grpOfficeId, String grpId, String grpDesc,
 						   String sharedTsAliasId, String sharedRefTsId)
 	{
+		super(grpOfficeId);
 		this.timeSeriesCategory = new TimeSeriesCategory(cat);
-		this.officeId = grpOfficeId;
 		this.id = grpId;
 		this.description = grpDesc;
 		this.sharedAliasId = sharedTsAliasId;
@@ -67,12 +66,12 @@ public class TimeSeriesGroup implements CwmsDTO
 
 	public TimeSeriesGroup(TimeSeriesGroup group)
 	{
-			this.timeSeriesCategory = new TimeSeriesCategory(group.timeSeriesCategory);
-			this.officeId = group.officeId;
-			this.id = group.id;
-			this.description = group.description;
-			this.sharedAliasId = group.sharedAliasId;
-			this.sharedRefTsId = group.sharedRefTsId;
+		super(group.getOfficeId());
+		this.timeSeriesCategory = new TimeSeriesCategory(group.timeSeriesCategory);
+		this.id = group.id;
+		this.description = group.description;
+		this.sharedAliasId = group.sharedAliasId;
+		this.sharedRefTsId = group.sharedRefTsId;
 	}
 
 	public TimeSeriesGroup(TimeSeriesGroup group, List<AssignedTimeSeries> timeSeries){
@@ -96,11 +95,6 @@ public class TimeSeriesGroup implements CwmsDTO
 	public String getDescription()
 	{
 		return description;
-	}
-
-	public String getOfficeId()
-	{
-		return officeId;
 	}
 
 	public String getSharedAliasId()

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/TimeSeriesIdentifierDescriptor.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/TimeSeriesIdentifierDescriptor.java
@@ -12,24 +12,18 @@ import java.time.ZoneId;
 @JsonDeserialize(builder = cwms.radar.data.dto.TimeSeriesIdentifierDescriptor.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class TimeSeriesIdentifierDescriptor implements CwmsDTO {
-
-    private final String officeId;
+public class TimeSeriesIdentifierDescriptor extends CwmsDTO {
     private final String timeSeriesId;
     private final String timezoneName;
     private final Long intervalOffsetMinutes;
     private final boolean active;
 
     private TimeSeriesIdentifierDescriptor(Builder builder) {
-        this.officeId = builder.officeId;
+        super(builder.officeId);
         this.timeSeriesId = builder.timeSeriesId;
         this.timezoneName = builder.timezoneName;
         this.intervalOffsetMinutes = builder.intervalOffsetMinutes;
         this.active = builder.active;
-    }
-
-    public String getOfficeId() {
-        return officeId;
     }
 
     public String getTimeSeriesId() {

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/Basin.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/Basin.java
@@ -3,10 +3,9 @@ package cwms.radar.data.dto.basinconnectivity;
 import cwms.radar.api.errors.FieldException;
 import cwms.radar.data.dto.CwmsDTO;
 
-public final class Basin implements CwmsDTO
+public final class Basin extends CwmsDTO
 {
     private final String basinName;
-    private final String officeId;
     private final Stream primaryStream;
     private final Double sortOrder;
     private final Double basinArea;
@@ -15,9 +14,9 @@ public final class Basin implements CwmsDTO
 
     private Basin(Builder builder)
     {
+        super(builder.officeId);
         basinName = builder.basinName;
         primaryStream = builder.primaryStream;
-        officeId = builder.officeId;
         sortOrder = builder.sortOrder;
         basinArea = builder.basinArea;
         contributingArea = builder.contributingArea;
@@ -32,11 +31,6 @@ public final class Basin implements CwmsDTO
     public Stream getPrimaryStream()
     {
         return primaryStream;
-    }
-
-    public String getOfficeId()
-    {
-        return officeId;
     }
 
     public Double getSortOrder()

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/Stream.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/Stream.java
@@ -6,7 +6,7 @@ import cwms.radar.data.dto.basinconnectivity.buildercontracts.stream.*;
 
 import java.util.*;
 
-public final class Stream implements CwmsDTO
+public final class Stream extends CwmsDTO
 {
     private final String streamName;
     private final List<Stream> tributaries;//streams that flow into this
@@ -20,12 +20,12 @@ public final class Stream implements CwmsDTO
     private final Double confluenceStation;
     private final Double diversionStation;
     private final List<StreamLocation> streamLocations;
-    private final String officeId;
     private final String comment;
     private final Double averageSlope;
 
     private Stream(Builder streamBuilder)
     {
+        super(streamBuilder.officeId);
         streamName = streamBuilder.streamName;
         startsDownstream = streamBuilder.startsDownstream;
         divertingStreamId = streamBuilder.divertingStreamId;
@@ -40,7 +40,6 @@ public final class Stream implements CwmsDTO
         streamReaches = streamBuilder.streamReaches;
         comment = streamBuilder.comment;
         averageSlope = streamBuilder.averageSlope;
-        officeId = streamBuilder.officeId;
     }
 
     public List<StreamLocation> getStreamLocations()
@@ -111,11 +110,6 @@ public final class Stream implements CwmsDTO
     public Double getAverageSlope()
     {
         return averageSlope;
-    }
-
-    public String getOfficeId()
-    {
-        return officeId;
     }
 
     public static class Builder implements BuildStream, BuildDiversionStation, BuildConfluenceStation, BuildDiversionBank, BuildConfluenceBank

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/StreamLocation.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/StreamLocation.java
@@ -3,13 +3,12 @@ package cwms.radar.data.dto.basinconnectivity;
 import cwms.radar.api.errors.FieldException;
 import cwms.radar.data.dto.CwmsDTO;
 
-public class StreamLocation implements CwmsDTO
+public class StreamLocation extends CwmsDTO
 {
     private final String locationName;
     private final String streamName;
     private final Double station;
     private final String bank;
-    private final String officeId;
     private final Double publishedStation;
     private final Double navigationStation;
     private final Double lowestMeasurableStage;
@@ -18,11 +17,11 @@ public class StreamLocation implements CwmsDTO
 
     private StreamLocation(Builder builder)
     {
+        super(builder.officeId);
         locationName = builder.locationName;
         streamName = builder.streamName;
         station = builder.station;
         bank = builder.bank;
-        officeId = builder.officeId;
         publishedStation = builder.publishedStation;
         navigationStation = builder.navigationStation;
         lowestMeasurableStage = builder.lowestMeasurableStage;
@@ -73,11 +72,6 @@ public class StreamLocation implements CwmsDTO
     public Double getUngagedDrainageArea()
     {
         return ungagedDrainageArea;
-    }
-
-    public String getOfficeId()
-    {
-        return officeId;
     }
 
     public static class Builder

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/StreamReach.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/basinconnectivity/StreamReach.java
@@ -3,25 +3,24 @@ package cwms.radar.data.dto.basinconnectivity;
 import cwms.radar.api.errors.FieldException;
 import cwms.radar.data.dto.CwmsDTO;
 
-public class StreamReach implements CwmsDTO
+public class StreamReach extends CwmsDTO
 {
     private final String upstreamLocationName;
     private final String downstreamLocationName;
     private final String streamName;
     private final String reachName;
-    private final String officeId;
     private final String comment;
     private final String configuration;
 
     StreamReach(Builder builder)
     {
+        super(builder.officeId);
         streamName = builder.streamName;
         reachName = builder.reachName;
         upstreamLocationName = builder.upstreamLocationName;
         downstreamLocationName = builder.downstreamLocationName;
         comment = builder.comment;
         configuration = builder.configuration;
-        officeId = builder.officeId;
     }
 
     public String getReachName()
@@ -52,11 +51,6 @@ public class StreamReach implements CwmsDTO
     public String getConfiguration()
     {
         return configuration;
-    }
-
-    public String getOfficeId()
-    {
-        return officeId;
     }
 
     public static class Builder

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingMetadata.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingMetadata.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import cwms.radar.api.errors.FieldException;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -15,7 +17,7 @@ import java.util.List;
 @JsonDeserialize(builder = RatingMetadata.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class RatingMetadata implements CwmsDTO {
+public class RatingMetadata implements CwmsDTOBase {
 
     private final RatingSpec ratingSpec;
 

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingSpec.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingSpec.java
@@ -18,8 +18,7 @@ import org.jetbrains.annotations.NotNull;
 @JsonDeserialize(builder = RatingSpec.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class RatingSpec implements CwmsDTO {
-    private final String officeId;
+public class RatingSpec extends CwmsDTO {
     private final String ratingId;
     private final String templateId;
     private final String locationId;
@@ -42,7 +41,7 @@ public class RatingSpec implements CwmsDTO {
 
 
     public RatingSpec(Builder builder) {
-        this.officeId = builder.officeId;
+        super(builder.officeId);
         this.ratingId = builder.ratingId;
         this.templateId = builder.templateId;
         this.locationId = builder.locationId;
@@ -59,10 +58,6 @@ public class RatingSpec implements CwmsDTO {
         this.dependentRoundingSpec = builder.dependentRoundingSpec;
         this.description = builder.description;
         this.effectiveDates = builder.effectiveDates;
-    }
-
-    public String getOfficeId() {
-        return officeId;
     }
 
     public String getRatingId() {

--- a/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingTemplate.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/data/dto/rating/RatingTemplate.java
@@ -17,8 +17,7 @@ import org.jetbrains.annotations.NotNull;
 @JsonDeserialize(builder = RatingTemplate.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class RatingTemplate implements CwmsDTO {
-    private final String officeId;
+public class RatingTemplate extends CwmsDTO {
     private final String id;
     private final String version;
 
@@ -30,9 +29,9 @@ public class RatingTemplate implements CwmsDTO {
     private final List<String> ratingIds;
 
     public RatingTemplate(Builder builder) {
+        super(builder.officeId);
         this.id = builder.id;
         this.version = builder.version;
-        this.officeId = builder.officeId;
         this.description = builder.description;
         this.dependentParameter = builder.dependentParameter;
         this.independentParameterSpecs = builder.independentParameterList;
@@ -45,10 +44,6 @@ public class RatingTemplate implements CwmsDTO {
 
     public String getVersion() {
         return version;
-    }
-
-    public String getOfficeId() {
-        return officeId;
     }
 
     public String getDescription() {

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/Formats.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/Formats.java
@@ -25,6 +25,7 @@
 package cwms.radar.formatters;
 
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.helpers.ResourceHelper;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -130,7 +131,7 @@ public class Formats {
     }
 
 
-    private String getFormatted(ContentType type, CwmsDTO toFormat) throws FormattingException {
+    private String getFormatted(ContentType type, CwmsDTOBase toFormat) throws FormattingException {
         Objects.requireNonNull(toFormat, "Object to be formatted should not be null");
         formatters.keySet().forEach(k -> logger.fine(k::toString));
         OutputFormatter outputFormatter = getOutputFormatter(type, toFormat.getClass());
@@ -145,7 +146,7 @@ public class Formats {
 
     }
 
-    private OutputFormatter getOutputFormatter(ContentType type, Class<? extends CwmsDTO> klass) {
+    private OutputFormatter getOutputFormatter(ContentType type, Class<? extends CwmsDTOBase> klass) {
         OutputFormatter outputFormatter = null;
         Map<Class<CwmsDTO>, OutputFormatter> contentFormatters = formatters.get(type);
         if (contentFormatters != null) {
@@ -154,8 +155,8 @@ public class Formats {
         return outputFormatter;
     }
 
-    private String getFormatted(ContentType type, List<? extends CwmsDTO> dtos, Class<?
-            extends CwmsDTO> rootType) throws FormattingException {
+    private String getFormatted(ContentType type, List<? extends CwmsDTOBase> dtos, Class<?
+            extends CwmsDTOBase> rootType) throws FormattingException {
         for (ContentType key : formatters.keySet()) {
             logger.finest(key.toString());
         }
@@ -182,14 +183,14 @@ public class Formats {
         }
     }
 
-    public static String format(ContentType type, CwmsDTO toFormat) throws FormattingException {
+    public static String format(ContentType type, CwmsDTOBase toFormat) throws FormattingException {
         logger.finest("formats");
         init();
         return formats.getFormatted(type, toFormat);
     }
 
-    public static String format(ContentType type, List<? extends CwmsDTO> toFormat, Class<?
-            extends CwmsDTO> rootType) throws FormattingException {
+    public static String format(ContentType type, List<? extends CwmsDTOBase> toFormat, Class<?
+            extends CwmsDTOBase> rootType) throws FormattingException {
         logger.finest("format list");
         init();
         return formats.getFormatted(type, toFormat, rootType);
@@ -272,5 +273,5 @@ public class Formats {
             }
         }
         return null;
-    }    
+    }
 }

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/OutputFormatter.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/OutputFormatter.java
@@ -2,10 +2,10 @@ package cwms.radar.formatters;
 
 import java.util.List;
 
-import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 
 public interface OutputFormatter {
     public String getContentType();
-    public String format(CwmsDTO dto);
-    public String format(List<? extends CwmsDTO> dtoList);
+    public String format(CwmsDTOBase dto);
+    public String format(List<? extends CwmsDTOBase> dtoList);
 }

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/csv/CsvV1.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/csv/CsvV1.java
@@ -3,6 +3,7 @@ package cwms.radar.formatters.csv;
 import java.util.List;
 
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.LocationGroup;
 import cwms.radar.data.dto.Office;
 import cwms.radar.formatters.Formats;
@@ -18,7 +19,7 @@ public class CsvV1 implements OutputFormatter {
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         String retval = null;
         if( dto instanceof Office )
         {
@@ -30,11 +31,11 @@ public class CsvV1 implements OutputFormatter {
     }
 
     @Override
-    public String format(List<? extends CwmsDTO> dtoList) {
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         String retval = null;
         if(dtoList != null && !dtoList.isEmpty())
         {
-            CwmsDTO dto = dtoList.get(0);
+            CwmsDTOBase dto = dtoList.get(0);
             if( dto instanceof Office)
             {
                 retval = new CsvV1Office().format(dtoList);

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/csv/CsvV1LocationGroup.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/csv/CsvV1LocationGroup.java
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import cwms.radar.data.dto.AssignedLocation;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.LocationCategory;
 import cwms.radar.data.dto.LocationGroup;
 import cwms.radar.formatters.Formats;
@@ -39,7 +40,7 @@ public class CsvV1LocationGroup implements OutputFormatter{
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         LocationGroup locationGroup = (LocationGroup)dto;
 
         ObjectWriter writer = buildWriter();
@@ -72,7 +73,7 @@ public class CsvV1LocationGroup implements OutputFormatter{
 
     @Override
     @SuppressWarnings("unchecked") // for the daoList conversion
-    public String format(List<? extends CwmsDTO> dtoList) {        
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         List<LocationGroup> locationGroups = (List<LocationGroup>)dtoList;
         ObjectWriter writer = buildWriter();
         try

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/csv/CsvV1Office.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/csv/CsvV1Office.java
@@ -2,7 +2,7 @@ package cwms.radar.formatters.csv;
 
 import java.util.List;
 
-import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.Office;
 import cwms.radar.formatters.Formats;
 import cwms.radar.formatters.OutputFormatter;
@@ -32,7 +32,7 @@ public class CsvV1Office implements OutputFormatter{
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         Office office = (Office)dto;
         StringBuilder builder = new StringBuilder();
         builder.append(getOfficeTabHeader()).append("\r\n");
@@ -43,7 +43,7 @@ public class CsvV1Office implements OutputFormatter{
 
     @Override
     @SuppressWarnings("unchecked") // for the daoList conversion
-    public String format(List<? extends CwmsDTO> dtoList) {        
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         List<Office> offices = (List<Office>)dtoList;
         StringBuilder builder = new StringBuilder();
         builder.append(getOfficeTabHeader()).append("\r\n");

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/json/JsonV1.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/json/JsonV1.java
@@ -14,6 +14,7 @@ import cwms.radar.data.dto.Catalog;
 import cwms.radar.data.dto.Clob;
 import cwms.radar.data.dto.Clobs;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.Location;
 import cwms.radar.data.dto.LocationCategory;
 import cwms.radar.data.dto.LocationGroup;
@@ -86,7 +87,7 @@ public class JsonV1 implements OutputFormatter{
 	}
 
 	@Override
-	public String format(CwmsDTO dto)
+	public String format(CwmsDTOBase dto)
 	{
 		Object fmtv1 = buildFormatting(dto);
 		try
@@ -100,7 +101,7 @@ public class JsonV1 implements OutputFormatter{
 	}
 
 	@Override
-	public String format(List<? extends CwmsDTO> daoList)
+	public String format(List<? extends CwmsDTOBase> daoList)
 	{
 		Object wrapped = buildFormatting(daoList);
 		try
@@ -113,7 +114,7 @@ public class JsonV1 implements OutputFormatter{
 		}
 	}
 
-	private Object buildFormatting(CwmsDTO dao)
+	private Object buildFormatting(CwmsDTOBase dao)
 	{
 		Object retval = null;
 
@@ -161,13 +162,13 @@ public class JsonV1 implements OutputFormatter{
 		return retval;
 	}
 
-	private Object buildFormatting(List<? extends CwmsDTO> daoList)
+	private Object buildFormatting(List<? extends CwmsDTOBase> daoList)
 	{
 		Object retval = null;
 
 		if(daoList != null && !daoList.isEmpty())
 		{
-			CwmsDTO firstObj = daoList.get(0);
+			CwmsDTOBase firstObj = daoList.get(0);
 			if(firstObj instanceof Office)
 			{
 				List<Office> officesList = daoList.stream().map(Office.class::cast).collect(Collectors.toList());

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/json/JsonV2.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/json/JsonV2.java
@@ -10,6 +10,7 @@ import cwms.radar.data.dto.Catalog;
 import cwms.radar.data.dto.Clob;
 import cwms.radar.data.dto.Clobs;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.Location;
 import cwms.radar.data.dto.LocationLevel;
 import cwms.radar.data.dto.LocationLevels;
@@ -94,7 +95,7 @@ public class JsonV2 implements OutputFormatter {
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         try {
             return om.writeValueAsString(dto);
         } catch (JsonProcessingException e) {
@@ -103,7 +104,7 @@ public class JsonV2 implements OutputFormatter {
     }
 
     @Override
-    public String format(List<? extends CwmsDTO> dtoList) {
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         try {
             return om.writeValueAsString(dtoList);
         } catch (JsonProcessingException e) {

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/json/NamedPgJsonFormatter.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/json/NamedPgJsonFormatter.java
@@ -7,6 +7,7 @@ import cwms.radar.api.graph.basinconnectivity.BasinConnectivityGraph;
 import cwms.radar.api.graph.pg.dto.NamedPgGraphData;
 import cwms.radar.api.graph.pg.dto.PgGraphData;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.basinconnectivity.Basin;
 import cwms.radar.formatters.Formats;
 import cwms.radar.formatters.FormattingException;
@@ -33,7 +34,7 @@ public class NamedPgJsonFormatter implements OutputFormatter
     }
 
     @Override
-    public String format(CwmsDTO dto)
+    public String format(CwmsDTOBase dto)
     {
         String retVal;
         try
@@ -58,10 +59,10 @@ public class NamedPgJsonFormatter implements OutputFormatter
     }
 
     @Override
-    public String format(List<? extends CwmsDTO> dtoList)
+    public String format(List<? extends CwmsDTOBase> dtoList)
     {
         StringBuilder retval = new StringBuilder();
-        for(CwmsDTO dto : dtoList)
+        for(CwmsDTOBase dto : dtoList)
         {
             retval.append(format(dto));
         }

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/json/PgJsonFormatter.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/json/PgJsonFormatter.java
@@ -112,7 +112,7 @@ public final class PgJsonFormatter implements OutputFormatter
     }
 
     @Override
-    public String format(CwmsDTO dto)
+    public String format(CwmsDTOBase dto)
     {
         String retVal;
         Graph graph;
@@ -137,10 +137,10 @@ public final class PgJsonFormatter implements OutputFormatter
     }
 
     @Override
-    public String format(List<? extends CwmsDTO> dtoList)
+    public String format(List<? extends CwmsDTOBase> dtoList)
     {
         StringBuilder retval = new StringBuilder();
-        for(CwmsDTO dto : dtoList)
+        for(CwmsDTOBase dto : dtoList)
         {
             retval.append(format(dto));
         }

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/tab/TabV1.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/tab/TabV1.java
@@ -3,6 +3,7 @@ package cwms.radar.formatters.tab;
 import java.util.List;
 
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.Office;
 import cwms.radar.formatters.Formats;
 import cwms.radar.formatters.OutputFormatter;
@@ -17,7 +18,7 @@ public class TabV1 implements OutputFormatter {
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         if( dto instanceof Office ){
             return new TabV1Office().format(dto);
         } else {
@@ -26,7 +27,7 @@ public class TabV1 implements OutputFormatter {
     }
 
     @Override
-    public String format(List<? extends CwmsDTO> dtoList) {
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         if( !dtoList.isEmpty() && dtoList.get(0) instanceof Office ){
             return new TabV1Office().format(dtoList);
         } else {

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/tab/TabV1Office.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/tab/TabV1Office.java
@@ -3,6 +3,7 @@ package cwms.radar.formatters.tab;
 import java.util.List;
 
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.Office;
 import cwms.radar.formatters.Formats;
 import cwms.radar.formatters.OutputFormatter;
@@ -31,7 +32,7 @@ public class TabV1Office implements OutputFormatter{
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         Office office = (Office)dto;
         StringBuilder builder = new StringBuilder();
         builder.append(getOfficeTabHeader()).append("\r\n");
@@ -42,7 +43,7 @@ public class TabV1Office implements OutputFormatter{
 
     @Override
     @SuppressWarnings("unchecked") // for the daoList conversion
-    public String format(List<? extends CwmsDTO> dtoList) {        
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         List<Office> offices = (List<Office>)dtoList;
         StringBuilder builder = new StringBuilder();
         builder.append(getOfficeTabHeader()).append("\r\n");

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/xml/XMLv1.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/xml/XMLv1.java
@@ -13,6 +13,7 @@ import javax.xml.bind.Marshaller;
 
 import cwms.radar.data.dto.Catalog;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.Office;
 import cwms.radar.formatters.Formats;
 import cwms.radar.formatters.OutputFormatter;
@@ -43,7 +44,7 @@ public class XMLv1 implements OutputFormatter {
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         try{
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
@@ -66,7 +67,7 @@ public class XMLv1 implements OutputFormatter {
 
     @Override
     @SuppressWarnings("unchecked") // we're ALWAYS checking before conversion in this function
-    public String format(List<? extends CwmsDTO> dtoList) {
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         try{
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);

--- a/cwms_radar_api/src/main/java/cwms/radar/formatters/xml/XMLv2.java
+++ b/cwms_radar_api/src/main/java/cwms/radar/formatters/xml/XMLv2.java
@@ -12,6 +12,7 @@ import javax.xml.bind.Marshaller;
 
 import cwms.radar.data.dto.Clobs;
 import cwms.radar.data.dto.CwmsDTO;
+import cwms.radar.data.dto.CwmsDTOBase;
 import cwms.radar.data.dto.TimeSeries;
 import cwms.radar.formatters.Formats;
 import cwms.radar.formatters.OutputFormatter;
@@ -42,7 +43,7 @@ public class XMLv2 implements OutputFormatter {
     }
 
     @Override
-    public String format(CwmsDTO dto) {
+    public String format(CwmsDTOBase dto) {
         try{
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);
@@ -59,7 +60,7 @@ public class XMLv2 implements OutputFormatter {
     }
 
     @Override
-    public String format(List<? extends CwmsDTO> dtoList) {
+    public String format(List<? extends CwmsDTOBase> dtoList) {
         throw new UnsupportedOperationException("Unable to process your request");
     }
 

--- a/cwms_radar_api/src/test/java/cwms/radar/api/ClobControllerTest.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/ClobControllerTest.java
@@ -148,14 +148,14 @@ public class ClobControllerTest extends ControllerTest{
 
     @Test
     void testDeserialize() throws JsonProcessingException {
-        String input = "{\"office\":\"MYOFFICE\",\"id\":\"MYID\",\"description\":\"MYDESC\","
+        String input = "{\"office-id\":\"MYOFFICE\",\"id\":\"MYID\",\"description\":\"MYDESC\","
                 + "\"value\":\"MYVALUE\"}";
 
         ClobController controller = new ClobController(new MetricRegistry());
 
         Clob clob = controller.deserialize(input, Formats.JSONV2);
         assertNotNull(clob);
-        assertEquals("MYOFFICE", clob.getOffice());
+        assertEquals("MYOFFICE", clob.getOfficeId());
         assertEquals("MYID", clob.getId());
         assertEquals("MYDESC", clob.getDescription());
         assertEquals("MYVALUE", clob.getValue());

--- a/cwms_radar_api/src/test/java/cwms/radar/api/DataApiTestIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/api/DataApiTestIT.java
@@ -359,9 +359,20 @@ public class DataApiTestIT {
         },"cwms_20");
     }
 
+    /**
+     * Get context, setting a specific session office.
+     */
     protected static DSLContext dslContext(Connection connection, String officeId) {
         DSLContext dsl = DSL.using(connection, SQLDialect.ORACLE11G);
         CWMS_ENV_PACKAGE.call_SET_SESSION_OFFICE_ID(dsl.configuration(), officeId);
+        return dsl;
+    }
+
+    /**
+     * Get context without setting office
+     */
+    protected static DSLContext dslContext(Connection connection) {
+        DSLContext dsl = DSL.using(connection, SQLDialect.ORACLE11G);
         return dsl;
     }
 

--- a/cwms_radar_api/src/test/java/cwms/radar/data/dao/ClobDaoTest.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/data/dao/ClobDaoTest.java
@@ -33,7 +33,7 @@ class ClobDaoTest {
             logger.atFine().log("Found: " + found.size());
 
             for (Clob clob : found) {
-                dao.delete(clob.getOffice(), clob.getId());
+                dao.delete(clob.getOfficeId(), clob.getId());
             }
 
             found = dao.getClobsLike(OFFICE, "TEST/TEST%");

--- a/cwms_radar_api/src/test/java/cwms/radar/data/dao/LocationGroupDaoTestIT.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/data/dao/LocationGroupDaoTestIT.java
@@ -31,7 +31,7 @@ class LocationGroupDaoTestIT extends DataApiTestIT {
         CwmsDatabaseContainer<?> db = RadarApiSetupCallback.getDatabaseLink();
         db.connection(c -> {
             try {
-                LocationGroupDao dao = new LocationGroupDao(dslContext(c, "SPK"));
+                LocationGroupDao dao = new LocationGroupDao(dslContext(c));
                 List<LocationGroup> groups = dao.getLocationGroups("SPK");
                 Optional<LocationGroup> group = groups.stream()
                     .filter(g -> "Test Group2".equals(g.getId()))
@@ -48,7 +48,7 @@ class LocationGroupDaoTestIT extends DataApiTestIT {
         CwmsDatabaseContainer<?> db = RadarApiSetupCallback.getDatabaseLink();
         db.connection(c -> {
             try {
-                LocationGroupDao dao = new LocationGroupDao(dslContext(c, "SPK"));
+                LocationGroupDao dao = new LocationGroupDao(dslContext(c));
                 Optional<LocationGroup> group = dao.getLocationGroup("SPK", "Test Category2", "Test Group2");
                 assertTrue(group.isPresent());
             } catch (Exception e) {

--- a/cwms_radar_api/src/test/java/cwms/radar/data/dto/ClobTest.java
+++ b/cwms_radar_api/src/test/java/cwms/radar/data/dto/ClobTest.java
@@ -30,7 +30,7 @@ class ClobTest {
         assertNotNull(clob2);
 
         assertEquals(clob.getId(), clob2.getId());
-        assertEquals(clob.getOffice(), clob2.getOffice());
+        assertEquals(clob.getOfficeId(), clob2.getOfficeId());
         assertEquals(clob.getDescription(), clob2.getDescription());
         assertEquals(clob.getValue(), clob2.getValue());
     }
@@ -50,7 +50,7 @@ class ClobTest {
         assertNotNull(clob2);
 
         assertEquals(clob.getId(), clob2.getId());
-        assertEquals(clob.getOffice(), clob2.getOffice());
+        assertEquals(clob.getOfficeId(), clob2.getOfficeId());
         assertEquals(clob.getDescription(), clob2.getDescription());
         assertEquals(clob.getValue(), clob2.getValue());
     }
@@ -79,7 +79,7 @@ class ClobTest {
         assertNotNull(clob2);
 
         assertEquals(clob.getId(), clob2.getId());
-        assertEquals(clob.getOffice(), clob2.getOffice());
+        assertEquals(clob.getOfficeId(), clob2.getOfficeId());
         assertEquals(clob.getDescription(), clob2.getDescription());
         assertEquals(clob.getValue(), clob2.getValue());
     }


### PR DESCRIPTION
Currently initial work. A few integration tests don't pass due to the session office issue discussed, but considering this change is relatively clean I'm thinking I'll just fix that here and implement the changes discussed.

After that I'm also going to to the rebranding since the next release is going to be 3.0.0 anyways. Might as well do *all* the breaking things now.

Oh, and this does break the Clob DTO since that's the one that kept "office" vs "office-id". I'm not super worried about it though.