### PR TITLE
add client identifier information to JDBC connections

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -154,6 +154,7 @@ public class ApiServlet extends HttpServlet {
     // The VERSION should match the gradle version but not contain the patch version.
     // For example 2.4 not 2.4.13
     public static final String VERSION = "3.0";
+    public static final String APPLICATION_TITLE = "CWMS Data API";
     public static final String PROVIDER_KEY_OLD = "radar.access.provider";
     public static final String PROVIDER_KEY = "cwms.dataapi.access.provider";
     public static final String DEFAULT_PROVIDER = "MultipleAccessManager";
@@ -421,7 +422,7 @@ public class ApiServlet extends HttpServlet {
     }
 
     private void getOpenApiOptions(JavalinConfig config) {
-        Info applicationInfo = new Info().title("CWMS Data API").version(VERSION)
+        Info applicationInfo = new Info().title(APPLICATION_TITLE).version(VERSION)
                 .description("CWMS REST API for Data Retrieval");
 
         String provider = getAccessManagerName();

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -95,7 +95,6 @@ public abstract class JooqDao<T> extends Dao<T> {
             logger.atSevere().withStackTrace(StackSize.FULL)
                   .log("System still using old context method.");
             Connection database = ctx.attribute(ApiServlet.DATABASE);
-            setClientInfo(ctx, database);
             retval = getDslContext(database, officeId);
         }
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -24,20 +24,14 @@
 
 package cwms.cda.data.dao;
 
-import static org.jooq.SQLDialect.ORACLE;
-
+import com.google.common.flogger.FluentLogger;
+import com.google.common.flogger.StackSize;
 import cwms.cda.ApiServlet;
 import cwms.cda.api.errors.AlreadyExists;
 import cwms.cda.api.errors.InvalidItemException;
 import cwms.cda.api.errors.NotFoundException;
+import cwms.cda.datasource.ConnectionPreparingDataSource;
 import io.javalin.http.Context;
-import java.math.BigDecimal;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import javax.sql.DataSource;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.Condition;
 import org.jooq.ConnectionCallable;
@@ -50,11 +44,18 @@ import org.jooq.exception.DataAccessException;
 import org.jooq.impl.CustomCondition;
 import org.jooq.impl.DSL;
 import org.jooq.impl.DefaultExecuteListenerProvider;
-
-import com.google.common.flogger.FluentLogger;
-import com.google.common.flogger.StackSize;
-
 import usace.cwms.db.jooq.codegen.packages.CWMS_ENV_PACKAGE;
+
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.jooq.SQLDialect.ORACLE;
 
 public abstract class JooqDao<T> extends Dao<T> {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -86,18 +87,35 @@ public abstract class JooqDao<T> extends Dao<T> {
         final String officeId = ctx.attribute(ApiServlet.OFFICE_ID);
         final DataSource dataSource = ctx.attribute(ApiServlet.DATA_SOURCE);
         if (dataSource != null) {
-            retval = DSL.using(dataSource, SQLDialect.ORACLE11G);
+            DataSource wrappedDataSource = new ConnectionPreparingDataSource(connection ->
+                    setClientInfo(ctx, connection), dataSource);
+            retval = DSL.using(wrappedDataSource, SQLDialect.ORACLE11G);
         } else {
             // Some tests still use this method
             logger.atSevere().withStackTrace(StackSize.FULL)
                   .log("System still using old context method.");
             Connection database = ctx.attribute(ApiServlet.DATABASE);
+            setClientInfo(ctx, database);
             retval = getDslContext(database, officeId);
         }
 
         retval.configuration().set(new DefaultExecuteListenerProvider(listener));
 
         return retval;
+    }
+
+    private static Connection setClientInfo(Context ctx, Connection connection) {
+        try {
+            connection.setClientInfo("OCSID.ECID", ApiServlet.APPLICATION_TITLE + " " + ApiServlet.VERSION);
+            connection.setClientInfo("OCSID.MODULE", ctx.path());
+            connection.setClientInfo("OCSID.ACTION", ctx.method());
+            connection.setClientInfo("OCSID.CLIENTID", ctx.url().replace(ctx.path(), "") + ctx.contextPath());
+        } catch (SQLClientInfoException ex) {
+            logger.atWarning()
+                    .withCause(ex)
+                    .log("Unable to set client info on connection.");
+        }
+        return connection;
     }
 
     public static DSLContext getDslContext(Connection database, String officeId) {


### PR DESCRIPTION
Adds information to the V$SESSION table for each session. Columns include MODULE, ACTION, CLIENTID

Relevant documentation:
https://docs.oracle.com/en/database/oracle/oracle-database/19/jjdbc/JDBC-standards-support.html#GUID-1987FAC4-E93A-49A5-9EB4-A78B465E6938


From the V$SESSION docs:
https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/V-SESSION.html#GUID-28E2DC75-E157-4C0A-94AB-117C205789B9

ACTION
VARCHAR2(64)
Name of the currently executing action as set by calling the DBMS_APPLICATION_INFO.SET_ACTION procedure


MODULE
VARCHAR2(64)
Name of the currently executing module as set by calling the DBMS_APPLICATION_INFO.SET_MODULE procedure


CLIENT_IDENTIFIER
VARCHAR2(64)
Client identifier of the session


ECID
VARCHAR2(64)
Execution context identifier (sent by Application Server)
