### PR TITLE
Change LineLength to 120

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -34,7 +34,7 @@
 
     <module name="LineLength">
         <property name="fileExtensions" value="java"/>
-        <property name="max" value="100"/>
+        <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 


### PR DESCRIPTION
Can we extend the LineLength to 120 (or even just 110)? 

I parsed the checkstyle warnings from a recent build and put them in excel.

![LineLength](https://github.com/USACE/cwms-data-api/assets/89810919/6c9350cc-003f-402d-bc9a-c7af01a5f67f)
