### PR TITLE
cleanup inheritance structure of CwmsDTO vs CwmsDTOBase

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/RatingController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/RatingController.java
@@ -488,10 +488,9 @@ public class RatingController implements CrudHandler {
     }
 
     /**
-     * This is a marker interface only used by <code>Formats</code> to support <code>ContentType</code> aliases.
-     * There's no reason to implement this interface.
+     * This is a marker class only used by <code>Formats</code> to support <code>ContentType</code> aliases.
      */
     @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.JSON})
     @FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML, Formats.DEFAULT})
-    private interface RatingAliasMarker extends CwmsDTOBase { }
+    private static final class RatingAliasMarker extends CwmsDTOBase { }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/PoolDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/PoolDao.java
@@ -18,7 +18,6 @@ import org.jooq.exception.TooManyRowsException;
 import org.jooq.impl.DSL;
 
 import usace.cwms.db.dao.ifc.pool.PoolNameType;
-import usace.cwms.db.dao.ifc.pool.PoolType;
 import usace.cwms.db.dao.util.OracleTypeMap;
 import usace.cwms.db.jooq.codegen.packages.CWMS_POOL_PACKAGE;
 import usace.cwms.db.jooq.codegen.packages.cwms_pool.RETRIEVE_POOL;
@@ -26,7 +25,7 @@ import usace.cwms.db.jooq.codegen.tables.AV_POOL;
 
 import static java.util.stream.Collectors.toList;
 
