### PR TITLE
update embankments to use locationidentifier

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/EmbankmentDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/EmbankmentDao.java
@@ -76,8 +76,7 @@ public class EmbankmentDao extends JooqDao<Embankment> {
                 .withUnitsId(embankment.getUNITS_ID())
                 .withUpstreamSideSlope(embankment.getUPSTREAM_SIDESLOPE())
                 .withDownstreamSideSlope(embankment.getDOWNSTREAM_SIDESLOPE())
-                .withProjectOfficeId(embankment.getPROJECT_LOCATION_REF().getOFFICE_ID())
-                .withProjectId(getLocationId(embankment.getPROJECT_LOCATION_REF()))
+                .withProjectIdentifier(getLocationIdentifier(embankment.getPROJECT_LOCATION_REF()))
                 .withUpstreamProtType(getLookupType(embankment.getUPSTREAM_PROT_TYPE()))
                 .withDownstreamProtType(getLookupType(embankment.getDOWNSTREAM_PROT_TYPE()))
                 .withLocation(getLocation(embankment.getEMBANKMENT_LOCATION()))
@@ -93,7 +92,7 @@ public class EmbankmentDao extends JooqDao<Embankment> {
         retval.setUNITS_ID(embankment.getUnitsId());
         retval.setUPSTREAM_SIDESLOPE(embankment.getUpstreamSideSlope());
         retval.setDOWNSTREAM_SIDESLOPE(embankment.getDownstreamSideSlope());
-        retval.setPROJECT_LOCATION_REF(getLocationRef(embankment.getProjectId(), embankment.getProjectOfficeId()));
+        retval.setPROJECT_LOCATION_REF(getLocationRef(embankment.getProjectIdentifier()));
         retval.setUPSTREAM_PROT_TYPE(getLookupType(embankment.getUpstreamProtType()));
         retval.setDOWNSTREAM_PROT_TYPE(getLookupType(embankment.getDownstreamProtType()));
         retval.setEMBANKMENT_LOCATION(getLocation(embankment.getLocation()));

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/LocationUtil.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/LocationUtil.java
@@ -26,6 +26,7 @@ package cwms.cda.data.dao.location.kind;
 
 import cwms.cda.api.enums.Nation;
 import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.LocationIdentifier;
 import cwms.cda.data.dto.LookupType;
 import usace.cwms.db.dao.util.OracleTypeMap;
 import usace.cwms.db.jooq.codegen.udt.records.LOCATION_OBJ_T;
@@ -39,6 +40,36 @@ public final class LocationUtil {
 
     private LocationUtil() {
         throw new AssertionError("Utility class");
+    }
+
+    public static LocationIdentifier getLocationIdentifier(LOCATION_REF_T ref) {
+        LocationIdentifier retval = null;
+        if(ref != null) {
+            String locationId = ref.getBASE_LOCATION_ID();
+            String sub = ref.getSUB_LOCATION_ID();
+            if (sub != null && !sub.isEmpty()) {
+                locationId += "-" + sub;
+            }
+            retval = new LocationIdentifier.Builder()
+                    .withLocationId(locationId)
+                    .withOfficeId(ref.getOFFICE_ID())
+                    .build();
+        }
+        return retval;
+    }
+
+    public static LOCATION_REF_T getLocationRef(LocationIdentifier locationIdentifier) {
+        LOCATION_REF_T retval = null;
+        if(locationIdentifier != null) {
+            retval = new LOCATION_REF_T();
+            String[] split = locationIdentifier.getLocationId().split("-");
+            retval.setBASE_LOCATION_ID(split[0]);
+            if(split.length > 1) {
+                retval.setSUB_LOCATION_ID(split[1]);
+            }
+            retval.setOFFICE_ID(locationIdentifier.getOfficeId());
+        }
+        return retval;
     }
 
     public static String getLocationId(LOCATION_REF_T ref) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/Embankment.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/Embankment.java
@@ -25,12 +25,14 @@
 package cwms.cda.data.dto.location.kind;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.LocationIdentifier;
 import cwms.cda.data.dto.LookupType;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -42,7 +44,10 @@ import java.util.Objects;
 @JsonDeserialize(builder = Embankment.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@JsonPropertyOrder({"projectIdentifier", "location"})
 public final class Embankment implements CwmsDTOBase {
+    private final LocationIdentifier projectIdentifier;
+    private final Location location;
     private final Double upstreamSideSlope;
     private final Double downstreamSideSlope;
     private final Double structureLength;
@@ -52,13 +57,9 @@ public final class Embankment implements CwmsDTOBase {
     private final LookupType downstreamProtType;
     private final LookupType upstreamProtType;
     private final LookupType structureType;
-    private final Location location;
-    private final String projectId;
-    private final String projectOfficeId;
 
     private Embankment(Builder builder) {
-        this.projectId = builder.projectId;
-        this.projectOfficeId = builder.projectOfficeId;
+        this.projectIdentifier = builder.projectIdentifier;
         this.location = builder.location;
         this.structureType = builder.structureType;
         this.upstreamProtType = builder.upstreamProtType;
@@ -111,12 +112,8 @@ public final class Embankment implements CwmsDTOBase {
         return location;
     }
 
-    public String getProjectId() {
-        return projectId;
-    }
-
-    public String getProjectOfficeId() {
-        return projectOfficeId;
+    public LocationIdentifier getProjectIdentifier() {
+        return projectIdentifier;
     }
 
     @Override
@@ -139,8 +136,7 @@ public final class Embankment implements CwmsDTOBase {
                 && Objects.equals(getUpstreamProtType(), that.getUpstreamProtType())
                 && Objects.equals(getStructureType(), that.getStructureType())
                 && Objects.equals(getLocation(), that.getLocation())
-                && Objects.equals(getProjectId(), that.getProjectId())
-                && Objects.equals(getProjectOfficeId(), that.getProjectOfficeId());
+                && Objects.equals(getProjectIdentifier(), that.getProjectIdentifier());
     }
 
     @Override
@@ -155,8 +151,7 @@ public final class Embankment implements CwmsDTOBase {
         result = 31 * result + Objects.hashCode(getUpstreamProtType());
         result = 31 * result + Objects.hashCode(getStructureType());
         result = 31 * result + Objects.hashCode(getLocation());
-        result = 31 * result + Objects.hashCode(getProjectId());
-        result = 31 * result + Objects.hashCode(getProjectOfficeId());
+        result = 31 * result + Objects.hashCode(getProjectIdentifier());
         return result;
     }
 
@@ -165,12 +160,11 @@ public final class Embankment implements CwmsDTOBase {
         if (this.location == null) {
             throw new FieldException("Location field can't be null");
         }
-        if (this.projectId == null) {
+        location.validate();
+        if (this.projectIdentifier == null) {
             throw new FieldException("Project location Id field can't be null");
         }
-        if (this.projectOfficeId == null) {
-            throw new FieldException("Project office Id field can't be null");
-        }
+        projectIdentifier.validate();
         if (this.structureType == null) {
             throw new FieldException("Structure type field can't be null");
         }
@@ -187,8 +181,7 @@ public final class Embankment implements CwmsDTOBase {
         private LookupType upstreamProtType;
         private LookupType structureType;
         private Location location;
-        private String projectId;
-        private String projectOfficeId;
+        private LocationIdentifier projectIdentifier;
 
         public Builder withUpstreamSideSlope(Double upstreamSideSlope) {
             this.upstreamSideSlope = upstreamSideSlope;
@@ -240,13 +233,8 @@ public final class Embankment implements CwmsDTOBase {
             return this;
         }
 
-        public Builder withProjectId(String projectId) {
-            this.projectId = projectId;
-            return this;
-        }
-
-        public Builder withProjectOfficeId(String projectOfficeId) {
-            this.projectOfficeId = projectOfficeId;
+        public Builder withProjectIdentifier(LocationIdentifier projectIdentifier) {
+            this.projectIdentifier = projectIdentifier;
             return this;
         }
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/EmbankmentControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/EmbankmentControllerIT.java
@@ -156,8 +156,8 @@ final class EmbankmentControllerIT extends DataApiTestIT {
             .body("upstream-prot-type", not(nullValue()))
             .body("structure-type", not(nullValue()))
             .body("location", not(nullValue()))
-            .body("project-id", equalTo(EMBANKMENT.getProjectId()))
-            .body("project-office-id", equalTo(EMBANKMENT.getProjectOfficeId()))
+            .body("project-identifier.location-id", equalTo(EMBANKMENT.getProjectIdentifier().getLocationId()))
+            .body("project-identifier.office-id", equalTo(EMBANKMENT.getProjectIdentifier().getOfficeId()))
         ;
 
         // Delete a Embankment
@@ -266,7 +266,7 @@ final class EmbankmentControllerIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL,true)
             .accept(Formats.JSON)
             .queryParam(Controllers.OFFICE, office)
-            .queryParam(Controllers.PROJECT_ID, EMBANKMENT.getProjectId())
+            .queryParam(Controllers.PROJECT_ID, EMBANKMENT.getProjectIdentifier().getLocationId())
         .when()
             .redirects().follow(true)
             .redirects().max(3)
@@ -285,8 +285,8 @@ final class EmbankmentControllerIT extends DataApiTestIT {
             .body("[0].upstream-prot-type", not(nullValue()))
             .body("[0].structure-type", not(nullValue()))
             .body("[0].location", not(nullValue()))
-            .body("[0].project-id", equalTo(EMBANKMENT.getProjectId()))
-            .body("[0].project-office-id", equalTo(EMBANKMENT.getProjectOfficeId()))
+            .body("project-identifier.location-id", equalTo(EMBANKMENT.getProjectIdentifier().getLocationId()))
+            .body("project-identifier.office-id", equalTo(EMBANKMENT.getProjectIdentifier().getOfficeId()))
         ;
 
         // Delete a Embankment

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/EmbankmentDaoTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/EmbankmentDaoTest.java
@@ -26,6 +26,7 @@ package cwms.cda.data.dao.location.kind;
 
 import cwms.cda.api.enums.Nation;
 import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.LocationIdentifier;
 import cwms.cda.data.dto.LookupType;
 import cwms.cda.data.dto.location.kind.Embankment;
 import org.junit.jupiter.api.Test;
@@ -49,8 +50,10 @@ final class EmbankmentDaoTest {
         return new Embankment.Builder()
                 .withLocation(buildTestLocation())
                 .withHeightMax(5.0)
-                .withProjectId("PROJECT")
-                .withProjectOfficeId("LRD")
+                .withProjectIdentifier(new LocationIdentifier.Builder()
+                        .withLocationId("PROJECT")
+                        .withOfficeId("LRD")
+                        .build())
                 .withStructureLength(10.0)
                 .withStructureType(new LookupType.Builder()
                         .withOfficeId("CWMS")

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/location/kind/EmbankmentTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/location/kind/EmbankmentTest.java
@@ -27,6 +27,7 @@ package cwms.cda.data.dto.location.kind;
 import cwms.cda.api.enums.Nation;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.LocationIdentifier;
 import cwms.cda.data.dto.LookupType;
 import cwms.cda.formatters.Formats;
 import org.apache.commons.io.IOUtils;
@@ -62,7 +63,6 @@ final class EmbankmentTest {
     @Test
     void testValidate() {
         Location location = buildTestLocation();
-        String projectId = "project";
         assertAll(() -> {
                     Embankment embankment = new Embankment.Builder().build();
                     assertThrows(FieldException.class, embankment::validate,
@@ -71,14 +71,6 @@ final class EmbankmentTest {
                     Embankment embankment = new Embankment.Builder().withLocation(location).build();
                     assertThrows(FieldException.class, embankment::validate,
                             "Expected validate() to throw FieldException because Project Id field can't be null, but it didn't");
-                }, () -> {
-                    Embankment embankment = new Embankment.Builder().withLocation(location).withProjectId(projectId).build();
-                    assertThrows(FieldException.class, embankment::validate,
-                            "Expected validate() to throw FieldException because Project Office Id field can't be null, but it didn't");
-                }, () -> {
-                    Embankment embankment = new Embankment.Builder().withLocation(location).withProjectId(projectId).withProjectOfficeId("SPK").build();
-                    assertThrows(FieldException.class, embankment::validate,
-                            "Expected validate() to throw FieldException because Structure type field can't be null, but it didn't");
                 }
         );
     }
@@ -87,8 +79,10 @@ final class EmbankmentTest {
         return new Embankment.Builder()
                 .withLocation(buildTestLocation())
                 .withHeightMax(5.0)
-                .withProjectId("PROJECT")
-                .withProjectOfficeId("LRD")
+                .withProjectIdentifier(new LocationIdentifier.Builder()
+                        .withOfficeId("LRD")
+                        .withLocationId("PROJECT")
+                        .build())
                 .withStructureLength(10.0)
                 .withStructureType(new LookupType.Builder()
                         .withOfficeId("CWMS")

--- a/cwms-data-api/src/test/resources/cwms/cda/data/dto/location/kind/embankment.json
+++ b/cwms-data-api/src/test/resources/cwms/cda/data/dto/location/kind/embankment.json
@@ -1,4 +1,8 @@
 {
+  "project-identifier": {
+    "location-id": "PROJECT",
+    "office-id": "LRD"
+  },
   "upstream-side-slope": 15.0,
   "downstream-side-slope": 90.0,
   "structure-length": 25.0,
@@ -45,7 +49,5 @@
     "elevation-units": "m",
     "bounding-office-id": "LRL",
     "nearest-city": "Davis"
-  },
-  "project-id": "PROJECT",
-  "project-office-id": "LRD"
+  }
 }


### PR DESCRIPTION
The changes enhance EmbankmentDao by updating project location and office reference handling. The use of a LocationIdentifier improves code clarity and maintainability. These improvements are also propagated to associated integration and unit tests