### PR TITLE
Feature/remove deprecated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ eclipse {
 
 allprojects {
     group = 'mil.army.usace.hec.cwms'
-    version = '3.0-SNAPSHOT'   // ApiServlet.VERSION should be updated to match MAJOR.MINOR changes.
+    version = '3.1-SNAPSHOT'   // ApiServlet.VERSION should be updated to match MAJOR.MINOR changes.
 }
 
 // versions for shared dependencies

--- a/cwms-data-api/src/main/java/cwms/cda/api/BlobController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/BlobController.java
@@ -79,15 +79,6 @@ public class BlobController implements CrudHandler {
                                     + " value, and can be obtained from the 'next-page' value in "
                                     + "the response."
                     ),
-                    @OpenApiParam(name = CURSOR,
-                            deprecated = true,
-                            description = "Deprecated. Use 'page' instead."
-                    ),
-                    @OpenApiParam(name = PAGESIZE3,
-                            deprecated = true,
-                            type = Integer.class,
-                            description = "Deprecated.  Use page-size instead."
-                    ),
                     @OpenApiParam(name = PAGE_SIZE,
                             type = Integer.class,
                             description = "How many entries per page returned. Default "

--- a/cwms-data-api/src/main/java/cwms/cda/api/BlobController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/BlobController.java
@@ -7,8 +7,6 @@ import static cwms.cda.api.Controllers.GET_ONE;
 import static cwms.cda.api.Controllers.LIKE;
 import static cwms.cda.api.Controllers.OFFICE;
 import static cwms.cda.api.Controllers.PAGE;
-import static cwms.cda.api.Controllers.PAGESIZE2;
-import static cwms.cda.api.Controllers.PAGESIZE3;
 import static cwms.cda.api.Controllers.PAGE_SIZE;
 import static cwms.cda.api.Controllers.RESULTS;
 import static cwms.cda.api.Controllers.SIZE;
@@ -117,8 +115,8 @@ public class BlobController implements CrudHandler {
                 return;
             }
 
-            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE, PAGESIZE3,
-                            PAGESIZE2}, Integer.class, defaultPageSize, metrics,
+            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE},
+                    Integer.class, defaultPageSize, metrics,
                     name(BlobController.class.getName(), GET_ALL));
 
             String like = ctx.queryParamAsClass(LIKE, String.class).getOrDefault(".*");

--- a/cwms-data-api/src/main/java/cwms/cda/api/CatalogController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/CatalogController.java
@@ -8,23 +8,16 @@ import static cwms.cda.api.Controllers.GET_ONE;
 import static cwms.cda.api.Controllers.LIKE;
 import static cwms.cda.api.Controllers.LOCATIONS;
 import static cwms.cda.api.Controllers.LOCATION_CATEGORY_LIKE;
-import static cwms.cda.api.Controllers.LOCATION_CATEGORY_LIKE2;
 import static cwms.cda.api.Controllers.LOCATION_GROUP_LIKE;
-import static cwms.cda.api.Controllers.LOCATION_GROUP_LIKE2;
 import static cwms.cda.api.Controllers.OFFICE;
 import static cwms.cda.api.Controllers.PAGE;
-import static cwms.cda.api.Controllers.PAGESIZE2;
-import static cwms.cda.api.Controllers.PAGESIZE3;
 import static cwms.cda.api.Controllers.PAGE_SIZE;
 import static cwms.cda.api.Controllers.RESULTS;
 import static cwms.cda.api.Controllers.SIZE;
 import static cwms.cda.api.Controllers.STATUS_200;
 import static cwms.cda.api.Controllers.TIMESERIES;
-import static cwms.cda.api.Controllers.TIMESERIESCATEGORYLIKE2;
 import static cwms.cda.api.Controllers.TIMESERIES_CATEGORY_LIKE;
 import static cwms.cda.api.Controllers.TIMESERIES_GROUP_LIKE;
