### PR TITLE
switch to a blocking queue so that the tasks are not executed immediately

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingMetadataDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingMetadataDao.java
@@ -60,7 +60,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
@@ -80,7 +80,7 @@ public class RatingMetadataDao extends JooqDao<RatingSpec> {
             + ".mil/xmlSchema/cwms/Ratings.xsd\"/>";
     private final Executor executor = new ThreadPoolExecutor(6, Integer.MAX_VALUE,
             60L, TimeUnit.SECONDS,
-            new SynchronousQueue<>(), r -> {
+            new LinkedBlockingQueue<>(), r -> {
                 Thread thread = new Thread(r, getClass().getSimpleName());
                 thread.setDaemon(true);
                 return thread;


### PR DESCRIPTION
the synchronous queue was added in from the copy of the cached thread pool implementation and should have been updated so that we could queue up many task even though we only run a couple at a time.