### PR TITLE
Switch dockerfile link from dlcdn.apache.org to archive.apache.org so…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache bash
 
 RUN mkdir /download && \
     cd /download && \
-    wget https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.85/bin/apache-tomcat-9.0.85.tar.gz && \
+    wget https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.85/bin/apache-tomcat-9.0.85.tar.gz && \
     echo "06e239d15ff7b72017c1d0752ddb1be4651374f7c1391631ec5619f4981cb2911267bc6b044d6c71a2a74738f70d433b96418951439848121f1d874862ddd3de *apache-tomcat-9.0.85.tar.gz" > checksum.txt && \
     sha512sum -c checksum.txt && \
     tar xzf apache-tomcat-*tar.gz && \


### PR DESCRIPTION
… that we can update tomcat versions on our own timeframe.  The dlcdn links apparently go away when new releases are made.