-import static cwms.cda.api.Controllers.TIMESERIES_GROUP_LIKE2;
-import static cwms.cda.api.Controllers.UNITSYSTEM2;
 import static cwms.cda.api.Controllers.UNIT_SYSTEM;
 import static cwms.cda.api.Controllers.queryParamAsClass;
 
@@ -167,12 +160,12 @@ public class CatalogController implements CrudHandler {
             String cursor = queryParamAsClass(ctx, new String[]{PAGE, CURSOR},
                     String.class, "", metrics, name(CatalogController.class.getName(), GET_ONE));
 
-            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE, PAGESIZE3,
-                    PAGESIZE2}, Integer.class, defaultPageSize, metrics,
+            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE              },
+                    Integer.class, defaultPageSize, metrics,
                     name(CatalogController.class.getName(), GET_ONE));
 
             String unitSystem = queryParamAsClass(ctx,
-                    new String[]{UNIT_SYSTEM, UNITSYSTEM2},
+                    new String[]{UNIT_SYSTEM, },
                     String.class, UnitSystem.SI.getValue(), metrics,
                     name(CatalogController.class.getName(), GET_ONE));
 
@@ -182,16 +175,16 @@ public class CatalogController implements CrudHandler {
 
             String like = ctx.queryParamAsClass(LIKE, String.class).getOrDefault(".*");
 
-            String tsCategoryLike = queryParamAsClass(ctx, new String[]{TIMESERIES_CATEGORY_LIKE, TIMESERIESCATEGORYLIKE2},
+            String tsCategoryLike = queryParamAsClass(ctx, new String[]{TIMESERIES_CATEGORY_LIKE},
                     String.class, null, metrics, name(CatalogController.class.getName(), GET_ONE));
 
-            String tsGroupLike = queryParamAsClass(ctx, new String[]{TIMESERIES_GROUP_LIKE, TIMESERIES_GROUP_LIKE2},
+            String tsGroupLike = queryParamAsClass(ctx, new String[]{TIMESERIES_GROUP_LIKE},
                     String.class, null, metrics, name(CatalogController.class.getName(), GET_ONE));
 
-            String locCategoryLike = queryParamAsClass(ctx, new String[]{LOCATION_CATEGORY_LIKE, LOCATION_CATEGORY_LIKE2},
+            String locCategoryLike = queryParamAsClass(ctx, new String[]{LOCATION_CATEGORY_LIKE},
                     String.class, null, metrics, name(CatalogController.class.getName(), GET_ONE));
 
-            String locGroupLike = queryParamAsClass(ctx, new String[]{LOCATION_GROUP_LIKE, LOCATION_GROUP_LIKE2},
+            String locGroupLike = queryParamAsClass(ctx, new String[]{LOCATION_GROUP_LIKE },
                     String.class, null, metrics, name(CatalogController.class.getName(), GET_ONE));
 
             String boundingOfficeLike = queryParamAsClass(ctx, new String[]{BOUNDING_OFFICE_LIKE},

--- a/cwms-data-api/src/main/java/cwms/cda/api/CatalogController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/CatalogController.java
@@ -101,23 +101,10 @@ public class CatalogController implements CrudHandler {
                             description = "This end point can return a lot of data, this "
                                     + "identifies where in the request you are."
                     ),
-                    @OpenApiParam(name = CURSOR,
-                            deprecated = true,
-                            description = "Deprecated. Use 'page' instead."
-                    ),
+
                     @OpenApiParam(name = PAGE_SIZE,
                             type = Integer.class,
                             description = "How many entires per page returned. Default 500."
-                    ),
-                    @OpenApiParam(name = PAGESIZE3,
-                            deprecated = true,
-                            type = Integer.class,
-                            description = "Deprecated. Use page-size."
-                    ),
-                    @OpenApiParam(name = UNITSYSTEM2,
-                            deprecated = true,
-                            type = UnitSystem.class,
-                            description = "Deprecated. Use unit-system."
                     ),
                     @OpenApiParam(name = UNIT_SYSTEM,
                             type = UnitSystem.class,
@@ -134,33 +121,17 @@ public class CatalogController implements CrudHandler {
                             description = "Posix <a href=\"regexp.html\">regular expression</a> matching against the "
                                     + "timeseries category id"
                     ),
-                    @OpenApiParam(name = TIMESERIESCATEGORYLIKE2,
-                            deprecated = true,
-                            description = "Deprecated. Use timeseries-category-like."
-                    ),
                     @OpenApiParam(name = TIMESERIES_GROUP_LIKE,
                             description = "Posix <a href=\"regexp.html\">regular expression</a> matching against the "
                                     + "timeseries group id"
-                    ),
-                    @OpenApiParam(name = TIMESERIES_GROUP_LIKE2,
-                            deprecated = true,
-                            description = "Deprecated. Use timeseries-group-like."
                     ),
                     @OpenApiParam(name = LOCATION_CATEGORY_LIKE,
                             description = "Posix <a href=\"regexp.html\">regular expression</a> matching against the location"
                                     + " category id"
                     ),
-                    @OpenApiParam(name = LOCATION_CATEGORY_LIKE2,
-                            deprecated = true,
-                            description = "Deprecated. Use location-category-like."
-                    ),
                     @OpenApiParam(name = LOCATION_GROUP_LIKE,
                             description = "Posix <a href=\"regexp.html\">regular expression</a> matching against the location"
                                     + " group id"
-                    ),
-                    @OpenApiParam(name = LOCATION_GROUP_LIKE2,
-                            deprecated = true,
-                            description = "Deprecated. Use location-group-like."
                     ),
                     @OpenApiParam(name = BOUNDING_OFFICE_LIKE, description = "Posix <a href=\"regexp.html\">regular expression</a> "
                             + "matching against the location bounding office. "

--- a/cwms-data-api/src/main/java/cwms/cda/api/ClobController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/ClobController.java
@@ -99,29 +99,15 @@ public class ClobController implements CrudHandler {
                                     + " value, and can be obtained from the 'next-page' value in "
                                     + "the response."
                     ),
-                    @OpenApiParam(name = CURSOR,
-                            deprecated = true,
-                            description = "Deprecated. Use 'page' instead."
-                    ),
                     @OpenApiParam(name = PAGE_SIZE,
                             type = Integer.class,
                             description = "How many entries per page returned. Default "
                                     + defaultPageSize + "."
                     ),
-                    @OpenApiParam(name = PAGESIZE3,
-                            deprecated = true,
-                            type = Integer.class,
-                            description = "Deprecated, use 'page-size' instead."
-                    ),
                     @OpenApiParam(name = INCLUDE_VALUES,
                             type = Boolean.class,
                             description = "Do you want the value associated with this particular "
                                     + "clob (default: false)"
-                    ),
-                    @OpenApiParam(name = INCLUDE_VALUES2,
-                            deprecated = true,
-                            type = Boolean.class,
-                            description = "Deprecated, use 'include-values' instead."
                     ),
                     @OpenApiParam(name = LIKE,
                             description = "Posix <a href=\"regexp.html\">regular expression</a> matching against the id"

--- a/cwms-data-api/src/main/java/cwms/cda/api/ClobController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/ClobController.java
@@ -9,12 +9,9 @@ import static cwms.cda.api.Controllers.GET_ALL;
 import static cwms.cda.api.Controllers.GET_ONE;
 import static cwms.cda.api.Controllers.IGNORE_NULLS;
 import static cwms.cda.api.Controllers.INCLUDE_VALUES;
-import static cwms.cda.api.Controllers.INCLUDE_VALUES2;
 import static cwms.cda.api.Controllers.LIKE;
 import static cwms.cda.api.Controllers.OFFICE;
 import static cwms.cda.api.Controllers.PAGE;
-import static cwms.cda.api.Controllers.PAGESIZE2;
-import static cwms.cda.api.Controllers.PAGESIZE3;
 import static cwms.cda.api.Controllers.PAGE_SIZE;
 import static cwms.cda.api.Controllers.RESULTS;
 import static cwms.cda.api.Controllers.SIZE;
@@ -145,12 +142,11 @@ public class ClobController implements CrudHandler {
                 return;
             }
 
-            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE, PAGESIZE3,
-                            PAGESIZE2}, Integer.class, defaultPageSize, metrics,
+            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE}, Integer.class, defaultPageSize, metrics,
                     name(ClobController.class.getName(), GET_ALL));
 
-            boolean includeValues = queryParamAsClass(ctx, new String[]{INCLUDE_VALUES,
-                            INCLUDE_VALUES2}, Boolean.class, false, metrics,
+            boolean includeValues = queryParamAsClass(ctx, new String[]{INCLUDE_VALUES},
+                    Boolean.class, false, metrics,
                     name(ClobController.class.getName(), GET_ALL));
             String like = ctx.queryParamAsClass(LIKE, String.class).getOrDefault(".*");
 

--- a/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
@@ -47,8 +47,7 @@ public final class Controllers {
     public static final String PAGE_SIZE = "page-size";
 
     // IF the constant has a number at the end its a deprecated variant
-    public static final String PAGESIZE2 = "pagesize"; // deprecated
-    public static final String PAGESIZE3 = "pageSize"; // deprecated
+
     public static final String SIZE = "size";
 
     public static final String OFFICE = "office";
@@ -60,20 +59,19 @@ public final class Controllers {
     public static final String LIKE = "like";
 
     public static final String UNIT_SYSTEM = "unit-system";
-    public static final String UNITSYSTEM2 = "unitSystem"; // deprecated
+
     public static final String TIMESERIES_CATEGORY_LIKE = "timeseries-category-like";
-    public static final String TIMESERIESCATEGORYLIKE2 = "timeseriesCategoryLike"; // deprecated
+
     public static final String LOCATION_CATEGORY_LIKE = "location-category-like";
     public static final String LOCATION_GROUP_LIKE = "location-group-like";
-    public static final String TIMESERIES_GROUP_LIKE2 = "timeseriesGroupLike"; // deprecated
-    public static final String LOCATION_CATEGORY_LIKE2 = "locationCategoryLike"; // deprecated
-    public static final String LOCATION_GROUP_LIKE2 = "locationGroupLike"; // deprecated
+
+
+
 
     public static final String TIMESERIES_GROUP_LIKE = "timeseries-group-like";
     public static final String ACCEPT = "Accept";
     public static final String CLOB_ID = "clob-id";
     public static final String INCLUDE_VALUES = "include-values";
-    public static final String INCLUDE_VALUES2 = "includeValues"; // deprecated
     public static final String FAIL_IF_EXISTS = "fail-if-exists";
     public static final String IGNORE_NULLS = "ignore-nulls";
     public static final String EFFECTIVE_DATE = "effective-date";
@@ -122,7 +120,6 @@ public final class Controllers {
     public static final String TS_IDS = "ts-ids";
     public static final String DATE_FORMAT = "YYYY-MM-dd'T'hh:mm:ss[Z'['VV']']";
     public static final String INCLUDE_ASSIGNED = "include-assigned";
-    public static final String INCLUDE_ASSIGNED2 = "includeAssigned"; // deprecated
     public static final String ANY_MASK = "*";
     public static final String ID_MASK = "id-mask";
     public static final String NAME_MASK = "name-mask";

--- a/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
@@ -158,9 +158,6 @@ public class LevelsController implements CrudHandler {
                             + "the location level whose data is to be deleted. If this field is "
                             + "not specified, matching location level information will be deleted"
                             + " from all offices."),
-
-                    @OpenApiParam(name = DATE, deprecated = true, description = "Deprecated, use "
-                            + EFFECTIVE_DATE),
                     @OpenApiParam(name = EFFECTIVE_DATE, description = "Specifies the "
                             + "effective date of the level to be deleted. If not provided will "
                             + "delete all data and reference to the location level.")
@@ -193,8 +190,6 @@ public class LevelsController implements CrudHandler {
 
     @OpenApi(
             queryParams = {
-                    @OpenApiParam(name = NAME, deprecated = true, description = "Deprecated, use "
-                            + LEVEL_ID_MASK + ". "),
                     @OpenApiParam(name = LEVEL_ID_MASK, description = "Specifies the name(s) of "
                             + "the location level(s) whose data is to be included in the response. "
                             + "Uses * for all."),
@@ -352,8 +347,6 @@ public class LevelsController implements CrudHandler {
             queryParams = {
                     @OpenApiParam(name = OFFICE, required = true, description = "Specifies the "
                             + "office of the Location Level to be returned"),
-                    @OpenApiParam(name = DATE, deprecated = true, description = "Deprecated, use "
-                            + EFFECTIVE_DATE),
                     @OpenApiParam(name = EFFECTIVE_DATE, required = true, description = "Specifies "
                             + "the effective date of Location Level to be returned"),
                     @OpenApiParam(name = UNIT, required = false, description = "Desired unit for "
@@ -401,8 +394,6 @@ public class LevelsController implements CrudHandler {
                             + "location level id of the Location Level to be updated"),
             },
             queryParams = {
-                    @OpenApiParam(name = DATE, deprecated = true, description = "Deprecated, use "
-                            + EFFECTIVE_DATE),
                     @OpenApiParam(name = EFFECTIVE_DATE, description = "Specifies "
                             + "the effective date of Location Level that will be updated")
             },

--- a/cwms-data-api/src/main/java/cwms/cda/api/LocationGroupController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LocationGroupController.java
@@ -84,8 +84,7 @@ public class LocationGroupController implements CrudHandler {
                     + "offices shall be returned."),
             @OpenApiParam(name = INCLUDE_ASSIGNED, type = Boolean.class, description = "Include"
                     + " the assigned locations in the returned location groups. (default: false)"),
-            @OpenApiParam(name = INCLUDE_ASSIGNED2, deprecated = true, type = Boolean.class,
-                    description = "Deprecated. Use include-assigned instead."),
+
             @OpenApiParam(name = LOCATION_CATEGORY_LIKE, description = "Posix <a href=\"regexp.html\">regular expression</a> "
                     + "matching against the location category id"), },
             responses = {

--- a/cwms-data-api/src/main/java/cwms/cda/api/LocationGroupController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LocationGroupController.java
@@ -107,7 +107,7 @@ public class LocationGroupController implements CrudHandler {
 
             String office = ctx.queryParam(OFFICE);
 
-            boolean includeAssigned = queryParamAsClass(ctx, new String[]{INCLUDE_ASSIGNED, INCLUDE_ASSIGNED2},
+            boolean includeAssigned = queryParamAsClass(ctx, new String[]{INCLUDE_ASSIGNED},
                     Boolean.class, false, metrics, name(LocationGroupController.class.getName(),
                             GET_ALL));
 

--- a/cwms-data-api/src/main/java/cwms/cda/api/PoolController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/PoolController.java
@@ -86,19 +86,11 @@ public class PoolController implements CrudHandler {
                             + " in the request you are. This is an opaque value, and can be"
                             + " obtained from the 'next-page' value in the response."
             ),
-            @OpenApiParam(name = CURSOR,
-                    deprecated = true,
-                    description = "Deprecated. Use '" + PAGE + "' instead."
-            ),
             @OpenApiParam(name = PAGE_SIZE,
                     type = Integer.class,
                     description =
                             "How many entries per page returned. Default " + defaultPageSize + "."
-            ),
-            @OpenApiParam(name = PAGESIZE3,
-                    deprecated = true,
-                    type = Integer.class,
-                    description = "Deprecated. Use '" + PAGE_SIZE + "' instead."),},
+            ),},
             responses = {
                     @OpenApiResponse(status = STATUS_200, content = {
                             @OpenApiContent(type = Formats.JSONV2, from = Pools.class)}),

--- a/cwms-data-api/src/main/java/cwms/cda/api/PoolController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/PoolController.java
@@ -14,8 +14,6 @@ import static cwms.cda.api.Controllers.NAME_MASK;
 import static cwms.cda.api.Controllers.NOT_SUPPORTED_YET;
 import static cwms.cda.api.Controllers.OFFICE;
 import static cwms.cda.api.Controllers.PAGE;
-import static cwms.cda.api.Controllers.PAGESIZE2;
-import static cwms.cda.api.Controllers.PAGESIZE3;
 import static cwms.cda.api.Controllers.PAGE_SIZE;
 import static cwms.cda.api.Controllers.POOL_ID;
 import static cwms.cda.api.Controllers.PROJECT_ID;
@@ -126,8 +124,8 @@ public class PoolController implements CrudHandler {
                     String.class, "", metrics, name(PoolController.class.getName(),
                             GET_ALL));
 
-            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE, PAGESIZE3,
-                PAGESIZE2}, Integer.class, defaultPageSize, metrics,
+            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE},
+                    Integer.class, defaultPageSize, metrics,
                     name(PoolController.class.getName(), GET_ALL));
 
             Pools pools = dao.retrievePools(cursor, pageSize, projectIdMask, nameMask, bottomMask,

--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
@@ -23,8 +23,6 @@ import static cwms.cda.api.Controllers.NOT_SUPPORTED_YET;
 import static cwms.cda.api.Controllers.OFFICE;
 import static cwms.cda.api.Controllers.OVERRIDE_PROTECTION;
 import static cwms.cda.api.Controllers.PAGE;
-import static cwms.cda.api.Controllers.PAGESIZE2;
-import static cwms.cda.api.Controllers.PAGESIZE3;
 import static cwms.cda.api.Controllers.PAGE_SIZE;
 import static cwms.cda.api.Controllers.RESULTS;
 import static cwms.cda.api.Controllers.SIZE;
@@ -374,8 +372,8 @@ public class TimeSeriesController implements CrudHandler {
                     String.class, "", metrics, name(TimeSeriesController.class.getName(),
                             GET_ALL));
 
-            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE, PAGESIZE3,
-                    PAGESIZE2}, Integer.class, defaultPageSize, metrics,
+            int pageSize = queryParamAsClass(ctx, new String[]{PAGE_SIZE  },
+                    Integer.class, defaultPageSize, metrics,
                     name(TimeSeriesController.class.getName(), GET_ALL));
 
             String acceptHeader = ctx.header(Header.ACCEPT);

--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
@@ -328,20 +328,10 @@ public class TimeSeriesController implements CrudHandler {
                                     + " value, and can be obtained from the 'next-page' value in "
                                     + "the response."
                     ),
-                    @OpenApiParam(name = CURSOR,
-                            deprecated = true,
-                            description = "Deprecated. Use 'page' instead."
-                    ),
                     @OpenApiParam(name = PAGE_SIZE,
                             type = Integer.class,
-                            description =
-                                    "How many entries per page returned. "
+                            description = "How many entries per page returned. "
                                             + "Default " + defaultPageSize + "."
-                    ),
-                    @OpenApiParam(name = PAGESIZE3,
-                            deprecated = true,
-                            type = Integer.class,
-                            description = "Deprecated. Please use page-size instead."
                     )
             },
             responses = {@OpenApiResponse(status = STATUS_200,


### PR DESCRIPTION
This removes query params that were previously marked as deprecated except for the two places using deprecated "format" params.  I think the format params should be handled in a different way.

This relates to contract W912HQ22F0193 Task 8 Topic A.