-public class PoolDao extends JooqDao<PoolType> {
+public class PoolDao extends JooqDao<Pool> {
 	private static Logger logger = Logger.getLogger(PoolDao.class.getName());
 
 	public PoolDao(DSLContext dsl) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/TurbineDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/TurbineDao.java
@@ -149,7 +149,7 @@ public class TurbineDao extends JooqDao<Turbine> {
             return;
         }
         connection(dsl, conn -> {
-            setOffice(conn, physicalStructureChange.get(0).getOfficeId());
+            setOffice(conn, physicalStructureChange.get(0).getProjectId().getOfficeId());
             TURBINE_CHANGE_TAB_T changes = new TURBINE_CHANGE_TAB_T();
             physicalStructureChange.stream()
                 .map(TurbineDao::map)

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedLocation.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedLocation.java
@@ -24,9 +24,7 @@
 
 package cwms.cda.data.dto;
 
-import cwms.cda.api.errors.FieldException;
-
-public class AssignedLocation implements CwmsDTOBase
+public class AssignedLocation extends CwmsDTOBase
 {
 	private String locationId;
 	private String officeId;
@@ -73,10 +71,5 @@ public class AssignedLocation implements CwmsDTOBase
 	public String getRefLocationId()
 	{
 		return refLocationId;
-	}
-
-	@Override
-	public void validate() throws FieldException {
-
 	}
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
@@ -24,10 +24,9 @@
 
 package cwms.cda.data.dto;
 
-import cwms.cda.api.errors.FieldException;
 import java.math.BigDecimal;
 
-public class AssignedTimeSeries implements CwmsDTOBase {
+public class AssignedTimeSeries extends CwmsDTOBase {
     private String officeId;
     private String timeseriesId;
     private BigDecimal tsCode;
@@ -72,10 +71,5 @@ public class AssignedTimeSeries implements CwmsDTOBase {
 
     public Integer getAttribute() {
         return attribute;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Blob.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Blob.java
@@ -15,6 +15,7 @@ public class Blob extends CwmsDTO
 	private String id;
 	private String description;
 	private String mediaTypeId;
+	@JsonProperty(required=true)
 	private byte[] value;
 
 	private Blob() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Blob.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Blob.java
@@ -3,12 +3,9 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
-import cwms.cda.formatters.FormattingException;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
-import cwms.cda.formatters.xml.XMLv2;
 
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
@@ -58,11 +55,4 @@ public class Blob extends CwmsDTO
         return getOfficeId() + "/" + id + ";description=" + description;
 	}
 
-	@Override
-	protected void validateInternal(CwmsDTOValidator validator) {
-		super.validateInternal(validator);
-		validator.required(getOfficeId(), "office-id");
-		validator.required(getId(), "id");
-		validator.required(getValue(), "value");
-	}
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Blobs.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Blobs.java
@@ -3,7 +3,6 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
@@ -66,10 +65,5 @@ public class Blobs extends CwmsDTOPaginated {
             return this;
         }
 
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        // always valid even if just empty list.
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Catalog.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Catalog.java
@@ -3,7 +3,6 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dao.CatalogRequestParameters;
 import cwms.cda.data.dto.catalog.CatalogEntry;
 import cwms.cda.data.dto.catalog.LocationCatalogEntry;
@@ -64,11 +63,6 @@ public class Catalog extends CwmsDTOPaginated {
      */
     public List<? extends CatalogEntry> getEntries() {
         return entries;
-    }
-
-    @Override
-    public void validate() throws FieldException{
-        // catalogs are never accepted as user input
     }
 
     public static class CatalogPage {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Clobs.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Clobs.java
@@ -3,7 +3,6 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
@@ -71,10 +70,4 @@ public class Clobs extends CwmsDTOPaginated {
             return this;
         }
     }
-
-    @Override
-    public void validate() throws FieldException {
-        // Clobs always contains a valid array even empty.
-    }
-
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/County.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/County.java
@@ -24,26 +24,26 @@
 
 package cwms.cda.data.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
-import cwms.cda.api.errors.RequiredFieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.ArrayList;
-
 @Schema(description = "A representation of a county")
 @JsonRootName("county")
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class County implements CwmsDTOBase {
+public class County extends CwmsDTOBase {
 
+    @JsonProperty(required = true)
     private String name;
+    @JsonProperty(required = true)
     private String countyId;
+    @JsonProperty(required = true)
     private String stateInitial;
 
     public County() {
@@ -65,22 +65,5 @@ public class County implements CwmsDTOBase {
 
     public String getStateInitial() {
         return stateInitial;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        ArrayList<String> missingFields = new ArrayList<>();
-        if (this.getName() == null) {
-            missingFields.add("Name");
-        }
-        if (this.getCountyId() == null) {
-            missingFields.add("County ID");
-        }
-        if (this.getStateInitial() == null) {
-            missingFields.add("State Initial");
-        }
-        if (!missingFields.isEmpty()) {
-            throw new RequiredFieldException(missingFields);
-        }
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTO.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTO.java
@@ -3,7 +3,6 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -12,8 +11,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
  * correctly.
  */
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public abstract class CwmsDTO implements CwmsDTOBase {
+public abstract class CwmsDTO extends CwmsDTOBase {
     @Schema(description = "Owning office of object.")
+    @JsonProperty(required=true)
     protected final String officeId; // ALL DTOs require an office field
 
     protected CwmsDTO(String office) {
@@ -22,18 +22,5 @@ public abstract class CwmsDTO implements CwmsDTOBase {
 
     public String getOfficeId() {
         return officeId;
-    }
-
-    @Override
-    public final void validate() throws FieldException {
-        CwmsDTOValidator validator = new CwmsDTOValidator();
-        validateInternal(validator);
-        validator.validateRequiredFields(this);
-        validator.validate();
-    }
-
-    protected void validateInternal(CwmsDTOValidator validator) {
-        //No-op for compatibility
-        //Eventually make validate() final and this method abstract
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOBase.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOBase.java
@@ -9,7 +9,6 @@ public abstract class CwmsDTOBase {
 
     public final void validate() throws FieldException {
         CwmsDTOValidator validator = new CwmsDTOValidator();
-        validator.validateRequiredFields(this);
         validateInternal(validator);
         validator.validate();
     }
@@ -19,6 +18,6 @@ public abstract class CwmsDTOBase {
      * @param validator validator that will aggregate all validation errors
      */
     protected void validateInternal(CwmsDTOValidator validator) {
-
+        validator.validateRequiredFields(this);
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOBase.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOBase.java
@@ -1,12 +1,24 @@
 package cwms.cda.data.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import cwms.cda.api.errors.FieldException;
 /*
  * Suitable base for objects not owned by an office, like a list of locations.
  * Or parameters, or the list of offices themselves.
  */
-public interface CwmsDTOBase {
-    public  void validate() throws FieldException; // additional validation logic.
+public abstract class CwmsDTOBase {
+
+    public final void validate() throws FieldException {
+        CwmsDTOValidator validator = new CwmsDTOValidator();
+        validator.validateRequiredFields(this);
+        validateInternal(validator);
+        validator.validate();
+    }
+
+    /**
+     * This method can be overridden to provide additional validation logic
+     * @param validator validator that will aggregate all validation errors
+     */
+    protected void validateInternal(CwmsDTOValidator validator) {
+
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOPaginated.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOPaginated.java
@@ -28,7 +28,7 @@ import kotlin.jvm.functions.Function1;
  */
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 @JsonPropertyOrder(alphabetic = true)
-public abstract class CwmsDTOPaginated implements CwmsDTOBase {
+public abstract class CwmsDTOPaginated extends CwmsDTOBase {
     private static final Logger logger = Logger.getLogger(CwmsDTOPaginated.class.getName());
 
     @Schema(

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOValidator.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/CwmsDTOValidator.java
@@ -39,7 +39,7 @@ import java.util.concurrent.Callable;
 
 
 /**
- * This class is used to validate the fields of a CwmsDTO object.
+ * This class is used to validate the fields of a CwmsDTOBase object.
  */
 public final class CwmsDTOValidator {
 
@@ -52,7 +52,7 @@ public final class CwmsDTOValidator {
     /**
      * Validates the presence of a required field in a given object or DTO.
      * Adds the field name to a set of missing fields if the value is null.
-     * If the value is an instance of CwmsDTO, it validates the CwmsDTO as well.
+     * If the value is an instance of CwmsDTOBase, it validates the CwmsDTOBase as well.
      *
      * @param value     the value of the field to be checked
      * @param fieldName the name of the field to be checked
@@ -60,27 +60,27 @@ public final class CwmsDTOValidator {
     public void required(Object value, String fieldName) {
         if (value == null) {
             missingFields.add(fieldName);
-        } else if (value instanceof CwmsDTO) {
-            ((CwmsDTO) value).validateInternal(this);
+        } else if (value instanceof CwmsDTOBase) {
+            ((CwmsDTOBase) value).validateInternal(this);
         }
     }
 
-    public void validateRequiredFields(CwmsDTO cwmsDTO) {
-        Class<? extends CwmsDTO> type = cwmsDTO.getClass();
-        while (CwmsDTO.class.isAssignableFrom(type)) {
+    public void validateRequiredFields(CwmsDTOBase cwmsDTO) {
+        Class<? extends CwmsDTOBase> type = cwmsDTO.getClass();
+        while (CwmsDTOBase.class.isAssignableFrom(type)) {
             validateFieldsInClass(cwmsDTO, type);
-            type = (Class<? extends CwmsDTO>) type.getSuperclass();
+            type = (Class<? extends CwmsDTOBase>) type.getSuperclass();
         }
     }
 
-    private void validateFieldsInClass(CwmsDTO cwmsDTO, Class<? extends CwmsDTO> type) {
+    private void validateFieldsInClass(CwmsDTOBase cwmsDTO, Class<? extends CwmsDTOBase> type) {
         Field[] fields = type.getDeclaredFields();
         try {
             for (Field field : fields) {
                 JsonProperty annotation = field.getAnnotation(JsonProperty.class);
                 if (annotation != null && annotation.required()) {
                     boolean accessible = field.isAccessible();
-                    synchronized (CwmsDTO.class) {
+                    synchronized (CwmsDTOBase.class) {
                         try {
                             if (!accessible) {
                                 field.setAccessible(true);
@@ -88,11 +88,9 @@ public final class CwmsDTOValidator {
                             Object value = field.get(cwmsDTO);
                             if (value == null) {
                                 missingFields.add(field.getName());
-                            } else if (value instanceof CwmsDTO) {
-                                ((CwmsDTO) value).validateInternal(this);
-                                validateRequiredFields((CwmsDTO) value);
                             } else if (value instanceof CwmsDTOBase) {
-                                ((CwmsDTOBase) value).validate();
+                                ((CwmsDTOBase) value).validateInternal(this);
+                                validateRequiredFields((CwmsDTOBase) value);
                             }
                         } finally {
                             if (!accessible) {
@@ -107,7 +105,7 @@ public final class CwmsDTOValidator {
         }
     }
 
-    public void validateCollection(Collection<? extends CwmsDTO> collection) {
+    public void validateCollection(Collection<? extends CwmsDTOBase> collection) {
         if (collection != null) {
             collection.forEach(c -> c.validateInternal(this));
         }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/LocationLevels.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/LocationLevels.java
@@ -3,7 +3,6 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
@@ -70,12 +69,4 @@ public class LocationLevels extends CwmsDTOPaginated {
             return this;
         }
     }
-
-
-    @Override
-    public void validate() throws FieldException {
-
-
-    }
-
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/LookupType.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/LookupType.java
@@ -25,23 +25,23 @@
 package cwms.cda.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
-
-import java.util.Objects;
 
 @FormattableWith(contentType = Formats.JSON, formatter = JsonV1.class)
 @JsonDeserialize(builder = LookupType.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class LookupType implements CwmsDTOBase {
+public final class LookupType extends CwmsDTOBase {
 
+    @JsonProperty(required = true)
     private final String officeId;
+    @JsonProperty(required = true)
     private final String displayValue;
     private final String tooltip;
     private final boolean active;
@@ -51,16 +51,6 @@ public final class LookupType implements CwmsDTOBase {
         this.displayValue = builder.displayValue;
         this.tooltip = builder.tooltip;
         this.active = builder.active;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        if (this.officeId == null || this.officeId.trim().isEmpty()) {
-            throw new FieldException("The 'officeId' field of a LookupType cannot be null or empty.");
-        }
-        if (this.displayValue == null || this.displayValue.trim().isEmpty()) {
-            throw new FieldException("The 'displayValue' field of a LookupType cannot be null or empty.");
-        }
     }
 
     public String getOfficeId() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Office.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Office.java
@@ -3,10 +3,7 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.csv.CsvV1;
@@ -28,7 +25,7 @@ import java.util.HashMap;
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @FormattableWith(contentType = Formats.CSV, formatter = CsvV1.class)
 @FormattableWith(contentType = Formats.TAB, formatter = TabV1.class)
-public class Office implements CwmsDTOBase {
+public class Office extends CwmsDTOBase {
     private static final HashMap<String,String> office_types = new HashMap<String,String>(){
         /**
          *
@@ -72,11 +69,5 @@ public class Office implements CwmsDTOBase {
 
     public static boolean validOfficeCanNull(String office){
         return office == null || validOfficeNotNull(office);
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        // TODO Auto-generated method stub
-
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Pool.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Pool.java
@@ -3,25 +3,82 @@ package cwms.cda.data.dto;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
 import cwms.cda.formatters.Formats;
 
 import usace.cwms.db.dao.ifc.pool.PoolNameType;
-import usace.cwms.db.dao.ifc.pool.PoolType;
 
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class)
-public class Pool extends PoolType implements CwmsDTOBase {
+public class Pool extends CwmsDTOBase {
+
+	private final PoolNameType poolName;
+	private final String projectId;
+	private final String bottomLevelId;
+	private final String topLevelId;
+	private final boolean implicit;
 	private final Number attribute;
 	private final String description;
 	private final String clobText;
 
 	private Pool(Builder b){
-		super(b.getPoolName(), b.getProjectId(), b.getBottomLevelId(), b.getTopLevelId(), b.isImplicit());
+		this.poolName = b.getPoolName();
+		this.projectId = b.getProjectId();
+		this.bottomLevelId = b.getBottomLevelId();
+		this.topLevelId	= b.getTopLevelId();
+		this.implicit = b.isImplicit();
 		this.attribute = b.getAttribute();
 		this.description = b.getDescription();
 		this.clobText = b.getClobText();
+	}
+
+	public boolean isImplicit()
+	{
+		return this.implicit;
+	}
+
+	/**
+	 * Returns the pool name information for the pool
+	 *
+	 * @return Pool name information for the pool
+	 */
+	public PoolNameType getPoolName()
+	{
+		return this.poolName;
+	}
+
+	/**
+	 * Returns the Project ID for the pool
+	 *
+	 * @return Project ID as a String
+	 */
+	public String getProjectId()
+	{
+		return this.projectId;
+	}
+
+	/**
+	 * Returns the bottom location level ID for the pool.
+	 *
+	 * This is represented as: {Project}.{Parameter}.{ParameterType}.{Duration}.{SpecifiedLevel}
+	 *
+	 * @return String that represents the bottom location level ID.
+	 */
+	public String getBottomLevelId()
+	{
+		return this.bottomLevelId;
+	}
+
+	/**
+	 * Returns the top location level ID for the pool.
+	 *
+	 * This is represented as: {Project}.{Parameter}.{ParameterType}.{Duration}.{SpecifiedLevel}
+	 *
+	 * @return String that represents the top location level ID.
+	 */
+	public String getTopLevelId()
+	{
+		return this.topLevelId;
 	}
 
 	public Number getAttribute()
@@ -223,24 +280,5 @@ public class Pool extends PoolType implements CwmsDTOBase {
 		{
 			return new Pool(this);
 		}
-
-		public Builder withPoolType(PoolType poolType)
-		{
-			withPoolName(poolType.getPoolName());
-			withBottomLevelId(poolType.getBottomLevelId());
-			withTopLevelId(poolType.getTopLevelId());
-			withProjectId(poolType.getProjectId());
-			withImplicit(poolType.isImplicit());
-
-			return this;
-		}
 	}
-
-	@Override
-	public void validate() throws FieldException {
-		// TODO Auto-generated method stub
-
-	}
-
-
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Pool.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Pool.java
@@ -1,284 +1,249 @@
 package cwms.cda.data.dto;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
+import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
-import cwms.cda.formatters.Formats;
-
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import usace.cwms.db.dao.ifc.pool.PoolNameType;
 
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class)
 public class Pool extends CwmsDTOBase {
 
-	private final PoolNameType poolName;
-	private final String projectId;
-	private final String bottomLevelId;
-	private final String topLevelId;
-	private final boolean implicit;
-	private final Number attribute;
-	private final String description;
-	private final String clobText;
+    private final PoolNameType poolName;
+    private final String projectId;
+    private final String bottomLevelId;
+    private final String topLevelId;
+    private final boolean implicit;
+    private final Number attribute;
+    private final String description;
+    private final String clobText;
 
-	private Pool(Builder b){
-		this.poolName = b.getPoolName();
-		this.projectId = b.getProjectId();
-		this.bottomLevelId = b.getBottomLevelId();
-		this.topLevelId	= b.getTopLevelId();
-		this.implicit = b.isImplicit();
-		this.attribute = b.getAttribute();
-		this.description = b.getDescription();
-		this.clobText = b.getClobText();
-	}
+    private Pool(Builder b) {
+        this.poolName = b.getPoolName();
+        this.projectId = b.getProjectId();
+        this.bottomLevelId = b.getBottomLevelId();
+        this.topLevelId = b.getTopLevelId();
+        this.implicit = b.isImplicit();
+        this.attribute = b.getAttribute();
+        this.description = b.getDescription();
+        this.clobText = b.getClobText();
+    }
 
-	public boolean isImplicit()
-	{
-		return this.implicit;
-	}
+    public boolean isImplicit() {
+        return this.implicit;
+    }
 
-	/**
-	 * Returns the pool name information for the pool
-	 *
-	 * @return Pool name information for the pool
-	 */
-	public PoolNameType getPoolName()
-	{
-		return this.poolName;
-	}
+    /**
+     * Returns the pool name information for the pool
+     *
+     * @return Pool name information for the pool
+     */
+    public PoolNameType getPoolName() {
+        return this.poolName;
+    }
 
-	/**
-	 * Returns the Project ID for the pool
-	 *
-	 * @return Project ID as a String
-	 */
-	public String getProjectId()
-	{
-		return this.projectId;
-	}
+    /**
+     * Returns the Project ID for the pool
+     *
+     * @return Project ID as a String
+     */
+    public String getProjectId() {
+        return this.projectId;
+    }
 
-	/**
-	 * Returns the bottom location level ID for the pool.
-	 *
-	 * This is represented as: {Project}.{Parameter}.{ParameterType}.{Duration}.{SpecifiedLevel}
-	 *
-	 * @return String that represents the bottom location level ID.
-	 */
-	public String getBottomLevelId()
-	{
-		return this.bottomLevelId;
-	}
+    /**
+     * Returns the bottom location level ID for the pool.
+     * <p>
+     * This is represented as: {Project}.{Parameter}.{ParameterType}.{Duration}.{SpecifiedLevel}
+     *
+     * @return String that represents the bottom location level ID.
+     */
+    public String getBottomLevelId() {
+        return this.bottomLevelId;
+    }
 
-	/**
-	 * Returns the top location level ID for the pool.
-	 *
-	 * This is represented as: {Project}.{Parameter}.{ParameterType}.{Duration}.{SpecifiedLevel}
-	 *
-	 * @return String that represents the top location level ID.
-	 */
-	public String getTopLevelId()
-	{
-		return this.topLevelId;
-	}
+    /**
+     * Returns the top location level ID for the pool.
+     * <p>
+     * This is represented as: {Project}.{Parameter}.{ParameterType}.{Duration}.{SpecifiedLevel}
+     *
+     * @return String that represents the top location level ID.
+     */
+    public String getTopLevelId() {
+        return this.topLevelId;
+    }
 
-	public Number getAttribute()
-	{
-		return attribute;
-	}
+    public Number getAttribute() {
+        return attribute;
+    }
 
 
-	public String getDescription()
-	{
-		return description;
-	}
+    public String getDescription() {
+        return description;
+    }
 
-	public String getClobText()
-	{
-		return clobText;
-	}
+    public String getClobText() {
+        return clobText;
+    }
 
-	@Override
-	public boolean equals(Object o)
-	{
-		if(this == o)
-		{
-			return true;
-		}
-		if(o == null || getClass() != o.getClass())
-		{
-			return false;
-		}
-		if(!super.equals(o))
-		{
-			return false;
-		}
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
 
-		final Pool pool = (Pool) o;
+        final Pool pool = (Pool) o;
 
-		if(getAttribute() != null ? !getAttribute().equals(pool.getAttribute()) : pool.getAttribute() != null)
-		{
-			return false;
-		}
-		if(getDescription() != null ? !getDescription().equals(pool.getDescription()) : pool.getDescription() != null)
-		{
-			return false;
-		}
+        if (getAttribute() != null ? !getAttribute().equals(pool.getAttribute()) : pool.getAttribute() != null) {
+            return false;
+        }
+        if (getDescription() != null ? !getDescription().equals(pool.getDescription()) :
+            pool.getDescription() != null) {
+            return false;
+        }
 
-		return getClobText() != null ? getClobText().equals(pool.getClobText()) : pool.getClobText() == null;
-	}
+        return getClobText() != null ? getClobText().equals(pool.getClobText()) : pool.getClobText() == null;
+    }
 
-	@Override
-	public int hashCode()
-	{
-		int result = super.hashCode();
-		result = 31 * result + (getAttribute() != null ? getAttribute().hashCode() : 0);
-		result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (getAttribute() != null ? getAttribute().hashCode() : 0);
+        result = 31 * result + (getDescription() != null ? getDescription().hashCode() : 0);
 
-		result = 31 * result + (getClobText() != null ? getClobText().hashCode() : 0);
-		return result;
-	}
+        result = 31 * result + (getClobText() != null ? getClobText().hashCode() : 0);
+        return result;
+    }
 
-	public static Pool fromString(String input){
-		Pool retval= null;
-		Pattern pattern = Pattern.compile("^(.*)/(.*):(.*)$");
-		Matcher matcher = pattern.matcher(input);
+    public static Pool fromString(String input) {
+        Pool retval = null;
+        Pattern pattern = Pattern.compile("^(.*)/(.*):(.*)$");
+        Matcher matcher = pattern.matcher(input);
 
-		if(matcher.matches()){
-			PoolNameType poolName = new PoolNameType(matcher.group(3), matcher.group(1) );
-			Builder builder = Builder.newInstance();
-			builder.withPoolName(poolName);
-			builder.withProjectId(matcher.group(2));
-			builder.withBottomLevelId(null);
-			builder.withTopLevelId(null);
-			builder.withImplicit(true);
-			retval = builder.build();
-		}
+        if (matcher.matches()) {
+            PoolNameType poolName = new PoolNameType(matcher.group(3), matcher.group(1));
+            Builder builder = Builder.newInstance();
+            builder.withPoolName(poolName);
+            builder.withProjectId(matcher.group(2));
+            builder.withBottomLevelId(null);
+            builder.withTopLevelId(null);
+            builder.withImplicit(true);
+            retval = builder.build();
+        }
 
-		return retval;
-	}
+        return retval;
+    }
 
-	// This is used in the Pools cursor.
-	@Override
-	public String toString(){
-		StringBuilder builder = new StringBuilder();
-		PoolNameType poolName = getPoolName();
+    // This is used in the Pools cursor.
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder();
+        PoolNameType poolName = getPoolName();
 
-		builder.append(poolName.getOfficeId())
-				.append("/").append(getProjectId())
-				.append(":").append(poolName.getPoolName());
-		return builder.toString();
-	}
+        builder.append(poolName.getOfficeId())
+            .append("/").append(getProjectId())
+            .append(":").append(poolName.getPoolName());
+        return builder.toString();
+    }
 
-	public static class Builder
-	{
-		private PoolNameType poolName;
+    public static class Builder {
+        private PoolNameType poolName;
 
-		private String projectId;
-		private String bottomLevelId;
-		private String topLevelId;
-		private boolean isImplicit;
-		private Number attribute;
-		private String description;
-		private String clobText;
+        private String projectId;
+        private String bottomLevelId;
+        private String topLevelId;
+        private boolean isImplicit;
+        private Number attribute;
+        private String description;
+        private String clobText;
 
 
-		public PoolNameType getPoolName()
-		{
-			return poolName;
-		}
+        public PoolNameType getPoolName() {
+            return poolName;
+        }
 
-		public Builder withPoolName(PoolNameType poolName)
-		{
-			this.poolName = poolName;
-			return this;
-		}
+        public Builder withPoolName(PoolNameType poolName) {
+            this.poolName = poolName;
+            return this;
+        }
 
-		public String getProjectId()
-		{
-			return projectId;
-		}
+        public String getProjectId() {
+            return projectId;
+        }
 
-		public Builder withProjectId(String projectId)
-		{
-			this.projectId = projectId;
-			return this;
-		}
+        public Builder withProjectId(String projectId) {
+            this.projectId = projectId;
+            return this;
+        }
 
-		public String getBottomLevelId()
-		{
-			return bottomLevelId;
-		}
+        public String getBottomLevelId() {
+            return bottomLevelId;
+        }
 
-		public Builder withBottomLevelId(String bottomLevelId)
-		{
-			this.bottomLevelId = bottomLevelId;
-			return this;
+        public Builder withBottomLevelId(String bottomLevelId) {
+            this.bottomLevelId = bottomLevelId;
+            return this;
 
-		}
+        }
 
-		public String getTopLevelId()
-		{
-			return topLevelId;
-		}
+        public String getTopLevelId() {
+            return topLevelId;
+        }
 
-		public Builder withTopLevelId(String topLevelId)
-		{
-			this.topLevelId = topLevelId;
-			return this;
-		}
+        public Builder withTopLevelId(String topLevelId) {
+            this.topLevelId = topLevelId;
+            return this;
+        }
 
-		public boolean isImplicit()
-		{
-			return isImplicit;
-		}
+        public boolean isImplicit() {
+            return isImplicit;
+        }
 
-		public Builder withImplicit(boolean implicit)
-		{
-			isImplicit = implicit;
-			return this;
-		}
+        public Builder withImplicit(boolean implicit) {
+            isImplicit = implicit;
+            return this;
+        }
 
-		public Number getAttribute()
-		{
-			return attribute;
-		}
+        public Number getAttribute() {
+            return attribute;
+        }
 
-		public Builder withAttribute(Number attribute)
-		{
-			this.attribute = attribute;
-			return this;
-		}
+        public Builder withAttribute(Number attribute) {
+            this.attribute = attribute;
+            return this;
+        }
 
-		public String getDescription()
-		{
-			return description;
-		}
+        public String getDescription() {
+            return description;
+        }
 
-		public Builder withDescription(String description)
-		{
-			this.description = description;
-			return this;
-		}
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
 
-		public String getClobText()
-		{
-			return clobText;
-		}
+        public String getClobText() {
+            return clobText;
+        }
 
-		public Builder withClobText(String clobText)
-		{
-			this.clobText = clobText;
-			return this;
-		}
+        public Builder withClobText(String clobText) {
+            this.clobText = clobText;
+            return this;
+        }
 
-		public static Builder newInstance()
-		{
-			return new Builder();
-		}
+        public static Builder newInstance() {
+            return new Builder();
+        }
 
-		public Pool build()
-		{
-			return new Pool(this);
-		}
-	}
+        public Pool build() {
+            return new Pool(this);
+        }
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Pools.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Pools.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
@@ -74,13 +73,4 @@ public class Pools extends CwmsDTOPaginated {
             return this;
         }
     }
-
-
-    @Override
-    public void validate() throws FieldException {
-        // TODO Auto-generated method stub
-
-    }
-
-
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Property.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Property.java
@@ -25,11 +25,11 @@
 package cwms.cda.data.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
@@ -41,10 +41,13 @@ import java.util.Objects;
 @JsonDeserialize(builder = Property.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class Property implements CwmsDTOBase {
+public final class Property extends CwmsDTOBase {
 
+    @JsonProperty(required = true)
     private final String category;
+    @JsonProperty(required = true)
     private final String name;
+    @JsonProperty(required = true)
     private final String officeId;
     private final String value;
     private final String comment; // added comment field
@@ -55,20 +58,6 @@ public final class Property implements CwmsDTOBase {
         this.officeId = builder.officeId;
         this.value = builder.value;
         this.comment = builder.comment; // included comment in constructor
-    }
-    
-    @Override
-    public void validate() throws FieldException {
-
-        if (this.category == null || this.category.trim().isEmpty()) {
-            throw new FieldException("The 'category' field of a Property cannot be null or empty.");
-        }
-        if (this.name == null || this.name.trim().isEmpty()) {
-            throw new FieldException("The 'name' field of a Property cannot be null or empty.");
-        }
-        if (this.officeId == null || this.officeId.trim().isEmpty()) {
-            throw new FieldException("The 'office' field of a Property cannot be null or empty.");
-        }
     }
 
     public String getOfficeId() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/RecentValue.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/RecentValue.java
@@ -1,12 +1,11 @@
 package cwms.cda.data.dto;
 
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
 import cwms.cda.formatters.Formats;
 
 @FormattableWith(contentType = Formats.JSON, formatter = JsonV1.class)
-public class RecentValue implements CwmsDTOBase
+public class RecentValue extends CwmsDTOBase
 {
 	String id;
 	TsvDqu dqu;
@@ -27,9 +26,4 @@ public class RecentValue implements CwmsDTOBase
 		return dqu;
 	}
 
-	@Override
-	public void validate() throws FieldException {
-		// TODO Auto-generated method stub
-
-	}
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/State.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/State.java
@@ -24,24 +24,23 @@
 
 package cwms.cda.data.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
-import cwms.cda.api.errors.RequiredFieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
 import io.swagger.v3.oas.annotations.media.Schema;
 
-import java.util.ArrayList;
-
 @Schema(description = "A representation of a state")
 @JsonRootName("state")
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.JSON, Formats.DEFAULT})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class State implements CwmsDTOBase {
+public class State extends CwmsDTOBase {
+    @JsonProperty(required = true)
     private String stateInitial;
+    @JsonProperty(required = true)
     private String name;
 
     public State(){}
@@ -55,19 +54,5 @@ public class State implements CwmsDTOBase {
 
     public String getStateInitial() {
         return stateInitial;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        ArrayList<String> missingFields = new ArrayList<>();
-        if (this.getName() == null) {
-            missingFields.add("Name");
-        }
-        if (this.getStateInitial() == null) {
-            missingFields.add("State Initial");
-        }
-        if (!missingFields.isEmpty()) {
-            throw new RequiredFieldException(missingFields);
-        }
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeSeries.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeSeries.java
@@ -10,7 +10,6 @@ import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import cwms.cda.api.enums.VersionType;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
@@ -19,7 +18,6 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.AccessMode;
 
-import javax.xml.bind.annotation.XmlType;
 import java.lang.reflect.Field;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -334,11 +332,5 @@ public class TimeSeries extends CwmsDTOPaginated {
         public String getDatatype() {
             return datatype.getTypeName();
         }
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        // TODO Auto-generated method stub
-
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeSeriesIdentifierDescriptors.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeSeriesIdentifierDescriptors.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV2;
@@ -36,12 +35,6 @@ public class TimeSeriesIdentifierDescriptors extends CwmsDTOPaginated {
 
     public List<TimeSeriesIdentifierDescriptor> getDescriptors() {
         return Collections.unmodifiableList(descriptors);
-    }
-
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     public static class Builder {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZone.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZone.java
@@ -7,6 +7,7 @@
 
 package cwms.cda.data.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -20,30 +21,26 @@ import java.time.ZoneId;
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class TimeZone extends CwmsDTO
-{
-	private String timeZone;
+public final class TimeZone extends CwmsDTOBase {
+    @JsonProperty(required = true)
+    private String timeZone;
 
-	public TimeZone()
-	{
-		super(null);
-	}
+    public TimeZone() {
+        super();
+    }
 
-	public TimeZone(String timeZone)
-	{
-		this();
-		this.timeZone = timeZone;
-	}
+    public TimeZone(String timeZone) {
+        this();
+        this.timeZone = timeZone;
+    }
 
-	public String getTimeZone()
-	{
-		return timeZone;
-	}
+    public String getTimeZone() {
+        return timeZone;
+    }
 
-	@Override
-	protected void validateInternal(CwmsDTOValidator validator) {
-		super.validateInternal(validator);
-		validator.required(getTimeZone(), "time-zone");
-		validator.validate(() -> ZoneId.of(getTimeZone()));
-	}
+    @Override
+    protected void validateInternal(CwmsDTOValidator validator) {
+        super.validateInternal(validator);
+        validator.validate(() -> ZoneId.of(getTimeZone()));
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZones.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZones.java
@@ -21,19 +21,18 @@ import java.util.List;
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class TimeZones extends CwmsDTO
+public final class TimeZones extends CwmsDTOBase
 {
 	private List<TimeZone> timeZones;
 
-	@SuppressWarnings("unused") // for JAXB to handle marshalling
+	@SuppressWarnings("unused")
 	private TimeZones()
 	{
-		super(null);
+		// for JAXB to handle marshalling
 	}
 
 	public TimeZones(List<TimeZone> timeZones)
 	{
-		super(null);
 		this.timeZones = timeZones;
 	}
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Unit.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Unit.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class Unit extends CwmsDTO
+public final class Unit extends CwmsDTOBase
 {
 	private String abstractParameter;
 	private String name;
@@ -34,7 +34,6 @@ public final class Unit extends CwmsDTO
 
 	public Unit(String name, String longName, String abstractParameter, String description, String unitSystem, List<String> alternateNames)
 	{
-		super(null);
 		this.abstractParameter = abstractParameter;
 		this.name = name;
 		this.longName = longName;
@@ -50,7 +49,7 @@ public final class Unit extends CwmsDTO
 
 	public Unit()
 	{
-		super(null);
+		//No-op
 	}
 
 	public String getLongName()

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/VerticalDatumInfo.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/VerticalDatumInfo.java
@@ -1,23 +1,17 @@
 package cwms.cda.data.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
-import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 
 @JsonRootName("vertical-datum-info")
 @JsonDeserialize(builder = VerticalDatumInfo.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class VerticalDatumInfo implements CwmsDTOBase {
+public class VerticalDatumInfo extends CwmsDTOBase {
     String office;
 
     String unit;
@@ -55,11 +49,6 @@ public class VerticalDatumInfo implements CwmsDTOBase {
 
     public Offset[] getOffsets() {
         return offsets;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/basin/Basin.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/basin/Basin.java
@@ -1,10 +1,10 @@
 package cwms.cda.data.dto.basin;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
@@ -17,7 +17,8 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonDeserialize(builder = Basin.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class Basin implements CwmsDTOBase {
+public final class Basin extends CwmsDTOBase {
+    @JsonProperty(required = true)
     private final CwmsId basinId;
     private final Double sortOrder;
     private final Double totalDrainageArea;
@@ -111,13 +112,5 @@ public final class Basin implements CwmsDTOBase {
         public Basin build() {
             return new Basin(this);
         }
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        if (this.basinId == null) {
-            throw new FieldException("Basin identifier field can't be null");
-        }
-        basinId.validate();
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/forecast/ForecastInstance.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/forecast/ForecastInstance.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -22,7 +21,7 @@ import java.util.Map;
 @JsonDeserialize(builder = ForecastInstance.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class ForecastInstance implements CwmsDTOBase {
+public class ForecastInstance extends CwmsDTOBase {
 
     @Schema(description = "Forecast Spec")
     private final ForecastSpec spec;
@@ -137,10 +136,6 @@ public class ForecastInstance implements CwmsDTOBase {
 
     public String getFileDataUrl() {
         return fileDataUrl;
-    }
-
-    public void validate() throws FieldException {
-        //TODO
     }
 
     @Override

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/CompoundOutletRecord.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/CompoundOutletRecord.java
@@ -25,9 +25,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
-import cwms.cda.api.errors.RequiredFieldException;
-import cwms.cda.data.dto.CwmsDTO;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsDTOValidator;
 import cwms.cda.data.dto.CwmsId;
@@ -36,19 +33,17 @@ import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 @FormattableWith(contentType = Formats.JSONV1, formatter = JsonV1.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @JsonDeserialize(builder = CompoundOutletRecord.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public class CompoundOutletRecord extends CwmsDTO {
+public class CompoundOutletRecord extends CwmsDTOBase {
     @JsonProperty(required = true)
     private final CwmsId outletId;
     private final List<CwmsId> downstreamOutletIds = new ArrayList<>();
 
     private CompoundOutletRecord(Builder builder) {
-        super(null);
         outletId = builder.outletId;
         if (builder.downstreamOutletIds != null) {
             downstreamOutletIds.addAll(builder.downstreamOutletIds);
@@ -66,7 +61,6 @@ public class CompoundOutletRecord extends CwmsDTO {
     @Override
     protected void validateInternal(CwmsDTOValidator validator) {
         super.validateInternal(validator);
-        validator.required(outletId, "outlet-id");
         validator.validateCollection(downstreamOutletIds);
     }
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/PhysicalStructureChange.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/PhysicalStructureChange.java
@@ -134,7 +134,6 @@ public abstract class PhysicalStructureChange<T extends Setting> extends CwmsDTO
     @Override
     protected void validateInternal(CwmsDTOValidator validator) {
         super.validateInternal(validator);
-        validator.validateRequiredFields(this);
         validator.validateCollection(getSettings());
     }
     

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/PhysicalStructureChange.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/PhysicalStructureChange.java
@@ -31,9 +31,8 @@ package cwms.cda.data.dto.location.kind;
 
 import static java.util.Comparator.comparing;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import cwms.cda.data.dto.CwmsDTO;
+import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsDTOValidator;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.data.dto.LookupType;
@@ -43,7 +42,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-public abstract class PhysicalStructureChange<T extends Setting> extends CwmsDTO {
+public abstract class PhysicalStructureChange<T extends Setting> extends CwmsDTOBase {
     @JsonProperty(required = true)
     private final CwmsId projectId;
     @JsonProperty(value = "protected", required = true)
@@ -64,8 +63,6 @@ public abstract class PhysicalStructureChange<T extends Setting> extends CwmsDTO
     private final Set<T> settings;
 
     PhysicalStructureChange(Builder<?,T> builder) {
-        //uses CwmsId instead of a separate office-id field
-        super(null);
         this.projectId = builder.projectId;
         this.dischargeComputationType = builder.dischargeComputationType;
         this.reasonType = builder.reasonType;
@@ -79,12 +76,6 @@ public abstract class PhysicalStructureChange<T extends Setting> extends CwmsDTO
         this.notes = builder.notes;
         this.changeDate = builder.changeDate;
         this.settings = builder.settings;
-    }
-
-    @JsonIgnore
-    @Override
-    public String getOfficeId() {
-        return projectId.getOfficeId();
     }
 
     public CwmsId getProjectId() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/ProjectStructure.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/ProjectStructure.java
@@ -20,34 +20,25 @@
 
 package cwms.cda.data.dto.location.kind;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.data.dto.CwmsDTO;
-import cwms.cda.data.dto.CwmsDTOValidator;
+import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.data.dto.Location;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public abstract class ProjectStructure extends CwmsDTO {
+public abstract class ProjectStructure extends CwmsDTOBase {
     @JsonProperty(required = true)
     private final CwmsId projectId;
     @JsonProperty(required = true)
     private final Location location;
 
     ProjectStructure(CwmsId projectId, Location location) {
-        super(null);
         this.location = location;
         this.projectId = projectId;
-    }
-
-    @JsonIgnore
-    @Override
-    public String getOfficeId() {
-        return location.getOfficeId();
     }
 
     public final CwmsId getProjectId() {
@@ -56,12 +47,5 @@ public abstract class ProjectStructure extends CwmsDTO {
 
     public final Location getLocation() {
         return location;
-    }
-
-    @Override
-    protected void validateInternal(CwmsDTOValidator validator) {
-        super.validateInternal(validator);
-        validator.required(getLocation(), "location");
-        validator.required(getProjectId(), "project-id");
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/Setting.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/location/kind/Setting.java
@@ -24,30 +24,21 @@
 
 package cwms.cda.data.dto.location.kind;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import cwms.cda.data.dto.CwmsDTO;
+import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({@JsonSubTypes.Type(value = TurbineSetting.class, name = "turbine-setting")})
-public abstract class Setting extends CwmsDTO {
+public abstract class Setting extends CwmsDTOBase {
 
     @JsonProperty(required = true)
     private final CwmsId locationId;
 
     protected Setting(Builder<?> builder) {
-        //uses CwmsId instead of a separate office-id field
-        super(null);
         this.locationId = builder.locationId;
-    }
-
-    @JsonIgnore
-    @Override
-    public String getOfficeId() {
-        return locationId.getOfficeId();
     }
 
     public CwmsId getLocationId() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/project/Project.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/project/Project.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.Location;
 import cwms.cda.formatters.Formats;
@@ -43,7 +42,7 @@ import java.time.Instant;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 @FormattableWith(contentType = Formats.JSONV1, aliases = {Formats.DEFAULT, Formats.JSON}, formatter = JsonV2.class)
-public class Project implements CwmsDTOBase {
+public class Project extends CwmsDTOBase {
 
     private final Location location;
     private final BigDecimal federalCost;
@@ -85,11 +84,6 @@ public class Project implements CwmsDTOBase {
         this.yieldTimeFrameStart = builder.yieldTimeFrameStart;
         this.yieldTimeFrameEnd = builder.yieldTimeFrameEnd;
         this.projectRemarks = builder.projectRemarks;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     public Location getLocation() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/project/ProjectLockId.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/project/ProjectLockId.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -37,7 +36,7 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 @FormattableWith(contentType = Formats.JSON, formatter = JsonV1.class)
-public class ProjectLockId implements CwmsDTOBase {
+public class ProjectLockId extends CwmsDTOBase {
     private final String id;
 
     public ProjectLockId(@JsonProperty(value = "id") String id) {
@@ -46,10 +45,5 @@ public class ProjectLockId implements CwmsDTOBase {
 
     public String getId() {
         return id;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/project/Projects.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/project/Projects.java
@@ -24,7 +24,6 @@
 
 package cwms.cda.data.dto.project;
 
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOPaginated;
 import cwms.cda.data.dto.Location;
 import cwms.cda.formatters.Formats;
@@ -137,12 +136,4 @@ public class Projects extends CwmsDTOPaginated {
             return this;
         }
     }
-
-
-    @Override
-    public void validate() throws FieldException {
-
-    }
-
-
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingMetadata.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingMetadata.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -20,7 +19,7 @@ import java.util.List;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class)
-public class RatingMetadata implements CwmsDTOBase {
+public class RatingMetadata extends CwmsDTOBase {
 
     private final RatingSpec ratingSpec;
 
@@ -29,11 +28,6 @@ public class RatingMetadata implements CwmsDTOBase {
     private RatingMetadata(Builder builder) {
         this.ratingSpec = builder.ratingSpec;
         this.ratings = builder.ratings;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     public RatingSpec getRatingSpec() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingMetadataList.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingMetadataList.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOPaginated;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -75,12 +74,6 @@ public class RatingMetadataList extends CwmsDTOPaginated {
             return Collections.emptyList();
         }
         return Collections.unmodifiableList(metadata);
-    }
-
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     public static class Builder {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingSpecs.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingSpecs.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOPaginated;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -36,12 +35,6 @@ public class RatingSpecs extends CwmsDTOPaginated {
 
     public List<RatingSpec> getSpecs() {
         return Collections.unmodifiableList(specs);
-    }
-
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     public static class Builder {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingTemplates.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingTemplates.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOPaginated;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -36,12 +35,6 @@ public class RatingTemplates extends CwmsDTOPaginated {
 
     public List<RatingTemplate> getTemplates() {
         return Collections.unmodifiableList(templates);
-    }
-
-
-    @Override
-    public void validate() throws FieldException {
-
     }
 
     public static class Builder {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/Stream.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/Stream.java
@@ -6,8 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
-import cwms.cda.data.dto.CwmsDTO;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
@@ -18,7 +16,7 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonDeserialize(builder = Stream.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class Stream extends CwmsDTO {
+public final class Stream extends CwmsDTOBase {
 
     private final Boolean startsDownstream;
     private final StreamNode flowsIntoStreamNode;
@@ -32,7 +30,6 @@ public final class Stream extends CwmsDTO {
     private final CwmsId id;
 
     private Stream(Builder builder) {
-        super(null);
         this.startsDownstream = builder.startsDownstream;
         this.flowsIntoStreamNode = builder.flowsIntoStreamNode;
         this.divertsFromStreamNode = builder.divertsFromStreamNode;

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamLocation.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamLocation.java
@@ -30,10 +30,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
-import cwms.cda.data.dto.CwmsDTO;
 import cwms.cda.data.dto.CwmsDTOBase;
-import cwms.cda.data.dto.CwmsDTOValidator;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
@@ -43,7 +40,7 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonDeserialize(builder = StreamLocation.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class StreamLocation extends CwmsDTO {
+public final class StreamLocation extends CwmsDTOBase {
 
     @JsonProperty(required = true)
     private final StreamLocationNode streamLocationNode; //the node representation of this location containing the loc id, stream id, bank, and station
@@ -56,7 +53,6 @@ public final class StreamLocation extends CwmsDTO {
     private final String stageUnits;
 
     private StreamLocation(Builder builder) {
-        super(null);
         this.streamLocationNode = builder.streamLocationNode;
         this.publishedStation = builder.publishedStation;
         this.navigationStation = builder.navigationStation;

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamLocationNode.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamLocationNode.java
@@ -1,10 +1,10 @@
 package cwms.cda.data.dto.stream;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
@@ -15,26 +15,16 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonDeserialize(builder = StreamLocationNode.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class StreamLocationNode implements CwmsDTOBase {
+public final class StreamLocationNode extends CwmsDTOBase {
 
+    @JsonProperty(required = true)
     private final CwmsId id; //stream location id
+    @JsonProperty(required = true)
     private final StreamNode streamNode;
 
     private StreamLocationNode(Builder builder) {
         this.id = builder.id;
         this.streamNode = builder.streamNode;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        if(this.id == null) {
-            throw new FieldException("The 'id' field of a StreamLocationNode cannot be null.");
-        }
-        id.validate();
-        if(this.streamNode == null) {
-            throw new FieldException("The 'streamNode' field of a StreamLocationNode cannot be null.");
-        }
-        streamNode.validate();
     }
 
     public CwmsId getId() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamNode.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamNode.java
@@ -25,10 +25,10 @@
 package cwms.cda.data.dto.stream;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
@@ -39,8 +39,9 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonDeserialize(builder = StreamNode.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class StreamNode implements CwmsDTOBase {
+public final class StreamNode extends CwmsDTOBase {
 
+    @JsonProperty(required = true)
     private final CwmsId streamId;
     private final Bank bank;
     private final Double station;
@@ -51,14 +52,6 @@ public final class StreamNode implements CwmsDTOBase {
         this.bank = builder.bank;
         this.station = builder.station;
         this.stationUnits = builder.stationUnits;
-    }
-
-    @Override
-    public void validate() throws FieldException {
-        if (this.streamId == null) {
-            throw new FieldException("The 'locationIdentifier' field of a StreamLocationRef cannot be null.");
-        }
-        streamId.validate();
     }
 
     public CwmsId getStreamId() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamReach.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/stream/StreamReach.java
@@ -29,8 +29,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
-import cwms.cda.api.errors.FieldException;
-import cwms.cda.data.dto.CwmsDTO;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
@@ -41,7 +39,7 @@ import cwms.cda.formatters.json.JsonV1;
 @JsonDeserialize(builder = StreamReach.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class StreamReach extends CwmsDTO {
+public final class StreamReach extends CwmsDTOBase {
 
     private final String comment;
     @JsonProperty(required = true)
@@ -55,7 +53,6 @@ public final class StreamReach extends CwmsDTO {
     private final CwmsId id;
 
     private StreamReach(Builder builder) {
-        super(null);
         this.comment = builder.comment;
         this.downstreamNode = builder.downstreamNode;
         this.upstreamNode = builder.upstreamNode;

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/CwmsDTOValidatorTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/CwmsDTOValidatorTest.java
@@ -33,6 +33,7 @@ import cwms.cda.api.errors.FieldException;
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 final class CwmsDTOValidatorTest {
@@ -44,7 +45,7 @@ final class CwmsDTOValidatorTest {
             .collect(toList());
 
         CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
-        assertTimeout(Duration.ofMillis(100L), cwmsDTOHolder::validate);
+        assertTimeout(Duration.ofMillis(150L), cwmsDTOHolder::validate);
     }
 
     @Test
@@ -54,7 +55,7 @@ final class CwmsDTOValidatorTest {
             .collect(toList());
 
         CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
-        assertTimeout(Duration.ofMillis(40L), cwmsDTOHolder::validate);
+        assertTimeout(Duration.ofMillis(150L), cwmsDTOHolder::validate);
     }
 
     @Test
@@ -64,7 +65,7 @@ final class CwmsDTOValidatorTest {
             .collect(toList());
 
         CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
-        assertTimeout(Duration.ofMillis(90L), () -> assertThrows(FieldException.class, cwmsDTOHolder::validate));
+        assertTimeout(Duration.ofMillis(150L), () -> assertThrows(FieldException.class, cwmsDTOHolder::validate));
     }
 
     private static final class OneField extends CwmsDTOBase {

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/CwmsDTOValidatorTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/CwmsDTOValidatorTest.java
@@ -45,7 +45,6 @@ final class CwmsDTOValidatorTest {
 
         CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
         assertTimeout(Duration.ofMillis(100L), cwmsDTOHolder::validate);
-        assertTimeout(Duration.ofMillis(10L), cwmsDTOHolder::validate);
     }
 
     @Test
@@ -56,7 +55,6 @@ final class CwmsDTOValidatorTest {
 
         CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
         assertTimeout(Duration.ofMillis(40L), cwmsDTOHolder::validate);
-        assertTimeout(Duration.ofMillis(35L), cwmsDTOHolder::validate);
     }
 
     @Test
@@ -67,7 +65,6 @@ final class CwmsDTOValidatorTest {
 
         CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
         assertTimeout(Duration.ofMillis(90L), () -> assertThrows(FieldException.class, cwmsDTOHolder::validate));
-        assertTimeout(Duration.ofMillis(30L), () -> assertThrows(FieldException.class, cwmsDTOHolder::validate));
     }
 
     private static final class OneField extends CwmsDTOBase {

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/CwmsDTOValidatorTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/CwmsDTOValidatorTest.java
@@ -1,0 +1,229 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.data.dto;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeout;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import cwms.cda.api.errors.FieldException;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+final class CwmsDTOValidatorTest {
+
+    @Test
+    void testLargeCwmsDTOValidationOneRequiredField() {
+        List<OneField> collect = IntStream.range(0, 100_000)
+            .mapToObj(i -> new OneField("name" + i))
+            .collect(toList());
+
+        CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
+        assertTimeout(Duration.ofMillis(100L), cwmsDTOHolder::validate);
+        assertTimeout(Duration.ofMillis(10L), cwmsDTOHolder::validate);
+    }
+
+    @Test
+    void testLargeCwmsDTOValidationNineRequiredFieldValid() {
+        List<NineFields> collect = IntStream.range(0, 100_000)
+            .mapToObj(i -> new NineFieldsFilled("name" + i, "_"))
+            .collect(toList());
+
+        CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
+        assertTimeout(Duration.ofMillis(40L), cwmsDTOHolder::validate);
+        assertTimeout(Duration.ofMillis(35L), cwmsDTOHolder::validate);
+    }
+
+    @Test
+    void testLargeCwmsDTOValidationNineRequiredFieldInvalid() {
+        List<NineFields> collect = IntStream.range(0, 100_000)
+            .mapToObj(i -> new NineFields("name" + i))
+            .collect(toList());
+
+        CwmsDTOHolder cwmsDTOHolder = new CwmsDTOHolder(collect);
+        assertTimeout(Duration.ofMillis(90L), () -> assertThrows(FieldException.class, cwmsDTOHolder::validate));
+        assertTimeout(Duration.ofMillis(30L), () -> assertThrows(FieldException.class, cwmsDTOHolder::validate));
+    }
+
+    private static final class OneField extends CwmsDTOBase {
+        @JsonProperty(required = true)
+        private String name;
+        private String name1;
+        private String name2;
+        private String name3;
+        private String name4;
+        private String name5;
+        private String name6;
+        private String name7;
+        private String name8;
+
+        private OneField(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getName1() {
+            return name1;
+        }
+
+        public String getName2() {
+            return name2;
+        }
+
+        public String getName3() {
+            return name3;
+        }
+
+        public String getName4() {
+            return name4;
+        }
+
+        public String getName5() {
+            return name5;
+        }
+
+        public String getName6() {
+            return name6;
+        }
+
+        public String getName7() {
+            return name7;
+        }
+
+        public String getName8() {
+            return name8;
+        }
+    }
+
+    private static class NineFields extends CwmsDTOBase {
+        @JsonProperty(required = true)
+        String name;
+        @JsonProperty(required = true)
+        String name1;
+        @JsonProperty(required = true)
+        String name2;
+        @JsonProperty(required = true)
+        String name3;
+        @JsonProperty(required = true)
+        String name4;
+        @JsonProperty(required = true)
+        String name5;
+        @JsonProperty(required = true)
+        String name6;
+        @JsonProperty(required = true)
+        String name7;
+        @JsonProperty(required = true)
+        String name8;
+
+        private NineFields(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getName1() {
+            return name1;
+        }
+
+        public String getName2() {
+            return name2;
+        }
+
+        public String getName3() {
+            return name3;
+        }
+
+        public String getName4() {
+            return name4;
+        }
+
+        public String getName5() {
+            return name5;
+        }
+
+        public String getName6() {
+            return name6;
+        }
+
+        public String getName7() {
+            return name7;
+        }
+
+        public String getName8() {
+            return name8;
+        }
+
+    }
+
+
+    private static final class NineFieldsFilled extends NineFields{
+
+
+        private NineFieldsFilled(String name, String suffix) {
+            super(name + suffix);
+            this.name1 = name + suffix;
+            this.name2 = name + suffix;
+            this.name3 = name + suffix;
+            this.name4 = name + suffix;
+            this.name5 = name + suffix;
+            this.name6 = name + suffix;
+            this.name7 = name + suffix;
+            this.name8 = name + suffix;
+        }
+    }
+
+    private static final class CwmsDTOHolder extends CwmsDTOBase {
+        @JsonProperty(required = true)
+        private final CwmsId cwmsId;
+        private List<? extends CwmsDTOBase> objects;
+
+        private CwmsDTOHolder(List<? extends CwmsDTOBase> objects) {
+            this.cwmsId = new CwmsId.Builder()
+                .withOfficeId("SPK")
+                .withName("Test")
+                .build();
+            this.objects = objects;
+        }
+
+        public List<? extends CwmsDTOBase> getObjects() {
+            return this.objects;
+        }
+
+        @Override
+        protected void validateInternal(CwmsDTOValidator validator) {
+            super.validateInternal(validator);
+            validator.validateCollection(objects);
+        }
+    }
+
+}

--- a/cwms-data-api/src/test/java/cwms/cda/helpers/DTOMatch.java
+++ b/cwms-data-api/src/test/java/cwms/cda/helpers/DTOMatch.java
@@ -34,7 +34,6 @@ import cwms.cda.data.dto.LookupType;
 import cwms.cda.data.dto.location.kind.CompoundOutletRecord;
 import cwms.cda.data.dto.location.kind.Embankment;
 import cwms.cda.data.dto.location.kind.Outlet;
-import cwms.cda.data.dto.location.kind.PhysicalStructureChange;
 import cwms.cda.data.dto.location.kind.Turbine;
 import cwms.cda.data.dto.location.kind.TurbineChange;
 import cwms.cda.data.dto.location.kind.TurbineSetting;
@@ -201,7 +200,6 @@ public final class DTOMatch {
                 () -> assertMatch(first.getProjectId(), second.getProjectId()),
                 () -> assertEquals(first.getLocation(), second.getLocation()),
                 () -> assertEquals(first.getRatingGroupId(), second.getRatingGroupId()),
-                () -> assertEquals(first.getOfficeId(), second.getOfficeId()),
                 () -> assertMatch(first.getCompoundOutletRecords(), second.getCompoundOutletRecords(), DTOMatch::assertMatch)
         );
     }


### PR DESCRIPTION
classes that were passing in null office ids to CwmsDTO are now using CwmsDTOBase and CwmsDTOBase is made abstract with the default validation logic

Also this updates the validator to use the Java Bean getter instead of using field access and having to modify access. Added caching to reduce performance hit in subsequent calls.