### PR TITLE
Bugfix/content type time series

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
@@ -35,6 +35,7 @@ import static cwms.cda.api.Controllers.UNIT;
 import static cwms.cda.api.Controllers.UPDATE;
 import static cwms.cda.api.Controllers.VERSION;
 import static cwms.cda.api.Controllers.VERSION_DATE;
+import static cwms.cda.api.Controllers.addDeprecatedContentTypeWarning;
 import static cwms.cda.api.Controllers.queryParamAsClass;
 import static cwms.cda.api.Controllers.queryParamAsZdt;
 import static cwms.cda.api.Controllers.requiredParam;
@@ -440,7 +441,7 @@ public class TimeSeriesController implements CrudHandler {
                     name(TimeSeriesController.class.getName(), GET_ALL));
 
             String acceptHeader = ctx.header(Header.ACCEPT);
-            ContentType contentType = Formats.parseHeaderAndQueryParm(acceptHeader, format);
+            ContentType contentType = Formats.parseHeaderAndQueryParm(acceptHeader, format, TimeSeries.class);
 
             String results;
             String version = contentType.getParameters().get(VERSION);
@@ -502,6 +503,7 @@ public class TimeSeriesController implements CrudHandler {
                 ctx.status(HttpServletResponse.SC_OK);
                 ctx.result(results);
             }
+            addDeprecatedContentTypeWarning(ctx, contentType);
             requestResultSize.update(results.length());
         } catch (NotFoundException e) {
             CdaError re = new CdaError("Not found.");

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeSeries.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeSeries.java
@@ -30,8 +30,8 @@ import java.util.List;
 @JsonRootName("timeseries")
 @JsonPropertyOrder(alphabetic = true)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-@FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class)
-@FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class)
+@FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
+@FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
 public class TimeSeries extends CwmsDTOPaginated {
     public static final String ZONED_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ'['VV']'";
 


### PR DESCRIPTION
Added deprecated notification to the getAll method for TimeseriesController, and aliased `application/json` and `\*/\*` as aliases to `application/json;version=2`.  Added `application/xml` as an alias for `application/xml;version=2`.
Fixes #505 