### PR TITLE
fix incorrect method call to get interval minutes for full tsid

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -182,7 +182,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
                 DSL.val(units, String.class);
 
         // another call to get the interval
-        Field<BigDecimal> ival = CWMS_TS_PACKAGE.call_GET_INTERVAL(validTs.field("tsid", String.class));
+        Field<BigDecimal> ival = CWMS_TS_PACKAGE.call_GET_TS_INTERVAL__2(validTs.field("tsid", String.class));
 
         // put all those columns together as "valid"
         CommonTableExpression<Record7<BigDecimal, String, String, String, String, BigDecimal,


### PR DESCRIPTION
the other method is for getting the minutes based on just the interval string