### PR TITLE
Explicitly adding DeleteMethod to JavalinValidation registry because …

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -64,6 +64,7 @@ import cwms.cda.api.errors.FieldException;
 import cwms.cda.api.errors.InvalidItemException;
 import cwms.cda.api.errors.JsonFieldsException;
 import cwms.cda.api.errors.NotFoundException;
+import cwms.cda.data.dao.JooqDao;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.FormattingException;
 import cwms.cda.security.CwmsAuthException;
@@ -185,6 +186,7 @@ public class ApiServlet extends HttpServlet {
     public void init() {
         logger.atInfo().log("Initializing API");
         JavalinValidation.register(UnitSystem.class, UnitSystem::systemFor);
+        JavalinValidation.register(JooqDao.DeleteMethod.class, Controllers::getDeleteMethod);
         ObjectMapper om = new ObjectMapper();
         om.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
         om.registerModule(new JavaTimeModule());

--- a/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
@@ -24,19 +24,17 @@
 
 package cwms.cda.api;
 
+import static com.codahale.metrics.MetricRegistry.name;
+
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import cwms.cda.data.dao.JooqDao;
-import cwms.cda.data.dao.TimeSeriesIdentifierDescriptorDao;
 import io.javalin.core.validation.JavalinValidation;
 import io.javalin.core.validation.Validator;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
 
 public final class Controllers {
-
 
 
     public static final String GET_ONE = "getOne";
@@ -132,8 +130,7 @@ public final class Controllers {
     static final String SPECIFIED_LEVEL_ID = "specified-level-id";
 
     static {
-        JavalinValidation.register(JooqDao.DeleteMethod.class,
-            Controllers::getDeleteMethod);
+        JavalinValidation.register(JooqDao.DeleteMethod.class, Controllers::getDeleteMethod);
     }
 
     private Controllers() {
@@ -234,11 +231,11 @@ public final class Controllers {
         return retval;
     }
 
-    public static TimeSeriesIdentifierDescriptorDao.DeleteMethod getDeleteMethod(String input) {
-        TimeSeriesIdentifierDescriptorDao.DeleteMethod retval = null;
+    public static JooqDao.DeleteMethod getDeleteMethod(String input) {
+        JooqDao.DeleteMethod retval = null;
 
         if (input != null) {
-            retval = TimeSeriesIdentifierDescriptorDao.DeleteMethod.valueOf(input.toUpperCase());
+            retval = JooqDao.DeleteMethod.valueOf(input.toUpperCase());
         }
         return retval;
     }

--- a/cwms-data-api/src/test/java/cwms/cda/api/ControllersTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/ControllersTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
@@ -252,12 +253,7 @@ class ControllersTest {
         JooqDao.DeleteMethod deleteMethod = Controllers.getDeleteMethod(null);
         assertNull(deleteMethod);
 
-        try {
-            deleteMethod = Controllers.getDeleteMethod("garbage");
-            fail("Expected an exception to be thrown");
-        } catch (IllegalArgumentException iae){
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, () -> Controllers.getDeleteMethod("garbage"));
 
         deleteMethod = Controllers.getDeleteMethod("delete_data");
         assertEquals(JooqDao.DeleteMethod.DELETE_DATA, deleteMethod);
@@ -271,42 +267,18 @@ class ControllersTest {
         deleteMethod = Controllers.getDeleteMethod("delete_all");
         assertEquals(JooqDao.DeleteMethod.DELETE_ALL, deleteMethod);
 
-        try {
-            deleteMethod = Controllers.getDeleteMethod("delete-data");
-            fail("Expected an exception to be thrown");
-        } catch (IllegalArgumentException iae){
-            // expected
-        }
-
-
+        assertThrows(IllegalArgumentException.class, () -> Controllers.getDeleteMethod("delete-data"));
     }
 
     @Test
-    void testDeleteMethodValidationRegistration(){
-        JavalinValidation jv = JavalinValidation.INSTANCE;
+    void testDeleteMethodValidationRegistration() throws ClassNotFoundException {
 
-        boolean hadConverter = jv.hasConverter(JooqDao.DeleteMethod.class);
+        // Trigger static initialization of Controllers class
+        Class<?> ignored = Class.forName("cwms.cda.api.Controllers");
+        assertNotNull(ignored);
 
-        if(!hadConverter){
-            String message = "FYI the converter was not registered.  "
-                    + "This means that the Controllers class static initializer hadn't been called."
-                    + " Triggering the static initializer to run.";
-            // System.out.println(message);
-            try {
-                Class<?> ignored = Class.forName("cwms.cda.api.Controllers");
-                assertNotNull(ignored);
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-            }
-            // Could also call a static method instead.
-//            JooqDao.DeleteMethod dontcare = Controllers.getDeleteMethod("delete_data");
-        }
-
-        assertTrue(jv.hasConverter(JooqDao.DeleteMethod.class));
-
-        assertTrue(jv.hasConverter(JooqDao.DeleteMethod.class));
-        JooqDao.DeleteMethod deleteMethod = jv.convertValue(JooqDao.DeleteMethod.class, "delete_data");
+        assertTrue(JavalinValidation.INSTANCE.hasConverter(JooqDao.DeleteMethod.class));
+        JooqDao.DeleteMethod deleteMethod = JavalinValidation.INSTANCE.convertValue(JooqDao.DeleteMethod.class, "delete_data");
         assertEquals(JooqDao.DeleteMethod.DELETE_DATA, deleteMethod);
-
     }
 }


### PR DESCRIPTION
…it was possible for a Controller method that needed a DeleteMethod argument to get called before the Controllers static initialization block which registered the converter was triggered.