### PR TITLE
add gradle run task to the "run" group

### DIFF
--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -218,6 +218,7 @@ task generateConfig(type: Copy) {
 }
 
 task run(type: JavaExec) {
+    group "application"
     dependsOn generateConfig
     dependsOn war
 


### PR DESCRIPTION
this prevents it from getting added to the "other" group and matches the gradle Application plugin