### PR TITLE
Handle unsupported format exception instead of just formattingexception

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -90,6 +90,7 @@ import cwms.cda.api.errors.RequiredQueryParameterException;
 import cwms.cda.data.dao.JooqDao;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.FormattingException;
+import cwms.cda.formatters.UnsupportedFormatException;
 import cwms.cda.security.CwmsAuthException;
 import cwms.cda.security.Role;
 import cwms.cda.spi.AccessManagers;
@@ -246,6 +247,11 @@ public class ApiServlet extends HttpServlet {
                     ctx.header("X-Content-Type-Options", "nosniff");
                     ctx.header("X-Frame-Options", "SAMEORIGIN");
                     ctx.header("X-XSS-Protection", "1; mode=block");
+                })
+                .exception(UnsupportedFormatException.class, (e, ctx) -> {
+                    CdaError re = new CdaError(e.getMessage());
+                    logger.atInfo().withCause(e).log(re.toString());
+                    ctx.status(HttpServletResponse.SC_NOT_ACCEPTABLE).json(re);
                 })
                 .exception(FormattingException.class, (fe, ctx) -> {
                     final CdaError re = new CdaError("Formatting error:" + fe.getMessage());

--- a/cwms-data-api/src/main/java/cwms/cda/api/BlobController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/BlobController.java
@@ -190,20 +190,6 @@ public class BlobController implements CrudHandler {
             boolean failIfExists = ctx.queryParamAsClass(FAIL_IF_EXISTS, Boolean.class).getOrDefault(true);
             ContentType contentType = Formats.parseHeader(formatHeader, Blob.class);
             Blob blob = Formats.parseContent(contentType, ctx.bodyAsInputStream(), Blob.class);
-
-            if (blob.getOfficeId() == null) {
-                throw new FormattingException("An officeId is required when creating a blob");
-            }
-
-            if (blob.getId() == null) {
-                throw new FormattingException("An Id is required when creating a blob");
-            }
-
-            if (blob.getValue() == null) {
-                throw new FormattingException("A non-empty value field is required when "
-                        + "creating a blob");
-            }
-
             BlobDao dao = new BlobDao(dsl);
             dao.create(blob, failIfExists, false);
             ctx.status(HttpCode.CREATED);

--- a/cwms-data-api/src/main/java/cwms/cda/api/ClobController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/ClobController.java
@@ -229,20 +229,6 @@ public class ClobController implements CrudHandler {
 
             ContentType contentType = Formats.parseHeader(formatHeader, Clob.class);
             Clob clob = Formats.parseContent(contentType, ctx.bodyAsInputStream(), Clob.class);
-
-            if (clob.getOfficeId() == null) {
-                throw new FormattingException("An officeId is required when creating a clob");
-            }
-
-            if (clob.getId() == null) {
-                throw new FormattingException("An Id is required when creating a clob");
-            }
-
-            if (clob.getValue() == null || clob.getValue().isEmpty()) {
-                throw new FormattingException("A non-empty value field is required when "
-                        + "creating a clob");
-            }
-
             ClobDao dao = new ClobDao(dsl);
             dao.create(clob, failIfExists);
             ctx.status(HttpCode.CREATED);

--- a/cwms-data-api/src/main/java/cwms/cda/api/EmbankmentController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/EmbankmentController.java
@@ -79,7 +79,8 @@ public final class EmbankmentController  implements CrudHandler {
             },
             responses = {
                     @OpenApiResponse(status = STATUS_200, content = {
-                            @OpenApiContent(isArray = true, type = Formats.JSONV1, from = Embankment.class)
+                            @OpenApiContent(isArray = true, type = Formats.JSONV1, from = Embankment.class),
+                            @OpenApiContent(isArray = true, type = Formats.JSON, from = Embankment.class)
                     })
             },
             description = "Returns matching CWMS Embankment Data for a Reservoir Project.",
@@ -116,7 +117,8 @@ public final class EmbankmentController  implements CrudHandler {
             responses = {
                     @OpenApiResponse(status = STATUS_200,
                             content = {
-                                    @OpenApiContent(type = Formats.JSONV1, from = Embankment.class)
+                                    @OpenApiContent(isArray = true, type = Formats.JSONV1, from = Embankment.class),
+                                    @OpenApiContent(isArray = true, type = Formats.JSON, from = Embankment.class)
                             })
             },
             description = "Returns CWMS Embankment Data",

--- a/cwms-data-api/src/main/java/cwms/cda/api/EmbankmentController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/EmbankmentController.java
@@ -79,7 +79,7 @@ public final class EmbankmentController  implements CrudHandler {
             },
             responses = {
                     @OpenApiResponse(status = STATUS_200, content = {
-                            @OpenApiContent(isArray = true, type = Formats.JSON, from = Embankment.class)
+                            @OpenApiContent(isArray = true, type = Formats.JSONV1, from = Embankment.class)
                     })
             },
             description = "Returns matching CWMS Embankment Data for a Reservoir Project.",
@@ -94,8 +94,8 @@ public final class EmbankmentController  implements CrudHandler {
             EmbankmentDao dao = new EmbankmentDao(dsl);
             List<Embankment> embankments = dao.retrieveEmbankments(projectId, office);
             String formatHeader = ctx.header(Header.ACCEPT) != null ? ctx.header(Header.ACCEPT) :
-                    Formats.JSON;
-            ContentType contentType = Formats.parseHeader(formatHeader);
+                    Formats.JSONV1;
+            ContentType contentType = Formats.parseHeader(formatHeader, Embankment.class);
             ctx.contentType(contentType.toString());
             String serialized = Formats.format(contentType, embankments, Embankment.class);
             ctx.result(serialized);
@@ -116,7 +116,7 @@ public final class EmbankmentController  implements CrudHandler {
             responses = {
                     @OpenApiResponse(status = STATUS_200,
                             content = {
-                                    @OpenApiContent(type = Formats.JSON, from = Embankment.class)
+                                    @OpenApiContent(type = Formats.JSONV1, from = Embankment.class)
                             })
             },
             description = "Returns CWMS Embankment Data",
@@ -130,8 +130,8 @@ public final class EmbankmentController  implements CrudHandler {
             EmbankmentDao dao = new EmbankmentDao(dsl);
             Embankment embankment = dao.retrieveEmbankment(name, office);
             String header = ctx.header(Header.ACCEPT);
-            String formatHeader = header != null ? header : Formats.JSON;
-            ContentType contentType = Formats.parseHeader(formatHeader);
+            String formatHeader = header != null ? header : Formats.JSONV1;
+            ContentType contentType = Formats.parseHeader(formatHeader, Embankment.class);
             ctx.contentType(contentType.toString());
             String serialized = Formats.format(contentType, embankment);
             ctx.result(serialized);
@@ -143,7 +143,7 @@ public final class EmbankmentController  implements CrudHandler {
     @OpenApi(
             requestBody = @OpenApiRequestBody(
                     content = {
-                            @OpenApiContent(from = Embankment.class, type = Formats.JSON)
+                            @OpenApiContent(from = Embankment.class, type = Formats.JSONV1)
                     },
                     required = true),
             queryParams = {
@@ -161,8 +161,8 @@ public final class EmbankmentController  implements CrudHandler {
     public void create(Context ctx) {
         try (Timer.Context ignored = markAndTime(CREATE)) {
             String acceptHeader = ctx.req.getContentType();
-            String formatHeader = acceptHeader != null ? acceptHeader : Formats.JSON;
-            ContentType contentType = Formats.parseHeader(formatHeader);
+            String formatHeader = acceptHeader != null ? acceptHeader : Formats.JSONV1;
+            ContentType contentType = Formats.parseHeader(formatHeader, Embankment.class);
             Embankment embankment = Formats.parseContent(contentType, ctx.body(), Embankment.class);
             embankment.validate();
             boolean failIfExists = ctx.queryParamAsClass(FAIL_IF_EXISTS, Boolean.class).getOrDefault(true);

--- a/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
@@ -76,6 +76,7 @@ import cwms.cda.data.dto.SeasonalValueBean;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.FormattingException;
+import cwms.cda.formatters.UnsupportedFormatException;
 import cwms.cda.helpers.DateUtils;
 import io.javalin.apibuilder.CrudHandler;
 import io.javalin.core.util.Header;
@@ -558,7 +559,7 @@ public class LevelsController implements CrudHandler {
         } else if (Formats.JSON.equals(format)) {
             om = new ObjectMapper();
         } else {
-            throw new FormattingException("Format is not currently supported for Levels");
+            throw new UnsupportedFormatException("Format is not currently supported for Levels: " + format);
         }
         om.registerModule(new JavaTimeModule());
         return om;

--- a/cwms-data-api/src/main/java/cwms/cda/api/LocationController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LocationController.java
@@ -64,6 +64,7 @@ import cwms.cda.data.dto.Location;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.FormattingException;
+import cwms.cda.formatters.UnsupportedFormatException;
 import io.javalin.apibuilder.CrudHandler;
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
@@ -454,7 +455,7 @@ public class LocationController implements CrudHandler {
         } else if (Formats.JSON.equals(format) || (Formats.JSONV2).equals(format)) {
             om = new ObjectMapper();
         } else {
-            throw new FormattingException("Format is not currently supported for Locations");
+            throw new UnsupportedFormatException("Format is not currently supported for Locations: " + format);
         }
         om.registerModule(new JavaTimeModule());
         return om;

--- a/cwms-data-api/src/main/java/cwms/cda/api/ProjectController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/ProjectController.java
@@ -122,11 +122,7 @@ public class ProjectController implements CrudHandler {
 
     private static @NotNull ContentType getContentType(Context ctx) {
         String formatHeader = ctx.header(Header.ACCEPT) != null ? ctx.header(Header.ACCEPT) : Formats.JSON;
-        ContentType contentType = Formats.parseHeader(formatHeader);
-        if (contentType == null) {
-            throw new FormattingException("Format header could not be parsed");
-        }
-        return contentType;
+        return Formats.parseHeader(formatHeader);
     }
 
     @OpenApi(
@@ -197,9 +193,6 @@ public class ProjectController implements CrudHandler {
             String reqContentType = ctx.req.getContentType();
             String formatHeader = reqContentType != null ? reqContentType : Formats.JSON;
             ContentType contentType = Formats.parseHeader(formatHeader);
-            if (contentType == null) {
-                throw new FormattingException("Format header could not be parsed");
-            }
             Project project = Formats.parseContent(contentType, ctx.body(), Project.class);
             project.validate();
 
@@ -231,9 +224,6 @@ public class ProjectController implements CrudHandler {
             String reqContentType = ctx.req.getContentType();
             String formatHeader = reqContentType != null ? reqContentType : Formats.JSON;
             ContentType contentType = Formats.parseHeader(formatHeader);
-            if (contentType == null) {
-                throw new FormattingException("Format header could not be parsed");
-            }
             Project project = Formats.parseContent(contentType, ctx.body(), Project.class);
             project.validate();
             DSLContext dsl = getDslContext(ctx);

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Blob.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Blob.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
+import cwms.cda.formatters.FormattingException;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
 import cwms.cda.formatters.xml.XMLv2;
@@ -59,5 +60,15 @@ public class Blob extends CwmsDTO
 
 	@Override
 	public void validate() throws FieldException {
+		if (getOfficeId() == null) {
+			throw new FieldException("An officeId is required when creating a blob");
+		}
+		if (getId() == null) {
+			throw new FieldException("An Id is required when creating a blob");
+		}
+		if (getValue() == null) {
+			throw new FieldException("A non-empty value field is required when "
+					+ "creating a blob");
+		}
 	}
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Clob.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Clob.java
@@ -9,7 +9,6 @@ import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
 import cwms.cda.formatters.json.JsonV2;
-import cwms.cda.formatters.xml.XMLv1;
 import cwms.cda.formatters.xml.XMLv2;
 
 
@@ -57,5 +56,15 @@ public class Clob extends CwmsDTO {
 
     @Override
     public void validate() throws FieldException {
+        if (getOfficeId() == null) {
+            throw new FieldException("An officeId is required when creating a clob");
+        }
+        if (getId() == null) {
+            throw new FieldException("An Id is required when creating a clob");
+        }
+        if (getValue() == null || getValue().isEmpty()) {
+            throw new FieldException("A non-empty value field is required when "
+                    + "creating a clob");
+        }
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
@@ -27,6 +27,7 @@ package cwms.cda.formatters;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.formatters.annotations.FormattableWith;
 
+import javax.validation.constraints.NotNull;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -303,7 +304,7 @@ public class Formats {
      * @deprecated Use overloaded parseHeader that takes in a class to utilize the format aliasing.
      */
     @Deprecated
-    public static ContentType parseHeader(String header) {
+    public static @NotNull ContentType parseHeader(String header) {
         return parseHeader(header, null);
     }
 
@@ -315,7 +316,7 @@ public class Formats {
      * @return an appropriate standard mimetype for lookup
      * @throws FormattingException if the header can't be identified as a mimetype
      */
-    public static ContentType parseHeader(String header, Class<? extends CwmsDTOBase> klass) {
+    public static @NotNull ContentType parseHeader(String header, Class<? extends CwmsDTOBase> klass) {
         ContentTypeAliasMap aliasMap = ContentTypeAliasMap.empty();
         if (klass != null) {
             aliasMap = ContentTypeAliasMap.forDtoClass(klass);

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
@@ -119,7 +119,7 @@ public class Formats {
         } else {
             String message = String.format("No Format for this content-type and data-type : (%s, %s)",
                     type.toString(), toFormat.getClass().getName());
-            throw new FormattingException(message);
+            throw new UnsupportedFormatException(message);
         }
 
     }
@@ -137,7 +137,7 @@ public class Formats {
         } else {
             String message = String.format("No Format for this content-type and data type : (%s, %s)",
                     type.toString(), rootType.getName());
-            throw new FormattingException(message);
+            throw new UnsupportedFormatException(message);
         }
     }
 
@@ -151,7 +151,7 @@ public class Formats {
         } else {
             String message = String.format("No Format for this content-type and data type : (%s, %s)",
                     type.toString(), rootType.getName());
-            throw new FormattingException(message);
+            throw new UnsupportedFormatException(message);
         }
     }
 
@@ -165,7 +165,7 @@ public class Formats {
         } else {
             String message = String.format("No Format for this content-type and data type : (%s, %s)",
                     type.toString(), rootType.getName());
-            throw new FormattingException(message);
+            throw new UnsupportedFormatException(message);
         }
     }
 
@@ -249,7 +249,7 @@ public class Formats {
                 // The older format= query parameters don't give us the option to supply a
                 // version the
                 // way that the accept header does.
-                throw new FormattingException("Accept header and query parameter are both "
+                throw new UnsupportedFormatException("Accept header and query parameter are both "
                         + "present, this is not supported.");
             }
 
@@ -257,17 +257,17 @@ public class Formats {
             if (ct != null) {
                 return ct;
             } else {
-                throw new FormattingException("content-type " + queryParam + " is not implemented");
+                throw new UnsupportedFormatException("content-type " + queryParam + " is not implemented");
             }
         } else if (header == null) {
-            throw new FormattingException("no content type or format specified");
+            throw new UnsupportedFormatException("no content type or format specified");
         } else {
             ContentType ct = parseHeader(header, klass);
             if (ct != null) {
                 return ct;
             }
         }
-        throw new FormattingException("Content-Type " + header + " is not available");
+        throw new UnsupportedFormatException("Content-Type " + header + " is not available");
     }
 
     public static ContentType parseQueryParam(String queryParam, Class<? extends CwmsDTOBase> klass)
@@ -349,6 +349,6 @@ public class Formats {
                 return new ContentType(Formats.JSON);
             }
         }
-        throw new FormattingException("Format header " + header + " could not be parsed");
+        throw new UnsupportedFormatException("Format header " + header + " could not be parsed");
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/UnsupportedFormatException.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/UnsupportedFormatException.java
@@ -1,0 +1,8 @@
+package cwms.cda.formatters;
+
+public class UnsupportedFormatException extends FormattingException {
+
+    public UnsupportedFormatException(String message){
+        super(message);
+    }
+}


### PR DESCRIPTION
FormattingException reports an error code 501 to the user, but 406 is more appropriate given it is the client's request that is in error. Updated embankment test to verify various format responses. Introduced new UnsupportedFormatException class to differentiate from a general FormattingException. Embankment serialization and API endpoints now support JSONv1 and default formats.