### PR TITLE
add OpenTelemetry, Grafana, Grafana Tempo, Grafana Loki, and Prometheus to docker-compose stack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ eclipse {
 
 allprojects {
     group = 'mil.army.usace.hec.cwms'
-    version = '3.0-SNAPSHOT'   // ApiServlet.VERSION should be updated to match MAJOR.MINOR changes.
+    version = '3.0.99'   // ApiServlet.VERSION should be updated to match MAJOR.MINOR changes.
 }
 
 // versions for shared dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ eclipse {
 
 allprojects {
     group = 'mil.army.usace.hec.cwms'
-    version = '3.0.99'   // ApiServlet.VERSION should be updated to match MAJOR.MINOR changes.
+    version = '3.0-SNAPSHOT'   // ApiServlet.VERSION should be updated to match MAJOR.MINOR changes.
 }
 
 // versions for shared dependencies

--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -6,6 +6,7 @@ configurations {
     docker
     baseLibs
     tomcatLibs
+    telemetry
 }
 
 configurations.implementation {
@@ -137,6 +138,9 @@ dependencies {
     tomcatLibs "com.google.flogger:flogger:0.7.4"
     tomcatLibs "com.google.flogger:flogger-system-backend:0.7.4"
 
+    telemetry 'software.amazon.opentelemetry:aws-opentelemetry-agent:1.31.0'
+
+
     testImplementation "com.github.h-thurow:tomcat8jndi:1.0.0"
 
 
@@ -226,8 +230,14 @@ task generateConfig(type: Copy) {
     outputs.dir "$buildDir/tomcat/conf"
 }
 
+task copyAutomaticTelemetry(type: Copy) {
+    from configurations.telemetry
+    into "$buildDir/tomcat/telemetry"
+}
+
 task run(type: JavaExec) {
     dependsOn generateConfig
+    dependsOn copyAutomaticTelemetry
     dependsOn war
 
     classpath += configurations.baseLibs
@@ -253,6 +263,7 @@ task run(type: JavaExec) {
 task integrationTests(type: Test) {
     dependsOn test
     dependsOn generateConfig
+    dependsOn copyAutomaticTelemetry
     dependsOn war
 
     useJUnitPlatform() {

--- a/cwms-data-api/src/docker/setenv.sh
+++ b/cwms-data-api/src/docker/setenv.sh
@@ -1,1 +1,25 @@
-export CATALINA_OPTS="$CATALINA_OPTS -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"
+#
+# MIT License
+#
+# Copyright (c) 2023 Hydrologic Engineering Center
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+export CATALINA_OPTS="$CATALINA_OPTS -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource -javaagent:$CATALINA_HOME/telemetry/aws-opentelemetry-agent.jar -Dotel.instrumentation.dropwizard-metrics.enabled=true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,3 +162,99 @@ services:
       - "traefik.http.routers.api.entryPoints=traefik"
       - "traefik.http.routers.api.service=api@internal"
       - "traefik.http.routers.api.tls=true"
+
+
+  # OpenTelemetry Collector for collecting Metrics, Traces, and Logs
+  collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    container_name: collector
+    hostname: collector
+    depends_on:
+      tempo:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    command: ["--config=/etc/collector-config.yaml"]
+    volumes:
+      - ./observability/collector-config-local.yaml:/etc/collector-config.yaml
+    ports:
+      - "5555:5555"
+      - "6666:6666"
+
+  # Grafana Tempo for processing Traces
+  tempo:
+    image: grafana/tempo:1.5.0
+    command: [ "-search.enabled=true", "-config.file=/etc/tempo.yaml" ]
+    container_name: tempo
+    hostname: tempo
+    volumes:
+      - ./observability/tempo-config.yaml:/etc/tempo.yaml
+      - ./observability/tempo-overrides.yaml:/etc/overrides.yaml
+      - ./tempo-data:/tmp/tempo
+    ports:
+      - "3200:3200"
+      - "4317:4317"
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: wget --no-verbose --tries=1 --spider http://localhost:3200/status || exit 1
+
+  # Prometheus for processing Metrics
+  prometheus:
+    image: prom/prometheus:v2.39.2
+    container_name: prometheus
+    hostname: prometheus
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
+    volumes:
+      - ./observability/prometheus.yaml:/etc/prometheus.yaml
+    ports:
+      - "9090:9090"
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: wget --no-verbose --tries=1 --spider http://localhost:9090/status || exit 1
+
+  # Grafana Loki for processing Logs
+  loki:
+    image: grafana/loki:2.9.0
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki.yaml
+    volumes:
+      - ./observability/loki-config.yaml:/etc/loki.yaml
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: wget --no-verbose --tries=1 --spider http://localhost:3100/ready || exit 1
+
+  # Grafana for telemetry visualizations and alerts
+  grafana:
+    image: grafana/grafana:9.2.2
+    container_name: grafana
+    hostname: grafana
+    depends_on:
+      tempo:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+      loki:
+       condition: service_healthy
+    volumes:
+      - ./observability/grafana-bootstrap.ini:/etc/grafana/grafana.ini
+      - ./observability/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - "GF_AUTH_ANONYMOUS_ENABLED=true"
+      - "GF_AUTH_ANONYMOUS_ORG_ROLE=Admin"
+      - "GF_AUTH_DISABLE_LOGIN_FORM=true"
+    ports:
+      - "3000:3000"
+    healthcheck:
+      interval: 5s
+      retries: 10
+      test: wget --no-verbose --tries=1 --spider http://localhost:3000 || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,17 @@ services:
       - cwms.dataapi.access.providers=KeyAccessManager,CwmsAccessManager,OpenID
       - cwms.dataapi.access.openid.wellKnownUrl=https://auth.localhost:8444/auth/realms/cwms/.well-known/openid-configuration
       - cwms.dataapi.access.openid.issuer=https://auth.localhost:8444/auth/realms/cwms
+      - OTEL_RESOURCE_ATTRIBUTES=service.name=swt-data,service.version=3.0.9-9-28-23-SNAPSHOT,deployment.environment=development
+      - OTEL_TRACES_SAMPLER=always_on
+      - OTEL_IMR_EXPORT_INTERVAL=5000
+      - OTEL_METRIC_EXPORT_INTERVAL=5000
+      - OTEL_TRACES_EXPORTER=otlp
+      - OTEL_METRICS_EXPORTER=otlp
+      - OTEL_LOGS_EXPORTER=otlp
+      - OTEL_EXPORTER_OTLP_COMPRESSION=gzip
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:5555
+      - OTEL_IMR_EXPORTING_INTERVAL=5000
+      - OTEL_EXPORTER_OTLP_INSECURE=true
     expose:
       - 7000
     healthcheck:

--- a/observability/collector-config-local.yaml
+++ b/observability/collector-config-local.yaml
@@ -25,8 +25,7 @@ exporters:
     tls:
       insecure: true
   loki:
-    # endpoint: "http://loki:3100/loki/api/v1/push"
-    endpoint: "http://localhost:3100/loki/api/v1/push"
+    endpoint: "http://loki:3100/loki/api/v1/push"
 
 service:
   pipelines:

--- a/observability/collector-config-local.yaml
+++ b/observability/collector-config-local.yaml
@@ -1,0 +1,48 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:5555
+  # filelog:
+  #   include: [/home/radar/tomcat/apache-tomcat-9.0.68/logs/*.log]
+
+processors:
+  batch:
+    timeout: 1s
+    send_batch_size: 1024
+  attributes:
+    actions:
+      - action: insert
+        key: loki.attribute.labels
+        value: log.file.name
+
+exporters:
+  prometheus:
+    endpoint: collector:6666
+    namespace: default
+  otlp:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  loki:
+    # endpoint: "http://loki:3100/loki/api/v1/push"
+    endpoint: "http://localhost:3100/loki/api/v1/push"
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp]
+    logs:
+      receivers: [otlp]
+      processors: [attributes]
+      exporters: [loki]
+
+  telemetry:
+    logs:
+      level: debug

--- a/observability/grafana-bootstrap.ini
+++ b/observability/grafana-bootstrap.ini
@@ -1,0 +1,2 @@
+[feature_toggles]
+enable = tempoSearch tempoBackendSearch

--- a/observability/grafana-datasources.yaml
+++ b/observability/grafana-datasources.yaml
@@ -1,0 +1,33 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  access: proxy
+  orgId: 1
+  url: http://prometheus:9090
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+- name: Tempo
+  type: tempo
+  access: proxy
+  orgId: 1
+  url: http://tempo:3200
+  basicAuth: false
+  isDefault: true
+  version: 1
+  editable: false
+  apiVersion: 1
+  uid: tempo
+- name: Loki
+  type: loki
+  access: proxy
+  orgId: 1
+  url: http://loki:3100
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  uid: loki

--- a/observability/loki-config.yaml
+++ b/observability/loki-config.yaml
@@ -1,0 +1,42 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v12
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/usagestats/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+analytics:
+  reporting_enabled: false

--- a/observability/prometheus.yaml
+++ b/observability/prometheus.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'collector'
+    scrape_interval: 5s
+    static_configs:
+      - targets: [ 'collector:6666' ]

--- a/observability/tempo-config.yaml
+++ b/observability/tempo-config.yaml
@@ -1,0 +1,51 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  search_tags_deny_list:
+    - "instance"
+    - "version"
+  receivers:
+    jaeger:
+      protocols:
+        thrift_http:
+        grpc:
+        thrift_binary:
+        thrift_compact:
+    zipkin:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_000_000
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    compaction_window: 1h
+    max_block_bytes: 100_000_000
+    block_retention: 1h
+    compacted_block_retention: 10m
+
+storage:
+  trace:
+    backend: local
+    block:
+      bloom_filter_false_positive: .05
+      index_downsample_bytes: 1000
+      encoding: zstd
+    wal:
+      path: /tmp/tempo/wal
+      encoding: snappy
+    local:
+      path: /tmp/tempo/blocks
+    pool:
+      max_workers: 100
+      queue_depth: 10000
+
+overrides:
+  per_tenant_override_config: /etc/overrides.yaml

--- a/observability/tempo-overrides.yaml
+++ b/observability/tempo-overrides.yaml
@@ -1,0 +1,13 @@
+overrides:
+  "single-tenant":
+    search_tags_allow_list:
+      - "instance"
+    ingestion_rate_strategy: "local"
+    ingestion_rate_limit_bytes: 15000000
+    ingestion_burst_size_bytes: 20000000
+    max_traces_per_user: 10000
+    max_global_traces_per_user: 0
+    max_bytes_per_trace: 50000
+    max_search_bytes_per_trace: 0
+    max_bytes_per_tag_values_query: 5000000
+    block_retention: 0s


### PR DESCRIPTION
I currently haven't tested the full stack together and the TLS certificates created for CDA should get used for all of the services. Additionally, I need to add the open telemetry auto-instrumentation (and drop wizard -D flags) to the CDA startup scripts. This is a proof of concept for adding the extra telemetry pipelines.