### PR TITLE
Removing the outlet characteristic-ref

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/Outlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/Outlet.java
@@ -35,29 +35,17 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 public class Outlet extends ProjectStructure {
-    private final CwmsId characteristicsId;
 
     private Outlet(Builder builder) {
         super(builder.projectId, builder.location);
-        characteristicsId = builder.characteristicsId;
-    }
-
-    public CwmsId getCharacteristicsId() {
-        return characteristicsId;
     }
 
     public static final class Builder {
-        private CwmsId characteristicsId;
         private CwmsId projectId;
         private Location location;
 
         public Outlet build() {
             return new Outlet(this);
-        }
-
-        public Builder withCharacteristicsId(CwmsId characteristicsId) {
-            this.characteristicsId = characteristicsId;
-            return this;
         }
 
         public Builder withProjectId(CwmsId projectIdentifier) {

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/location/kind/OutletTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/location/kind/OutletTest.java
@@ -47,7 +47,6 @@ class OutletTest {
         String json = Formats.format(contentType, outlet);
 
         Outlet parsedOutlet = Formats.parseContent(contentType, json, Outlet.class);
-        CwmsIdTest.assertSame(outlet.getCharacteristicsId(), parsedOutlet.getCharacteristicsId());
         assertEquals(outlet.getLocation(), parsedOutlet.getLocation(), "Locations do not match");
         CwmsIdTest.assertSame(outlet.getProjectId(), parsedOutlet.getProjectId());
     }
@@ -59,7 +58,6 @@ class OutletTest {
         String json = Formats.format(contentType, outlet);
 
         Outlet parsedOutlet = Formats.parseContent(contentType, json, Outlet.class);
-        CwmsIdTest.assertSame(outlet.getCharacteristicsId(), parsedOutlet.getCharacteristicsId());
         assertEquals(outlet.getLocation(), parsedOutlet.getLocation(), "Locations do not match");
         CwmsIdTest.assertSame(outlet.getProjectId(), parsedOutlet.getProjectId());
     }
@@ -72,8 +70,6 @@ class OutletTest {
         assertNotNull(resource);
         String serialized = IOUtils.toString(resource, StandardCharsets.UTF_8);
         Outlet deserialized = Formats.parseContent(contentType, serialized, Outlet.class);
-        CwmsIdTest.assertSame(outlet.getCharacteristicsId(), deserialized.getCharacteristicsId(),
-                "characteristic-ref");
         assertEquals(outlet.getLocation(), deserialized.getLocation(), "Locations do not match");
         CwmsIdTest.assertSame(outlet.getProjectId(), deserialized.getProjectId(), "project-id");
     }
@@ -86,8 +82,6 @@ class OutletTest {
         assertNotNull(resource);
         String serialized = IOUtils.toString(resource, StandardCharsets.UTF_8);
         Outlet deserialized = Formats.parseContent(contentType, serialized, Outlet.class);
-        CwmsIdTest.assertSame(outlet.getCharacteristicsId(), deserialized.getCharacteristicsId(),
-                              "characteristic-ref");
         assertEquals(outlet.getLocation(), deserialized.getLocation(), "Locations do not match");
         CwmsIdTest.assertSame(outlet.getProjectId(), deserialized.getProjectId(), "project-id");
     }
@@ -106,14 +100,9 @@ class OutletTest {
                 .withHorizontalDatum("NAD84")
                 .withVerticalDatum("NAVD88")
                 .build();
-        CwmsId charRef = new CwmsId.Builder()
-                .withName("Ogee Weir Depth")
-                .withOfficeId(SPK)
-                .build();
 
         return new Outlet.Builder()
                 .withProjectId(identifier)
-                .withCharacteristicsId(charRef)
                 .withLocation(loc)
                 .build();
     }

--- a/cwms-data-api/src/test/resources/cwms/cda/data/dto/location/kind/base_outlet.json
+++ b/cwms-data-api/src/test/resources/cwms/cda/data/dto/location/kind/base_outlet.json
@@ -14,9 +14,5 @@
     "location-kind": "Outlet",
     "horizontal-datum": "NAD84",
     "vertical-datum": "NAVD88"
-  },
-  "characteristics-id": {
-    "office-id": "SPK",
-    "name": "Ogee Weir Depth"
   }
 }

--- a/cwms-data-api/src/test/resources/cwms/cda/data/dto/location/kind/outlet.json
+++ b/cwms-data-api/src/test/resources/cwms/cda/data/dto/location/kind/outlet.json
@@ -14,9 +14,5 @@
     "location-kind": "Outlet",
     "horizontal-datum": "NAD84",
     "vertical-datum": "NAVD88"
-  },
-  "characteristics-id": {
-    "office-id": "SPK",
-    "name": "Ogee Weir Depth"
   }
 }


### PR DESCRIPTION
This is being removed, as the field is not used in the database, and it was determined by Ryan M., Peter M., and Adam K. to be REGI application specific code.