### PR TITLE
update to latest monolith and nucleus dependencies

### DIFF
--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
     implementation 'org.slf4j:slf4j-jdk14:1.7.36'
 
-    implementation( "mil.army.usace.hec:hec-monolith:2.0.2" ) {
+    implementation( "mil.army.usace.hec:hec-monolith:3.3.20" ) {
         //exclude group: "org.python", module: "jython-standalone"
         //exclude group: "mil.army.usace.hec.swingx"
         exclude group: "*"
@@ -50,8 +50,8 @@ dependencies {
     implementation 'com.google.errorprone:error_prone_annotations:2.15.0'
     runtime 'com.google.flogger:flogger-system-backend:0.7.4'
 
-    implementation "mil.army.usace.hec:hec-nucleus-data:1.0.33"
-    implementation "mil.army.usace.hec:hec-nucleus-metadata:1.0.33"
+    implementation "mil.army.usace.hec:hec-nucleus-data:2.0.1"
+    implementation "mil.army.usace.hec:hec-nucleus-metadata:2.0.1"
     implementation( 'mil.army.usace.hec:hec-cwms-ratings-core:2.0.2' ) {
         
         //exclude group: "mil.army.usace.hec.swingx"

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/RatingTemplateDaoTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/RatingTemplateDaoTest.java
@@ -1,24 +1,46 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package cwms.cda.data.dao;
 
-import static cwms.cda.data.dao.DaoTest.getConnection;
-import static cwms.cda.data.dao.DaoTest.getDslContext;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import cwms.cda.data.dto.rating.RatingTemplate;
 import hec.data.RatingException;
 import hec.data.cwmsRating.RatingSet;
-import hec.data.cwmsRating.io.RatingJdbcCompatUtil;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Set;
+import mil.army.usace.hec.cwms.rating.io.jdbc.RatingJdbcFactory;
 import mil.army.usace.hec.cwms.rating.io.xml.RatingXmlFactory;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import cwms.cda.data.dto.rating.RatingTemplate;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Set;
+
+import static cwms.cda.data.dao.DaoTest.getConnection;
+import static cwms.cda.data.dao.DaoTest.getDslContext;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 @Disabled
@@ -93,7 +115,7 @@ class RatingTemplateDaoTest
         RatingSet ratingSet = RatingXmlFactory.ratingSet(xmlRating);
         assertNotNull(ratingSet);
 
-        RatingJdbcCompatUtil.getInstance().storeToDatabase(ratingSet,c, true, true);
+        RatingJdbcFactory.store(ratingSet,c, true, true);
     }
 
 

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/RatingTemplateDaoTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/RatingTemplateDaoTestIT.java
@@ -1,35 +1,52 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package cwms.cda.data.dao;
 
-import static cwms.cda.data.dao.DaoTest.getDslContext;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
+import cwms.cda.api.DataApiTestIT;
+import cwms.cda.data.dto.rating.RatingTemplate;
 import fixtures.CwmsDataApiSetupCallback;
-import fixtures.TestAccounts;
 import hec.data.RatingException;
 import hec.data.cwmsRating.RatingSet;
-import hec.data.cwmsRating.io.RatingJdbcCompatUtil;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Set;
-import java.util.function.Consumer;
+import mil.army.usace.hec.cwms.rating.io.jdbc.RatingJdbcFactory;
 import mil.army.usace.hec.cwms.rating.io.xml.RatingXmlFactory;
 import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
-import cwms.cda.api.DataApiTestIT;
-import cwms.cda.data.dto.rating.RatingTemplate;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Set;
+
+import static cwms.cda.data.dao.DaoTest.getDslContext;
+import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("integration")
-@Disabled // tested through RatingControllerIT tests. Currently something about the backwards compatibility module
-// not being found. Suspect class loader issue
 class RatingTemplateDaoTestIT extends DataApiTestIT {
 
     @BeforeAll
@@ -42,8 +59,8 @@ class RatingTemplateDaoTestIT extends DataApiTestIT {
     @AfterAll
     public static void remove_swt_permissiosn() throws Exception {
         CwmsDatabaseContainer<?> databaseLink = CwmsDataApiSetupCallback.getDatabaseLink();
-        removeUserFromGroup(databaseLink.getUsername(), "CWMS Users", "SWT");
-        removeUserFromGroup(databaseLink.getUsername(), "TS ID Creator", "SWT");
+//        removeUserFromGroup(databaseLink.getUsername(), "CWMS Users", "SWT");
+//        removeUserFromGroup(databaseLink.getUsername(), "TS ID Creator", "SWT");
     }
 
     @Test
@@ -122,7 +139,7 @@ class RatingTemplateDaoTestIT extends DataApiTestIT {
         RatingSet ratingSet = RatingXmlFactory.ratingSet(xmlRating);
         assertNotNull(ratingSet);
 
-        RatingJdbcCompatUtil.getInstance().storeToDatabase(ratingSet,c, true, true);
+        RatingJdbcFactory.store(ratingSet,c, true, true);
     }
 
 


### PR DESCRIPTION
this fixes an issue loading db_parameters.def resource files from within the jars also fix issue with using the ForkJoinPool in the RatingMetadataDao. The ForkJoinPool does not use the correct classloader, so calls to the Lookup API will fail. Instead, use an executor service.

Fixes #400