### PR TITLE
Bugfix/apikey header capitalization

### DIFF
--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -149,11 +149,9 @@ dependencies {
 
 //    testImplementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
 
-    webjars('org.webjars:swagger-ui:4.18.2') {
+    webjars('org.webjars:swagger-ui:5.9.0') {
         transitive = false
     }
-
-    
 
 }
 

--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -433,16 +433,13 @@ public class ApiServlet extends HttpServlet {
         CdaAccessManager am = buildAccessManager(provider);
         Components components = new Components();
         final ArrayList<SecurityRequirement> secReqs = new ArrayList<>();
-        final ArrayList<String> securityItems = new ArrayList<>();
         am.getContainedManagers().forEach((manager)->{
             components.addSecuritySchemes(manager.getName(),manager.getScheme());
             SecurityRequirement req = new SecurityRequirement();
             if (!manager.getName().equalsIgnoreCase("guestauth") && !manager.getName().equalsIgnoreCase("noauth")) {
                 req.addList(manager.getName());
                 secReqs.add(req);
-                securityItems.add(manager.getName());
             }
-
         });
 
         config.accessManager(am);

--- a/cwms-data-api/src/main/java/cwms/cda/api/auth/ApiKeyController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/auth/ApiKeyController.java
@@ -57,7 +57,7 @@ public class ApiKeyController implements CrudHandler {
     public void create(Context ctx) {
         DataApiPrincipal p = ctx.attribute(AuthDao.DATA_API_PRINCIPAL);
         try(DSLContext dsl = getDslContext(ctx)) {
-            AuthDao auth = new AuthDao(dsl,null);
+            AuthDao auth = AuthDao.getInstance(dsl);
             ApiKey sourceData = ctx.bodyAsClass(ApiKey.class);
             ApiKey key = auth.createApiKey(p, sourceData);
             if(key == null) {
@@ -93,7 +93,7 @@ public class ApiKeyController implements CrudHandler {
     public void delete(Context ctx, String keyName) {
         DataApiPrincipal p = ctx.attribute(AuthDao.DATA_API_PRINCIPAL);
         try(DSLContext dsl = getDslContext(ctx)) {
-            AuthDao auth = new AuthDao(dsl,null);
+            AuthDao auth = AuthDao.getInstance(dsl);
             auth.deleteKeyForUser(p, keyName);
             ctx.status(HttpCode.NO_CONTENT);
         }
@@ -112,7 +112,7 @@ public class ApiKeyController implements CrudHandler {
     public void getAll(Context ctx) {
         DataApiPrincipal p = ctx.attribute(AuthDao.DATA_API_PRINCIPAL);
         try(DSLContext dsl = getDslContext(ctx)) {
-            AuthDao auth = new AuthDao(dsl,null);
+            AuthDao auth = AuthDao.getInstance(dsl);
             List<ApiKey> keys = auth.apiKeysForUser(p);
             ctx.json(keys).status(HttpCode.OK);            
         }
@@ -138,7 +138,7 @@ public class ApiKeyController implements CrudHandler {
     public void getOne(Context ctx, String keyName) {
         DataApiPrincipal p = ctx.attribute(AuthDao.DATA_API_PRINCIPAL);
         try(DSLContext dsl = getDslContext(ctx)) {
-            AuthDao auth = new AuthDao(dsl,null);
+            AuthDao auth = AuthDao.getInstance(dsl);
             ApiKey key = auth.apiKeyForUser(p,keyName);
             if(key != null) {
                 ctx.json(key).status(HttpCode.OK);            

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -105,8 +105,9 @@ public abstract class JooqDao<T> extends Dao<T> {
 
     private static Connection setClientInfo(Context ctx, Connection connection) {
         try {
+            //logger.atInfo().log("Path : " + ctx.url());
             connection.setClientInfo("OCSID.ECID", ApiServlet.APPLICATION_TITLE + " " + ApiServlet.VERSION);
-            connection.setClientInfo("OCSID.MODULE", ctx.path());
+            connection.setClientInfo("OCSID.MODULE", ctx.endpointHandlerPath());
             connection.setClientInfo("OCSID.ACTION", ctx.method());
             connection.setClientInfo("OCSID.CLIENTID", ctx.url().replace(ctx.path(), "") + ctx.contextPath());
         } catch (SQLClientInfoException ex) {
@@ -122,7 +123,7 @@ public abstract class JooqDao<T> extends Dao<T> {
         CWMS_ENV_PACKAGE.call_SET_SESSION_OFFICE_ID(dsl.configuration(), officeId);
 
         return dsl;
-    }    
+    }
 
     @Override
     public List<T> getAll(Optional<String> limitToOffice) {

--- a/cwms-data-api/src/main/java/cwms/cda/security/GuestAccessManager.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/GuestAccessManager.java
@@ -44,8 +44,6 @@ public class GuestAccessManager extends CdaAccessManager{
     }
     
     private void init(Context ctx) {
-        if (authDao == null) {
-            authDao = new AuthDao(JooqDao.getDslContext(ctx),ctx.attribute(ApiServlet.OFFICE_ID));
-        }
+        authDao = AuthDao.getInstance(JooqDao.getDslContext(ctx),ctx.attribute(ApiServlet.OFFICE_ID));
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/security/KeyAccessManager.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/KeyAccessManager.java
@@ -22,7 +22,7 @@ public class KeyAccessManager extends CdaAccessManager {
 
     @Override
     public void manage(Handler handler, Context ctx, Set<RouteRole> routeRoles) throws Exception {
-        init(ctx);        
+        init(ctx);
         String key = getApiKey(ctx);
         DataApiPrincipal p = authDao.getByApiKey(key);
         AuthDao.isAuthorized(ctx, p, routeRoles);
@@ -33,6 +33,8 @@ public class KeyAccessManager extends CdaAccessManager {
     private void init(Context ctx) {
         if (authDao == null) {
             authDao = new AuthDao(JooqDao.getDslContext(ctx),ctx.attribute(ApiServlet.OFFICE_ID));
+        } else {
+            authDao.resetContext(JooqDao.getDslContext(ctx));
         }
     }
 
@@ -53,8 +55,10 @@ public class KeyAccessManager extends CdaAccessManager {
     @Override
     public SecurityScheme getScheme() {
         return new SecurityScheme()
+                    .scheme("apikey")
                     .type(Type.APIKEY)
                     .in(In.HEADER)
+                    .description("Key value as generated from the /auth/keys endpoint. NOTE: you MUST manually prefix your key with 'apikey ' (without the single quotes).")
                     .name("Authorization");
     }
 
@@ -69,6 +73,6 @@ public class KeyAccessManager extends CdaAccessManager {
         if (header == null) {
             return false;
         }
-        return header.trim().startsWith("apikey");
+        return header.trim().toLowerCase().startsWith("apikey");
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/security/KeyAccessManager.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/KeyAccessManager.java
@@ -17,7 +17,7 @@ import java.util.Set;
 public class KeyAccessManager extends CdaAccessManager {
     private static final String AUTH_HEADER = "Authorization";
 
-    private AuthDao authDao;
+    private static AuthDao authDao;
 
 
     @Override
@@ -31,11 +31,7 @@ public class KeyAccessManager extends CdaAccessManager {
     }
 
     private void init(Context ctx) {
-        if (authDao == null) {
-            authDao = new AuthDao(JooqDao.getDslContext(ctx),ctx.attribute(ApiServlet.OFFICE_ID));
-        } else {
-            authDao.resetContext(JooqDao.getDslContext(ctx));
-        }
+        authDao = AuthDao.getInstance(JooqDao.getDslContext(ctx),ctx.attribute(ApiServlet.OFFICE_ID));
     }
 
     private String getApiKey(Context ctx) {

--- a/cwms-data-api/src/main/webapp/WEB-INF/web.xml
+++ b/cwms-data-api/src/main/webapp/WEB-INF/web.xml
@@ -18,29 +18,6 @@
         <url-pattern>/status/prometheus</url-pattern>
     </servlet-mapping>
 
-<!--
-    <login-config>
-        <auth-method>BASIC</auth-method>
-        <realm-name></realm-name>
-   </login-config>
-
-   <security-constraint>
-    <web-resource-collection>
-            <web-resource-name>CWMS DATA</web-resource-name>
-            <url-pattern>/*</url-pattern>
-            <http-method>POST</http-method>
-            <http-method>PUT</http-method>
-            <http-method>DELETE</http-method>
-    </web-resource-collection>
-    <auth-constraint>
-            <role-name>CWMS Users</role-name>
-    </auth-constraint>
-    </security-constraint>
-
-    <security-role>
-        <role-name>CWMS Users</role-name>
-    </security-role>
--->
     <filter>
         <filter-name>CorsFilter</filter-name>
         <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>


### PR DESCRIPTION
User haven't been:
1. Typing apikey before the actual token when used. So added a note to the description (tried to make it the "scheme" but apparently OpenAPI/Swagger will only accept schemes defined in RFCs) 
2. Uses who did type it mixed case, made check case ingoring compare.
3. Minor cleanup and updates.

the new setClientInfo on the JDBC connections would end up too long and fail.