### PR TITLE
Bugfix/LargeBlobUrl

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/BinaryTimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/BinaryTimeSeriesController.java
@@ -131,8 +131,13 @@ public class BinaryTimeSeriesController implements CrudHandler {
         ContentType contentType = Formats.parseHeaderAndQueryParm(formatHeader, "");
         try (Timer.Context ignored = markAndTime(GET_ALL)) {
             String dateToken = "{date_token}";
+            String path = ctx.path();
+            if(!path.endsWith("/"))  {
+                path += "/";
+            }
+            path += tsId + "/value";
             String url = new URIBuilder(ctx.fullUrl())
-                    .setPath(ctx.path() + "/" + tsId + "/value")
+                    .setPath(path)
                     .clearParameters()
                     .addParameter(OFFICE, office)
                     .addParameter(VERSION_DATE, ctx.queryParam(VERSION_DATE))

--- a/cwms-data-api/src/main/java/cwms/cda/api/BinaryTimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/BinaryTimeSeriesController.java
@@ -132,7 +132,7 @@ public class BinaryTimeSeriesController implements CrudHandler {
         try (Timer.Context ignored = markAndTime(GET_ALL)) {
             String dateToken = "{date_token}";
             String url = new URIBuilder(ctx.fullUrl())
-                    .setPath(ctx.path() + tsId + "/value")
+                    .setPath(ctx.path() + "/" + tsId + "/value")
                     .clearParameters()
                     .addParameter(OFFICE, office)
                     .addParameter(VERSION_DATE, ctx.queryParam(VERSION_DATE))

--- a/cwms-data-api/src/main/java/cwms/cda/api/TextTimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TextTimeSeriesController.java
@@ -131,8 +131,13 @@ public class TextTimeSeriesController implements CrudHandler {
             String textMask = "*";
 
             String dateToken = "{date_token}";
+            String path = ctx.path();
+            if(!path.endsWith("/"))  {
+                path += "/";
+            }
+            path += tsId + "/value";
             String url = new URIBuilder(ctx.fullUrl())
-                    .setPath(ctx.path() + "/" + tsId + "/value")
+                    .setPath(path)
                     .clearParameters()
                     .addParameter(OFFICE, office)
                     .addParameter(VERSION_DATE, ctx.queryParam(VERSION_DATE))


### PR DESCRIPTION
Added '/' in between ctx.path() and tsId for BinaryTimeSeries large blob url