### PR TITLE
Add servers to the swagger docs for use with openapi generators #587

### DIFF
--- a/cwms-data-api/src/main/webapp/swagger-config.yaml
+++ b/cwms-data-api/src/main/webapp/swagger-config.yaml
@@ -8,6 +8,13 @@ info:
     name: Support
     url: https://github.com/usace/cwms-data-api
 host: https://cmws-data.usace.army.mil
+servers: 
+  - url: https://cwms-data.usace.army.mil
+    description: PRIMARY production server
+  - url: https://water.usace.army.mil,
+    description: Alias for the PRIMARY production server
+  - url: https://cwms.sec.usace.army.mil,
+    description: CWBI Production Server
 url: /cwms-data/swagger-docs
 basePath: /cwms-data
 schemes:

--- a/cwms-data-api/src/main/webapp/swagger-config.yaml
+++ b/cwms-data-api/src/main/webapp/swagger-config.yaml
@@ -13,8 +13,6 @@ servers:
     description: PRIMARY production server
   - url: https://water.usace.army.mil
     description: Alias for the PRIMARY production server
-  - url: https://cwms.sec.usace.army.mil
-    description: CWBI Production Server
 url: /cwms-data/swagger-docs
 basePath: /cwms-data
 schemes:

--- a/cwms-data-api/src/main/webapp/swagger-config.yaml
+++ b/cwms-data-api/src/main/webapp/swagger-config.yaml
@@ -11,9 +11,9 @@ host: https://cmws-data.usace.army.mil
 servers: 
   - url: https://cwms-data.usace.army.mil
     description: PRIMARY production server
-  - url: https://water.usace.army.mil,
+  - url: https://water.usace.army.mil
     description: Alias for the PRIMARY production server
-  - url: https://cwms.sec.usace.army.mil,
+  - url: https://cwms.sec.usace.army.mil
     description: CWBI Production Server
 url: /cwms-data/swagger-docs
 basePath: /cwms-data


### PR DESCRIPTION
Added servers to the yaml config for swagger. 

I was able to test the json output for the openapi generator. However, I do not have an environment setup for non-production to test these work. 

If the changes look suspect I can attempt to deploy this on our internal CDA instance to confirm all other portions of CDA still work as expected *with* the servers present. 

issue #587
discussion #351 