### PR TITLE
Bugfix/419 location level units

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -229,22 +229,22 @@ public class ApiServlet extends HttpServlet {
                 })
                 .exception(BadRequestResponse.class, (e, ctx) -> {
                     CdaError re = new CdaError("Bad Request", e.getDetails());
-                    logger.atInfo().withCause(e).log(re.toString(), e);
+                    logger.atInfo().withCause(e).log(re.toString());
                     ctx.status(e.getStatus()).json(re);
                 })
                 .exception(IllegalArgumentException.class, (e, ctx) -> {
                     CdaError re = new CdaError("Bad Request");
-                    logger.atInfo().withCause(e).log(re.toString(), e);
+                    logger.atInfo().withCause(e).log(re.toString());
                     ctx.status(HttpServletResponse.SC_BAD_REQUEST).json(re);
                 })
                 .exception(InvalidItemException.class, (e, ctx) -> {
                     CdaError re = new CdaError("Bad Request.");
-                    logger.atInfo().withCause(e).log(re.toString(), e);
+                    logger.atInfo().withCause(e).log(re.toString());
                     ctx.status(HttpServletResponse.SC_BAD_REQUEST).json(re);
                 })
                 .exception(AlreadyExists.class, (e, ctx) -> {
                     CdaError re = new CdaError("Already Exists.");
-                    logger.atInfo().withCause(e).log(re.toString(), e);
+                    logger.atInfo().withCause(e).log(re.toString());
                     ctx.status(HttpServletResponse.SC_CONFLICT).json(re);
                 })
                 .exception(DeleteConflictException.class, (e, ctx) -> {
@@ -254,7 +254,7 @@ public class ApiServlet extends HttpServlet {
                 })
                 .exception(NotFoundException.class, (e, ctx) -> {
                     CdaError re = new CdaError("Not Found.");
-                    logger.atInfo().withCause(e).log(re.toString(), e);
+                    logger.atInfo().withCause(e).log(re.toString());
                     ctx.status(HttpServletResponse.SC_NOT_FOUND).json(re);
                 })
                 .exception(FieldException.class, (e, ctx) -> {

--- a/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
@@ -356,7 +356,7 @@ public class LevelsController implements CrudHandler {
                             + EFFECTIVE_DATE),
                     @OpenApiParam(name = EFFECTIVE_DATE, required = true, description = "Specifies "
                             + "the effective date of Location Level to be returned"),
-                    @OpenApiParam(name = UNIT, required = true, description = "Desired unit for "
+                    @OpenApiParam(name = UNIT, required = false, description = "Desired unit for "
                             + "the values retrieved.")
             },
             responses = {
@@ -645,7 +645,7 @@ public class LevelsController implements CrudHandler {
                             + " response. If this field is not specified, the default time zone "
                             + "of UTC shall be used.\r\nIgnored if begin was specified with "
                             + "offset and timezone."),
-                    @OpenApiParam(name = UNIT, required = true, description = "Desired unit for "
+                    @OpenApiParam(name = UNIT, required = false, description = "Desired unit for "
                             + "the values retrieved."),
             },
             responses = {

--- a/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
@@ -646,7 +646,7 @@ public class LevelsController implements CrudHandler {
                             + "of UTC shall be used.\r\nIgnored if begin was specified with "
                             + "offset and timezone."),
                     @OpenApiParam(name = UNIT, required = true, description = "Desired unit for "
-                            + "the values retrieved.")
+                            + "the values retrieved."),
             },
             responses = {
                     @OpenApiResponse(status = "200",
@@ -666,7 +666,9 @@ public class LevelsController implements CrudHandler {
                             + "implemented")
             },
             description = "Retrieves requested Location Level",
-            tags = {"Levels"}
+            tags = {"Levels"},
+            method = HttpMethod.GET,
+            path = "/levels/{level-id}/timeseries"
     )
     public void getLevelAsTimeSeries(Context ctx) {
 

--- a/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
@@ -683,9 +683,6 @@ public class LevelsController implements CrudHandler {
             String begin = ctx.queryParam(BEGIN);
             String end = ctx.queryParam(END);
             String units = ctx.queryParam(UNIT);
-            if (units == null) {
-                throw new IllegalArgumentException(UNIT + " parameter must be provided.");
-            };
             String timezone = ctx.queryParamAsClass(TIMEZONE, String.class).getOrDefault("UTC");
             String intervalParameter = ctx.queryParamAsClass(INTERVAL, String.class).getOrDefault("0");
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDao.java
@@ -53,5 +53,5 @@ public interface LocationLevelsDao {
                                      String names, String office, String unit, String datum,
                                      ZonedDateTime beginZdt, ZonedDateTime endZdt);
 
-    TimeSeries retrieveLocationLevelAsTimeSeries(ILocationLevelRef levelRef, Instant start, Instant end, Interval interval);
+    TimeSeries retrieveLocationLevelAsTimeSeries(ILocationLevelRef levelRef, Instant start, Instant end, Interval interval, String units);
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
@@ -51,6 +51,7 @@ import mil.army.usace.hec.metadata.constants.NumericalConstants;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jooq.Condition;
+import org.jooq.Configuration;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Record1;
@@ -64,6 +65,7 @@ import usace.cwms.db.dao.util.services.CwmsDbServiceLookup;
 import usace.cwms.db.jooq.codegen.packages.CWMS_ENV_PACKAGE;
 import usace.cwms.db.jooq.codegen.packages.CWMS_LEVEL_PACKAGE;
 import usace.cwms.db.jooq.codegen.packages.CWMS_LOC_PACKAGE;
+import usace.cwms.db.jooq.codegen.packages.CWMS_UTIL_PACKAGE;
 import usace.cwms.db.jooq.codegen.udt.records.ZTSV_ARRAY;
 import usace.cwms.db.jooq.codegen.udt.records.ZTSV_TYPE;
 
@@ -258,6 +260,18 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
             LocationLevelPojo levelPojo = levelJooq.retrieveLocationLevel(c,
                     locationLevelName, units, date, timezone, null, null,
                     units, false, officeId);
+            if (units == null) {
+                final String parameter = locationLevelName.split("\\.")[1];
+                Configuration configuration = getDslContext(c, officeId).configuration();
+                logger.info("Getting default units for " + parameter);
+                final String defaultUnits = CWMS_UTIL_PACKAGE.call_GET_DEFAULT_UNITS(
+                    configuration,
+                    parameter,
+                    UnitSystem.SI.getValue()
+                    );
+                logger.info("Default units are " + defaultUnits);
+                levelPojo.setLevelUnitsId(defaultUnits);
+            }
             LocationLevel level = getLevelFromPojo(levelPojo, effectiveDate);
             locationLevelRef.set(level);
         });

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
@@ -246,20 +246,18 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
     }
 
     @Override
-    public LocationLevel retrieveLocationLevel(String locationLevelName, String unitSystem,
+    public LocationLevel retrieveLocationLevel(String locationLevelName, String units,
                                                ZonedDateTime effectiveDate, String officeId) {
         TimeZone timezone = TimeZone.getTimeZone(effectiveDate.getZone());
         Date date =
                 Date.from(effectiveDate.toLocalDateTime().atZone(ZoneId.systemDefault()).toInstant());
-        String unitIn = UnitSystem.EN.value().equals(unitSystem) ? Unit.FEET.getValue() :
-                Unit.METER.getValue();
         AtomicReference<LocationLevel> locationLevelRef = new AtomicReference<>();
 
         connection(dsl, c -> {
             CwmsDbLevel levelJooq = CwmsDbServiceLookup.buildCwmsDb(CwmsDbLevel.class, c);
             LocationLevelPojo levelPojo = levelJooq.retrieveLocationLevel(c,
-                    locationLevelName, unitIn, date, timezone, null, null,
-                    unitIn, false, officeId);
+                    locationLevelName, units, date, timezone, null, null,
+                    units, false, officeId);
             LocationLevel level = getLevelFromPojo(levelPojo, effectiveDate);
             locationLevelRef.set(level);
         });
@@ -558,10 +556,10 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
 
     @Override
     public TimeSeries retrieveLocationLevelAsTimeSeries(ILocationLevelRef levelRef, Instant start, Instant end,
-                                                        Interval interval) {
+                                                        Interval interval, String units) {
         String officeId = levelRef.getOfficeId();
         String locationLevelId = levelRef.getLocationLevelId();
-        String levelUnits = levelRef.getParameter().getUnitsString();
+        String levelUnits = units;
         String attributeId = null;
         Number attributeValue = null;
         String attributeUnits = null;

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
@@ -260,7 +260,7 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
             LocationLevelPojo levelPojo = levelJooq.retrieveLocationLevel(c,
                     locationLevelName, units, date, timezone, null, null,
                     units, false, officeId);
-            if (units == null) {
+            if (units == null && levelPojo.getLevelUnitsId() == null) {
                 final String parameter = locationLevelName.split("\\.")[1];
                 Configuration configuration = getDslContext(c, officeId).configuration();
                 logger.info("Getting default units for " + parameter);

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/LocationLevel.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/LocationLevel.java
@@ -60,7 +60,7 @@ public final class LocationLevel extends CwmsDTO {
     @Schema(description = "Single value for this location level. Mutually exclusive with "
             + "seasonableTimeSeriesId and seasonValues.")
     private final Double constantValue;
-    @Schema(description = "Units thhe provided levels are in")
+    @Schema(description = "Units the provided levels are in")
     private final String levelUnitsId;
     @Schema(description = "The date/time at which this location level configuration takes effect.")
     @JsonFormat(shape = JsonFormat.Shape.STRING)

--- a/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
@@ -85,6 +85,7 @@ public class LevelsControllerTestIT extends DataApiTestIT {
             .assertThat()
             .log().body().log().everything(true)
             .statusCode(is(HttpServletResponse.SC_OK))
+            .body("level-units-id",equalTo("m3"))
             // I think we need to create a custom matcher.
             // This really shouldn't use equals but due to a quirk in
             // RestAssured it appears to be necessary.
@@ -104,6 +105,7 @@ public class LevelsControllerTestIT extends DataApiTestIT {
             .assertThat()
             .log().body().log().everything(true)
             .statusCode(is(HttpServletResponse.SC_OK))
+            .body("level-units-id",equalTo("ac-ft"))
             .body("constant-value",equalTo(1.0F));
     }
 


### PR DESCRIPTION
Fixes #419.

Require specification of Units to location level end points. Levels are more than actual "elevation" levels.