### PR TITLE
add property controller, dao, and integration tests

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -57,6 +57,7 @@ import cwms.cda.api.LocationGroupController;
 import cwms.cda.api.OfficeController;
 import cwms.cda.api.ParametersController;
 import cwms.cda.api.PoolController;
+import cwms.cda.api.PropertyController;
 import cwms.cda.api.RatingController;
 import cwms.cda.api.RatingMetadataController;
 import cwms.cda.api.RatingSpecController;
@@ -163,7 +164,8 @@ import org.owasp.html.PolicyFactory;
         "/specified-levels/*",
         "/forecast-spec/*",
         "/forecast-instance/*",
-        "/standard-text-id/*"
+        "/standard-text-id/*",
+        "/properties/*"
 })
 public class ApiServlet extends HttpServlet {
 
@@ -457,8 +459,8 @@ public class ApiServlet extends HttpServlet {
         String forecastFilePath = "/forecast-instance/{" + NAME + "}/file-data";
         get(forecastFilePath, new ForecastFileController(metrics));
         addCacheControl(forecastFilePath, 1, TimeUnit.DAYS);
-
-
+        cdaCrudCache(format("/properties/{%s}", Controllers.NAME),
+                new PropertyController(metrics), requiredRoles,1, TimeUnit.DAYS);
     }
 
     /**

--- a/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
@@ -110,6 +110,7 @@ public final class Controllers {
     public static final String INTERVAL_OFFSET = "interval-offset";
     public static final String INTERVAL = "interval";
     public static final String CATEGORY_ID = "category-id";
+    public static final String CATEGORY_ID_MASK = "category-id-mask";
     public static final String EXAMPLE_DATE = "2021-06-10T13:00:00-0700[PST8PDT]";
     public static final String VERSION_DATE = "version-date";
 
@@ -150,6 +151,7 @@ public final class Controllers {
     public static final String HAS_DATA = "has-data";
     public static final String STATUS_200 = "200";
     public static final String STATUS_201 = "201";
+    public static final String STATUS_204 = "204";
     public static final String STATUS_404 = "404";
     public static final String STATUS_501 = "501";
     public static final String STATUS_400 = "400";
@@ -164,6 +166,7 @@ public final class Controllers {
     public static final String DESIGNATOR_MASK = "designator-mask";
     public static final String INCLUDE_EXTENTS = "include-extents";
     public static final String EXCLUDE_EMPTY = "exclude-empty";
+    public static final String DEFAULT_VALUE = "default-value";
 
 
     static {

--- a/cwms-data-api/src/main/java/cwms/cda/api/PropertyController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/PropertyController.java
@@ -1,0 +1,296 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.api;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.flogger.FluentLogger;
+import cwms.cda.data.dao.PropertyDao;
+import cwms.cda.data.dto.Property;
+import cwms.cda.formatters.ContentType;
+import cwms.cda.formatters.Formats;
+import cwms.cda.formatters.FormattingException;
+import cwms.cda.formatters.json.JsonV2;
+import io.javalin.apibuilder.CrudHandler;
+import io.javalin.core.util.Header;
+import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import org.jetbrains.annotations.NotNull;
+import org.jooq.DSLContext;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static com.codahale.metrics.MetricRegistry.name;
+import static cwms.cda.api.Controllers.*;
+import static cwms.cda.data.dao.JooqDao.getDslContext;
+
+public final class PropertyController implements CrudHandler {
+    
+    static final String TAG = "Properties";
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
+    private final MetricRegistry metrics;
+
+    private final Histogram requestResultSize;
+
+
+    public PropertyController(MetricRegistry metrics) {
+        this.metrics = metrics;
+        String className = this.getClass().getName();
+
+        requestResultSize = this.metrics.histogram((name(className, RESULTS, SIZE)));
+    }
+
+    private Timer.Context markAndTime(String subject) {
+        return Controllers.markAndTime(metrics, getClass().getName(), subject);
+    }
+
+    @OpenApi(
+            pathParams = {
+            },
+            queryParams = {
+                @OpenApiParam(name = OFFICE_MASK, description = "Filters properties to the specified office mask"),
+                @OpenApiParam(name = CATEGORY_ID, description = "Filters properties to the specified category mask"),
+                @OpenApiParam(name = NAME_MASK, description = "Filters properties to the specified name mask"),
+            },
+            responses = {
+                @OpenApiResponse(status = STATUS_200, content = {
+                        @OpenApiContent(isArray = true, type = Formats.JSONV2, from = Property.class)
+                })
+            },
+            description = "Returns matching CWMS Property Data.",
+            tags = {TAG}
+    )
+    @Override
+    public void getAll(Context ctx) {
+        String officeMask = ctx.queryParam(OFFICE_MASK);
+        String categoryMask = ctx.queryParam(CATEGORY_ID_MASK);
+        String nameMask = ctx.queryParam(NAME_MASK);
+        try (Timer.Context ignored = markAndTime(GET_ALL)) {
+            DSLContext dsl = getDslContext(ctx);
+            PropertyDao dao = new PropertyDao(dsl);
+            List<Property> properties = dao.retrieveProperties(officeMask, categoryMask, nameMask);
+            ContentType contentType = getContentType(ctx);
+            ctx.contentType(contentType.toString());
+            ObjectMapper om = getObjectMapperForFormat(contentType);
+            String serialized = om.writeValueAsString(properties);
+            ctx.result(serialized);
+            ctx.status(HttpServletResponse.SC_OK);
+            requestResultSize.update(serialized.length());
+        } catch (IOException ex) {
+            String errorMsg = "Error retrieving properties.";
+            LOGGER.atWarning().withCause(ex).log("Error deserializing properties"
+                    + " with parameters: " + ctx.queryParamMap());
+            throw new FormattingException(errorMsg, ex);
+        }
+    }
+
+    @OpenApi(
+            pathParams = {
+                @OpenApiParam(name = NAME, description = "Specifies the name of "
+                        + "the property to be retrieved."),
+            },
+            queryParams = {
+                @OpenApiParam(name = OFFICE, description = "Specifies the owning office of "
+                        + "the property to be retrieved."),
+                @OpenApiParam(name = CATEGORY_ID, description = "Specifies the category id of "
+                        + "the property to be retrieved."),
+                @OpenApiParam(name = DEFAULT_VALUE, description = "Specifies the default value "
+                        + "if the property does not exist."),
+            },
+            responses = {
+                @OpenApiResponse(status = STATUS_200,
+                        content = {
+                                @OpenApiContent(type = Formats.JSONV2, from = Property.class)
+                        })
+            },
+            description = "Returns CWMS Property Data",
+            tags = {TAG}
+    )
+    @Override
+    public void getOne(Context ctx, String name) {
+        String office = ctx.queryParam(OFFICE);
+        String category = ctx.queryParam(CATEGORY_ID);
+        String defaultValue = ctx.queryParam(DEFAULT_VALUE);
+        try (Timer.Context ignored = markAndTime(GET_ONE)) {
+            DSLContext dsl = getDslContext(ctx);
+            PropertyDao dao = new PropertyDao(dsl);
+            Property property = dao.retrieveProperty(office, category, name, defaultValue);
+            ContentType contentType = getContentType(ctx);
+            ctx.contentType(contentType.toString());
+            ObjectMapper om = getObjectMapperForFormat(contentType);
+            String serialized = om.writeValueAsString(property);
+            ctx.result(serialized);
+            ctx.status(HttpServletResponse.SC_OK);
+            requestResultSize.update(serialized.length());
+        } catch (IOException ex) {
+            String errorMsg = "Error retrieving property " + name;
+            LOGGER.atWarning().withCause(ex).log("Error deserializing property: " + name
+                    + " with parameters: " + ctx.queryParamMap());
+            throw new FormattingException(errorMsg, ex);
+        }
+    }
+
+    private static @NotNull ContentType getContentType(Context ctx) {
+        String formatHeader = ctx.header(Header.ACCEPT) != null ? ctx.header(Header.ACCEPT) :
+                Formats.JSONV2;
+        ContentType contentType = Formats.parseHeader(formatHeader);
+        if (contentType == null) {
+            throw new FormattingException("Format header could not be parsed");
+        }
+        return contentType;
+    }
+
+
+    @OpenApi(
+            requestBody = @OpenApiRequestBody(
+                    content = {
+                        @OpenApiContent(from = Property.class, type = Formats.JSONV2)
+                    },
+                    required = true),
+            description = "Create CWMS Property",
+            method = HttpMethod.POST,
+            tags = {TAG},
+            responses = {
+                @OpenApiResponse(status = STATUS_204, description = "Property successfully stored to CWMS.")
+            }
+    )
+    @Override
+    public void create(Context ctx) {
+        try (Timer.Context ignored = markAndTime(CREATE)) {
+            String acceptHeader = ctx.req.getContentType();
+            String formatHeader = acceptHeader != null ? acceptHeader : Formats.JSONV2;
+            ContentType contentType = Formats.parseHeader(formatHeader);
+            if (contentType == null) {
+                throw new FormattingException("Format header could not be parsed");
+            }
+            Property property = deserializeProperty(ctx.body(), contentType);
+            property.validate();
+            DSLContext dsl = getDslContext(ctx);
+            PropertyDao dao = new PropertyDao(dsl);
+            dao.storeProperty(property);
+            ctx.status(HttpServletResponse.SC_CREATED).json("Created Property");
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Unable to parse property from content body", ex);
+        }
+
+    }
+
+    @OpenApi(
+            requestBody = @OpenApiRequestBody(
+                    content = {
+                        @OpenApiContent(from = Property.class, type = Formats.JSONV2)
+                    },
+                    required = true),
+            description = "Update CWMS Property",
+            method = HttpMethod.PATCH,
+            tags = {TAG},
+            responses = {
+                @OpenApiResponse(status = STATUS_204, description = "Property successfully stored to CWMS.")
+            }
+    )
+    @Override
+    public void update(Context ctx, String name) {
+        try (Timer.Context ignored = markAndTime(UPDATE)) {
+            String acceptHeader = ctx.req.getContentType();
+            String formatHeader = acceptHeader != null ? acceptHeader : Formats.JSONV2;
+            ContentType contentType = Formats.parseHeader(formatHeader);
+            if (contentType == null) {
+                throw new FormattingException("Format header could not be parsed");
+            }
+            Property property = deserializeProperty(ctx.body(), contentType);
+            property.validate();
+            DSLContext dsl = getDslContext(ctx);
+            PropertyDao dao = new PropertyDao(dsl);
+            dao.updateProperty(property);
+            ctx.status(HttpServletResponse.SC_OK).json("Updated Property");
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Unable to parse property from content body", ex);
+        }
+
+    }
+
+    @OpenApi(
+            pathParams = {
+                @OpenApiParam(name = NAME, description = "Specifies the name of "
+                        + "the property to be deleted."),
+            },
+            queryParams = {
+                @OpenApiParam(name = OFFICE, description = "Specifies the owning office of "
+                        + "the property to be deleted."),
+                @OpenApiParam(name = CATEGORY_ID, description = "Specifies the category id of "
+                        + "the property to be deleted."),
+            },
+            description = "Delete CWMS Property",
+            method = HttpMethod.DELETE,
+            tags = {TAG},
+            responses = {
+                @OpenApiResponse(status = STATUS_204, description = "Property successfully deleted from CWMS."),
+                @OpenApiResponse(status = STATUS_404, description = "Based on the combination of "
+                        + "inputs provided the property was not found.")
+            }
+    )
+    @Override
+    public void delete(Context ctx, String name) {
+        String office = ctx.queryParam(OFFICE);
+        String category = ctx.queryParam(CATEGORY_ID);
+        try (Timer.Context ignored = markAndTime(DELETE)) {
+            DSLContext dsl = getDslContext(ctx);
+            PropertyDao dao = new PropertyDao(dsl);
+            dao.deleteProperty(office, category, name);
+            ctx.status(HttpServletResponse.SC_NO_CONTENT).json(name + " Deleted");
+        }
+    }
+
+    private static Property deserializeProperty(String body, ContentType contentType)
+            throws IOException {
+        ObjectMapper om = getObjectMapperForFormat(contentType);
+        Property retVal;
+        try {
+            retVal = om.readValue(body, Property.class);
+        } catch (Exception e) {
+            throw new IOException("Failed to deserialize property", e);
+        }
+        return retVal;
+    }
+
+    private static ObjectMapper getObjectMapperForFormat(ContentType contentType) {
+        ObjectMapper om;
+        if (ContentType.equivalent(Formats.JSONV2, contentType.toString())) {
+            om = JsonV2.buildObjectMapper();
+        } else {
+            throw new FormattingException("Format is not currently supported for Properties");
+        }
+        return om;
+    }
+}

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/PropertyDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/PropertyDao.java
@@ -1,0 +1,102 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.data.dao;
+
+import cwms.cda.api.errors.NotFoundException;
+import cwms.cda.data.dto.Property;
+import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import usace.cwms.db.jooq.codegen.packages.CWMS_PROPERTIES_PACKAGE;
+import usace.cwms.db.jooq.codegen.packages.cwms_properties.GET_PROPERTY__2;
+import usace.cwms.db.jooq.codegen.tables.AV_PROPERTY;
+import usace.cwms.db.jooq.codegen.udt.records.PROPERTY_INFO_T;
+
+import java.util.List;
+
+public final class PropertyDao extends JooqDao<Property> {
+
+    public PropertyDao(DSLContext dsl) {
+        super(dsl);
+    }
+
+    public Property retrieveProperty(String office, String category, String name, String defaultValue) {
+        return connectionResult(dsl, conn -> {
+            setOffice(conn, office);
+            GET_PROPERTY__2 value = CWMS_PROPERTIES_PACKAGE.call_GET_PROPERTY__2(DSL.using(conn).configuration(), category, name, defaultValue, office);
+            return new Property.Builder()
+                    .withOfficeId(office)
+                    .withCategory(category)
+                    .withName(name)
+                    .withValue(value.getP_VALUE())
+                    .withComment(value.getP_COMMENT())
+                    .build();
+        });
+    }
+
+    public List<Property> retrieveProperties(String officeIdMask, String categoryMask, String idMask) {
+        return connectionResult(dsl, conn -> {
+            PROPERTY_INFO_T propInfo = new PROPERTY_INFO_T(officeIdMask, categoryMask, idMask);
+            return CWMS_PROPERTIES_PACKAGE.call_GET_PROPERTIES__4(DSL.using(conn).configuration(), propInfo)
+                    .map(r -> new Property.Builder()
+                            .withOfficeId(r.get(AV_PROPERTY.AV_PROPERTY.OFFICE_ID))
+                            .withCategory(r.get(AV_PROPERTY.AV_PROPERTY.PROP_CATEGORY))
+                            .withName(r.get(AV_PROPERTY.AV_PROPERTY.PROP_ID))
+                            .withValue(r.get(AV_PROPERTY.AV_PROPERTY.PROP_VALUE))
+                            .withComment(r.get(AV_PROPERTY.AV_PROPERTY.PROP_COMMENT))
+                            .build());
+        });
+    }
+
+    public void updateProperty(Property property) {
+        List<Property> properties = retrieveProperties(property.getOfficeId(), property.getCategory(), property.getName());
+        if (properties.isEmpty()) {
+            throw new NotFoundException("Could not find property to update.");
+        }
+        connection(dsl, conn -> {
+            setOffice(conn, property.getOfficeId());
+            CWMS_PROPERTIES_PACKAGE.call_SET_PROPERTY(DSL.using(conn).configuration(), property.getCategory(),
+                    property.getName(), property.getValue(), property.getComment(), property.getOfficeId());
+        });
+    }
+
+    public void storeProperty(Property property) {
+        connection(dsl, conn -> {
+            setOffice(conn, property.getOfficeId());
+            CWMS_PROPERTIES_PACKAGE.call_SET_PROPERTY(DSL.using(conn).configuration(), property.getCategory(),
+                    property.getName(), property.getValue(), property.getComment(), property.getOfficeId());
+        });
+    }
+
+    public void deleteProperty(String office, String category, String name) {
+        List<Property> properties = retrieveProperties(office, category, name);
+        if (properties.isEmpty()) {
+            throw new NotFoundException("Could not find property to delete.");
+        }
+        connection(dsl, conn -> {
+            setOffice(conn, office);
+            CWMS_PROPERTIES_PACKAGE.call_DELETE_PROPERTY(DSL.using(conn).configuration(), category, name, office);
+        });
+    }
+}

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Property.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Property.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
-import cwms.cda.formatters.json.JsonV2;
+import cwms.cda.formatters.json.JsonV1;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -40,7 +40,7 @@ import java.util.Objects;
 
 @XmlRootElement(name = "property")
 @XmlAccessorType(XmlAccessType.FIELD)
-@FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class)
+@FormattableWith(contentType = Formats.JSON, formatter = JsonV1.class)
 @JsonDeserialize(builder = Property.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
@@ -118,6 +118,20 @@ public class Formats {
         }
     }
 
+    private <T extends CwmsDTOBase> T parseContentFromType(ContentType type, String content, Class<T> rootType)
+            throws FormattingException {
+        OutputFormatter outputFormatter = getOutputFormatter(type, rootType);
+        if (outputFormatter != null) {
+            T retval = outputFormatter.parseContent(content, rootType);
+            retval.validate();
+            return retval;
+        } else {
+            String message = String.format("No Format for this content-type and data type : (%s, %s)",
+                    type.toString(), rootType.getName());
+            throw new FormattingException(message);
+        }
+    }
+
     private OutputFormatter getOutputFormatter(ContentType type,
                                                Class<? extends CwmsDTOBase> klass) {
         OutputFormatter outputFormatter = null;
@@ -154,6 +168,10 @@ public class Formats {
         return formats.getFormatted(type, toFormat, rootType);
     }
 
+    public static <T extends CwmsDTOBase> T parseContent(ContentType type, String content, Class<T> rootType)
+            throws FormattingException {
+        return formats.parseContentFromType(type, content, rootType);
+    }
 
     /**
      * Parses the supplied header param or queryParam to determine the content type.

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/OutputFormatter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/OutputFormatter.java
@@ -5,7 +5,8 @@ import java.util.List;
 import cwms.cda.data.dto.CwmsDTOBase;
 
 public interface OutputFormatter {
-    public String getContentType();
-    public String format(CwmsDTOBase dto);
-    public String format(List<? extends CwmsDTOBase> dtoList);
+    String getContentType();
+    String format(CwmsDTOBase dto);
+    String format(List<? extends CwmsDTOBase> dtoList);
+    <T extends CwmsDTOBase> T parseContent(String content, Class<T> type);
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/csv/CsvV1.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/csv/CsvV1.java
@@ -40,4 +40,15 @@ public class CsvV1 implements OutputFormatter {
         }
         return retVal;
     }
+
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        T retVal = null;
+        if (type.isAssignableFrom(Office.class)) {
+            retVal = new CsvV1Office().parseContent(content, type);
+        } else if (type.isAssignableFrom(LocationGroup.class)) {
+            retVal = new CsvV1LocationGroup().parseContent(content, type);
+        }
+        return retVal;
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/csv/CsvV1LocationGroup.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/csv/CsvV1LocationGroup.java
@@ -81,6 +81,12 @@ public class CsvV1LocationGroup implements OutputFormatter {
         return null;
     }
 
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        throw new UnsupportedOperationException("Unable to process your request. Deserialization of "
+                + getContentType() + " not yet supported.");
+    }
+
 
     // Mixin for LocationGroup
     // This class doesn't have to be related to LocationGroup, it just has to look like it.

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/csv/CsvV1Office.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/csv/CsvV1Office.java
@@ -53,6 +53,12 @@ public class CsvV1Office implements OutputFormatter {
         return builder.toString();
     }
 
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        throw new UnsupportedOperationException("Unable to process your request. Deserialization of "
+                + getContentType() + " not yet supported.");
+    }
+
     private String getOfficeTabHeader() {
         return "#Office Name,Long Name,Office Type,Reports To Office";
     }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV1.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV1.java
@@ -76,6 +76,15 @@ public class JsonV1 implements OutputFormatter {
         }
     }
 
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        try {
+            return om.readValue(content, type);
+        } catch (JsonProcessingException e) {
+            throw new FormattingException("Could not deserialize:" + content, e);
+        }
+    }
+
     private Object buildFormatting(CwmsDTOBase dto) {
         Object retVal = null;
 

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV2.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV2.java
@@ -97,4 +97,13 @@ public class JsonV2 implements OutputFormatter {
         }
     }
 
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        try {
+            return om.readValue(content, type);
+        } catch (JsonProcessingException e) {
+            throw new FormattingException("Could not deserialize:" + content, e);
+        }
+    }
+
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/json/NamedPgJsonFormatter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/json/NamedPgJsonFormatter.java
@@ -15,6 +15,8 @@ import cwms.cda.formatters.OutputFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static cwms.cda.formatters.Formats.NAMED_PGJSON;
+
 public class NamedPgJsonFormatter implements OutputFormatter {
     private final ObjectMapper om;
 
@@ -24,7 +26,7 @@ public class NamedPgJsonFormatter implements OutputFormatter {
 
     @Override
     public String getContentType() {
-        return Formats.NAMED_PGJSON;
+        return NAMED_PGJSON;
     }
 
     @Override
@@ -52,6 +54,12 @@ public class NamedPgJsonFormatter implements OutputFormatter {
             retVal.append(format(dto));
         }
         return retVal.toString();
+    }
+
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        throw new UnsupportedOperationException("Unable to process your request. Deserialization of "
+                + getContentType() + " not yet supported.");
     }
 
     private String formatNamedGraph(String name, Graph graph) throws JsonProcessingException {

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/json/PgJsonFormatter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/json/PgJsonFormatter.java
@@ -119,4 +119,10 @@ public final class PgJsonFormatter implements OutputFormatter {
         }
         return retVal.toString();
     }
+
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        throw new UnsupportedOperationException("Unable to process your request. Deserialization of "
+                + getContentType() + " not yet supported.");
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/tab/TabV1.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/tab/TabV1.java
@@ -31,4 +31,13 @@ public class TabV1 implements OutputFormatter {
             return null;
         }
     }
+
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        if (type.isAssignableFrom(Office.class)) {
+            return new TabV1Office().parseContent(content, type);
+        } else {
+            return null;
+        }
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/tab/TabV1Office.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/tab/TabV1Office.java
@@ -52,6 +52,12 @@ public class TabV1Office implements OutputFormatter {
         return builder.toString();
     }
 
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        throw new UnsupportedOperationException("Unable to process your request. Deserialization of "
+                + getContentType() + " not yet supported.");
+    }
+
     private String getOfficeTabHeader() {
         return "#Office Name	Long Name	Office Type	Reports To Office";
     }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/xml/XMLv1.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/xml/XMLv1.java
@@ -75,4 +75,10 @@ public class XMLv1 implements OutputFormatter {
         throw new UnsupportedOperationException("Unable to process your request");
     }
 
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+        throw new UnsupportedOperationException("Unable to process your request. Deserialization of "
+                + getContentType() + " not yet supported.");
+    }
+
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/xml/XMLv2.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/xml/XMLv2.java
@@ -1,7 +1,11 @@
 package cwms.cda.formatters.xml;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.formatters.Formats;
+import cwms.cda.formatters.FormattingException;
 import cwms.cda.formatters.OutputFormatter;
 import io.javalin.http.InternalServerErrorResponse;
 import java.io.PrintWriter;
@@ -48,6 +52,19 @@ public class XMLv2 implements OutputFormatter {
     @Override
     public String format(List<? extends CwmsDTOBase> dtoList) {
         throw new UnsupportedOperationException("Unable to process your request");
+    }
+
+    @Override
+    public <T extends CwmsDTOBase> T parseContent(String content, Class<T> type) {
+
+        try {
+            JacksonXmlModule module = new JacksonXmlModule();
+            module.setDefaultUseWrapper(false);
+            XmlMapper om = new XmlMapper(module);
+            return om.readValue(content, type);
+        } catch (JsonProcessingException e) {
+            throw new FormattingException("Could not deserialize:" + content, e);
+        }
     }
 
 }

--- a/cwms-data-api/src/test/java/cwms/cda/api/PropertyControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/PropertyControllerIT.java
@@ -25,8 +25,8 @@
 package cwms.cda.api;
 
 import cwms.cda.data.dto.Property;
+import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
-import cwms.cda.formatters.json.JsonV2;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
 import org.apache.commons.io.IOUtils;
@@ -55,7 +55,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         assertNotNull(resource);
         String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
         assertNotNull(json);
-        Property property = JsonV2.buildObjectMapper().readValue(json, Property.class);
+        Property property = Formats.parseContent(new ContentType(Formats.JSON), json, Property.class);
 
         // Structure of test:
         // 1)Create the Property
@@ -67,8 +67,8 @@ final class PropertyControllerIT extends DataApiTestIT {
         //Create the property
         given()
             .log().ifValidationFails(LogDetail.ALL, true)
-            .accept(Formats.JSONV2)
-            .contentType(Formats.JSONV2)
+            .accept(Formats.JSON)
+            .contentType(Formats.JSON)
             .body(json)
             .header(AUTH_HEADER, user.toHeaderValue())
         .when()
@@ -84,7 +84,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         // Retrieve the property and assert that it exists
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.JSONV2)
+            .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE, office)
             .queryParam(Controllers.CATEGORY_ID, property.getCategory())
         .when()
@@ -105,7 +105,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         // Delete a Property
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.JSONV2)
+            .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE, office)
             .queryParam(Controllers.CATEGORY_ID, property.getCategory())
             .header(AUTH_HEADER, user.toHeaderValue())
@@ -122,7 +122,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         // Retrieve a Property and assert that it does not exist
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.JSONV2)
+            .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE, office)
             .queryParam(Controllers.CATEGORY_ID, property.getCategory())
         .when()
@@ -143,24 +143,24 @@ final class PropertyControllerIT extends DataApiTestIT {
         assertNotNull(resource);
         String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
         assertNotNull(json);
-        Property property = JsonV2.buildObjectMapper().readValue(json, Property.class);
+        Property property = Formats.parseContent(new ContentType(Formats.JSON), json, Property.class);
         TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
 
         //Create the property
         given()
-                .log().ifValidationFails(LogDetail.ALL, true)
-                .accept(Formats.JSONV2)
-                .contentType(Formats.JSONV2)
-                .body(json)
-                .header(AUTH_HEADER, user.toHeaderValue())
-                .when()
-                .redirects().follow(true)
-                .redirects().max(3)
-                .patch("/properties/" + property.getName())
-                .then()
-                .log().ifValidationFails(LogDetail.ALL, true)
-                .assertThat()
-                .statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSON)
+            .contentType(Formats.JSON)
+            .body(json)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .patch("/properties/" + property.getName())
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND))
         ;
     }
 
@@ -170,7 +170,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         // Delete a Property
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.JSONV2)
+            .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE, user.getOperatingOffice())
             .queryParam(Controllers.CATEGORY_ID, Instant.now().toEpochMilli())
             .header(AUTH_HEADER, user.toHeaderValue())
@@ -191,7 +191,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         assertNotNull(resource);
         String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
         assertNotNull(json);
-        Property property = JsonV2.buildObjectMapper().readValue(json, Property.class);
+        Property property = Formats.parseContent(new ContentType(Formats.JSON), json, Property.class);
 
         // Structure of test:
         // 1)Create the Property
@@ -202,8 +202,8 @@ final class PropertyControllerIT extends DataApiTestIT {
         //Create the property
         given()
             .log().ifValidationFails(LogDetail.ALL, true)
-            .accept(Formats.JSONV2)
-            .contentType(Formats.JSONV2)
+            .accept(Formats.JSON)
+            .contentType(Formats.JSON)
             .body(json)
             .header(AUTH_HEADER, user.toHeaderValue())
         .when()
@@ -219,7 +219,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         // Retrieve the property and assert that it exists
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.JSONV2)
+            .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE_MASK, office)
             .queryParam(Controllers.CATEGORY_ID_MASK, property.getCategory())
             .queryParam(Controllers.NAME_MASK, property.getName())
@@ -241,7 +241,7 @@ final class PropertyControllerIT extends DataApiTestIT {
         // Delete a Property
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.JSONV2)
+            .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE, office)
             .queryParam(Controllers.CATEGORY_ID, property.getCategory())
             .header(AUTH_HEADER, user.toHeaderValue())

--- a/cwms-data-api/src/test/java/cwms/cda/api/PropertyControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/PropertyControllerIT.java
@@ -1,0 +1,258 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.api;
+
+import cwms.cda.data.dto.Property;
+import cwms.cda.formatters.Formats;
+import cwms.cda.formatters.json.JsonV2;
+import fixtures.TestAccounts;
+import io.restassured.filter.log.LogDetail;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+
+import static cwms.cda.security.KeyAccessManager.AUTH_HEADER;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Tag("integration")
+final class PropertyControllerIT extends DataApiTestIT {
+
+
+
+    @Test
+    void test_get_create_delete() throws IOException {
+        InputStream resource = this.getClass().getResourceAsStream("/cwms/cda/api/property.json");
+        assertNotNull(resource);
+        String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
+        assertNotNull(json);
+        Property property = JsonV2.buildObjectMapper().readValue(json, Property.class);
+
+        // Structure of test:
+        // 1)Create the Property
+        // 2)Retrieve the Property and assert that it exists
+        // 3)Delete the Property
+        // 4)Retrieve the Property and assert that it does not exist
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+
+        //Create the property
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .body(json)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/properties/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED))
+        ;
+        String office = property.getOfficeId();
+        // Retrieve the property and assert that it exists
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, office)
+            .queryParam(Controllers.CATEGORY_ID, property.getCategory())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("properties/" + property.getName())
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("category", equalTo(property.getCategory()))
+            .body("office-id", equalTo(office))
+            .body("comment", equalTo(property.getComment()))
+            .body("value", equalTo(property.getValue()))
+            .body("name", equalTo(property.getName()))
+        ;
+
+        // Delete a Property
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, office)
+            .queryParam(Controllers.CATEGORY_ID, property.getCategory())
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("properties/" + property.getName())
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NO_CONTENT))
+        ;
+
+        // Retrieve a Property and assert that it does not exist
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, office)
+            .queryParam(Controllers.CATEGORY_ID, property.getCategory())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("properties/" + property.getName())
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("value", nullValue())
+        ;
+    }
+
+    @Test
+    void test_update_does_not_exist() throws IOException {
+        InputStream resource = this.getClass().getResourceAsStream("/cwms/cda/api/property_bogus.json");
+        assertNotNull(resource);
+        String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
+        assertNotNull(json);
+        Property property = JsonV2.buildObjectMapper().readValue(json, Property.class);
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+
+        //Create the property
+        given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.JSONV2)
+                .contentType(Formats.JSONV2)
+                .body(json)
+                .header(AUTH_HEADER, user.toHeaderValue())
+                .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .patch("/properties/" + property.getName())
+                .then()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .assertThat()
+                .statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+        ;
+    }
+
+    @Test
+    void test_delete_does_not_exist() throws IOException {
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+        // Delete a Property
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, user.getOperatingOffice())
+            .queryParam(Controllers.CATEGORY_ID, Instant.now().toEpochMilli())
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("properties/" + Instant.now().toEpochMilli())
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+        ;
+    }
+
+    @Test
+    void test_get_all() throws IOException {
+        InputStream resource = this.getClass().getResourceAsStream("/cwms/cda/api/property.json");
+        assertNotNull(resource);
+        String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
+        assertNotNull(json);
+        Property property = JsonV2.buildObjectMapper().readValue(json, Property.class);
+
+        // Structure of test:
+        // 1)Create the Property
+        // 2)Retrieve the Property with getAll and assert that it exists
+        // 3)Delete the Property
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+
+        //Create the property
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .body(json)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+        .post("/properties/")
+            .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED))
+        ;
+        String office = property.getOfficeId();
+        // Retrieve the property and assert that it exists
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE_MASK, office)
+            .queryParam(Controllers.CATEGORY_ID_MASK, property.getCategory())
+            .queryParam(Controllers.NAME_MASK, property.getName())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("properties/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("[0].category", equalTo(property.getCategory()))
+            .body("[0].office-id", equalTo(office))
+            .body("[0].comment", equalTo(property.getComment()))
+            .body("[0].value", equalTo(property.getValue()))
+            .body("[0].name", equalTo(property.getName()))
+        ;
+
+        // Delete a Property
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, office)
+            .queryParam(Controllers.CATEGORY_ID, property.getCategory())
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("properties/" + property.getName())
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NO_CONTENT))
+        ;
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/PropertyDaoTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/PropertyDaoTestIT.java
@@ -1,0 +1,71 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.data.dao;
+
+import cwms.cda.api.DataApiTestIT;
+import cwms.cda.data.dto.Property;
+import fixtures.CwmsDataApiSetupCallback;
+import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static cwms.cda.data.dao.DaoTest.getDslContext;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("integration")
+final class PropertyDaoTestIT  extends DataApiTestIT {
+
+    @Test
+    void testPropertyRoundTrip() throws Exception {
+        CwmsDatabaseContainer<?> databaseLink = CwmsDataApiSetupCallback.getDatabaseLink();
+        Property property = new Property.Builder()
+                .withCategory("PropertyDaoTestIT")
+                .withOfficeId(databaseLink.getOfficeId())
+                .withName("testPropertyRoundTrip")
+                .withValue("value")
+                .withComment("CDA integration test property")
+                .build();
+        databaseLink.connection(c -> {
+            DSLContext context = getDslContext(c, databaseLink.getOfficeId());
+            PropertyDao propertyDao = new PropertyDao(context);
+            propertyDao.storeProperty(property);
+            Property fromDb = propertyDao.retrieveProperty(property.getOfficeId(),
+                    property.getCategory(), property.getName(), null);
+            assertEquals(property, fromDb, "Property retrieved from database does not match original property");
+            Property fromDbMulti = propertyDao.retrieveProperties(databaseLink.getOfficeId(), property.getCategory(), property.getName())
+                    .get(0);
+            assertEquals(property, fromDbMulti, "Property multi retrieved from database does not match original property");
+            propertyDao.deleteProperty(databaseLink.getOfficeId(), property.getCategory(), property.getName());
+            Property deleted = propertyDao.retrieveProperty(property.getOfficeId(),
+                    property.getCategory(), property.getName(), null);
+            assertNull(deleted.getValue(), "Property has been deleted, value should be null");
+            List<Property> empty = propertyDao.retrieveProperties(databaseLink.getOfficeId(), property.getCategory(), property.getName());
+            assertTrue(empty.isEmpty(), "Property has been deleted, it should not show up in multi retrieve query");
+        });
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/PropertyTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/PropertyTest.java
@@ -24,11 +24,9 @@
 
 package cwms.cda.data.dto;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
-import cwms.cda.formatters.json.JsonV2;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 
@@ -99,9 +97,9 @@ final class PropertyTest {
                 .withValue("TestValue")
                 .withComment("TestComment")
                 .build();
-        String json = Formats.format(new ContentType(Formats.JSONV2), property);
-        ObjectMapper om = JsonV2.buildObjectMapper();
-        Property deserialized = om.readValue(json, Property.class);
+        ContentType contentType = new ContentType(Formats.JSON);
+        String json = Formats.format(contentType, property);
+        Property deserialized = Formats.parseContent(contentType, json, Property.class);
         assertEquals(property, deserialized, "Property deserialized from JSON doesn't equal original");
     }
 
@@ -114,11 +112,11 @@ final class PropertyTest {
                 .withValue("TestValue")
                 .withComment("TestComment")
                 .build();
-        ObjectMapper om = JsonV2.buildObjectMapper();
         InputStream resource = this.getClass().getResourceAsStream("/cwms/cda/data/dto/property.json");
         assertNotNull(resource);
         String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
-        Property deserialized = om.readValue(json, Property.class);
+        ContentType contentType = new ContentType(Formats.JSON);
+        Property deserialized = Formats.parseContent(contentType, json, Property.class);
         assertEquals(property, deserialized, "Property deserialized from JSON doesn't equal original");
     }
 }

--- a/cwms-data-api/src/test/resources/cwms/cda/api/property.json
+++ b/cwms-data-api/src/test/resources/cwms/cda/api/property.json
@@ -1,0 +1,7 @@
+{
+  "category": "PropertyControllerIT",
+  "name": "test_get_create_delete",
+  "office-id": "SPK",
+  "value": "test value",
+  "comment": "integration test"
+}

--- a/cwms-data-api/src/test/resources/cwms/cda/api/property_bogus.json
+++ b/cwms-data-api/src/test/resources/cwms/cda/api/property_bogus.json
@@ -1,0 +1,7 @@
+{
+  "category": "PropertyControllerIT",
+  "name": "test_update_does_not_exist",
+  "office-id": "SPK",
+  "value": "test value",
+  "comment": "integration test"
+}


### PR DESCRIPTION
Adds features to handle properties in the Content Data API (CDA). It adds a new PropertyController and PropertyDao to manage access and manipulation of properties in the database layer.

Java client: https://github.com/HydrologicEngineeringCenter/cwms-data-api-client/pull/167