### PR TITLE
Add ability to override default context in Gradle run task

### DIFF
--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -229,14 +229,16 @@ task run(type: JavaExec) {
     systemProperties += project.properties.findAll { k, v -> k.startsWith("RADAR") }
     systemProperties += project.properties.findAll { k, v -> k.startsWith("CDA") }
 
-    args "$buildDir/tomcat", "$buildDir/libs/${project.name}-${project.version}.war", "/spk-data"
+    def context = project.findProperty("cda.war.context") ?: "spk-data"
+
+    args "$buildDir/tomcat", "$buildDir/libs/${project.name}-${project.version}.war", context
     jvmArgs += "-Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager"
     jvmArgs += "-Djava.util.logging.config.file=$projectDir/logging.properties"
     jvmArgs += "-DTOMCAT_RESOURCES=$buildDir/tomcat/conf/context.xml"
     jvmArgs += "-Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"
     jvmArgs += "-Dcatalina.base=$buildDir/tomcat"
-    jvmArgs += "-DwarContext=/spk-data"
-    // If you have the docker-compose environment up and are trying to run 
+    jvmArgs += "-DwarContext=/" + context
+    // If you have the docker-compose environment up and are trying to run
     // CDA from run to debug uncomment the following lines.
     //jvmArgs += "-Dcwms.dataapi.access.providers=KeyAccessManager,CwmsAccessManager,OpenID"
     //jvmArgs += "-Dcwms.dataapi.access.openid.wellKnownUrl=https://auth.test:8444/auth/realms/cwms/.well-known/openid-configuration"

--- a/gradle.properties.example
+++ b/gradle.properties.example
@@ -8,6 +8,9 @@ CDA_JDBC_USERNAME=username
 CDA_JDBC_PASSWORD=password
 CDA_LISTEN_PORT=7000
 
+# Allows an override of the default `spk-data` context used in the gradle run task
+cda.war.context=cwms-data
+
 # If you have an existing oracle instance the integration tests can skip the 
 # database setup and schema install process saving time.
 # NOTE: the integration tests ASSUME, and MUST be able to ASSUME, that it has


### PR DESCRIPTION
allow the developer to override the default context in the Gradle run task. an example property for the override is added to `gradle.properties.example`.