### PR TITLE
rename TimeZone class names to TimeZoneId

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeZoneController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeZoneController.java
@@ -18,8 +18,8 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import cwms.cda.data.dao.TimeZoneDao;
-import cwms.cda.data.dto.TimeZone;
-import cwms.cda.data.dto.TimeZones;
+import cwms.cda.data.dto.TimeZoneId;
+import cwms.cda.data.dto.TimeZoneIds;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
 import io.javalin.apibuilder.CrudHandler;
@@ -28,7 +28,6 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletResponse;
@@ -89,7 +88,7 @@ public class TimeZoneController implements CrudHandler {
             String format = ctx.queryParamAsClass(FORMAT, String.class).getOrDefault("");
             String header = ctx.header(ACCEPT);
 
-            ContentType contentType = Formats.parseHeaderAndQueryParm(header, format, TimeZone.class);
+            ContentType contentType = Formats.parseHeaderAndQueryParm(header, format, TimeZoneId.class);
             String version = contentType.getParameters()
                                         .getOrDefault(VERSION, "");
 
@@ -98,7 +97,7 @@ public class TimeZoneController implements CrudHandler {
             String results;
             if (format.isEmpty() && !isLegacyVersion)
             {
-                TimeZones zones = dao.getTimeZones();
+                TimeZoneIds zones = dao.getTimeZones();
                 results = Formats.format(contentType, zones);
                 ctx.contentType(contentType.toString());
             }

--- a/cwms-data-api/src/main/java/cwms/cda/api/UnitsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/UnitsController.java
@@ -18,8 +18,6 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import cwms.cda.api.errors.CdaError;
 import cwms.cda.data.dao.UnitsDao;
-import cwms.cda.data.dto.TimeZone;
-import cwms.cda.data.dto.TimeZones;
 import cwms.cda.data.dto.Unit;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
@@ -90,7 +88,7 @@ public class UnitsController implements CrudHandler {
             String format = ctx.queryParamAsClass(FORMAT, String.class).getOrDefault("");
             String header = ctx.header(ACCEPT);
 
-            ContentType contentType = Formats.parseHeaderAndQueryParm(header, format, TimeZone.class);
+            ContentType contentType = Formats.parseHeaderAndQueryParm(header, format, Unit.class);
             String version = contentType.getParameters()
                                         .getOrDefault(VERSION, "");
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeZoneDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeZoneDao.java
@@ -1,13 +1,12 @@
 package cwms.cda.data.dao;
 
-import cwms.cda.data.dto.TimeZone;
-import cwms.cda.data.dto.TimeZones;
+import cwms.cda.data.dto.TimeZoneId;
+import cwms.cda.data.dto.TimeZoneIds;
 import org.jooq.DSLContext;
 import org.jooq.Record1;
 import usace.cwms.db.jooq.codegen.packages.CWMS_CAT_PACKAGE;
 import usace.cwms.db.jooq.codegen.tables.MV_TIME_ZONE;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 public class TimeZoneDao extends JooqDao<String> {
@@ -20,13 +19,13 @@ public class TimeZoneDao extends JooqDao<String> {
         return CWMS_CAT_PACKAGE.call_RETRIEVE_TIME_ZONES_F(dsl.configuration(), format);
     }
 
-    public TimeZones getTimeZones()
+    public TimeZoneIds getTimeZones()
     {
-        return new TimeZones(dsl.select(MV_TIME_ZONE.MV_TIME_ZONE.TIME_ZONE_NAME)
+        return new TimeZoneIds(dsl.select(MV_TIME_ZONE.MV_TIME_ZONE.TIME_ZONE_NAME)
                                 .from(MV_TIME_ZONE.MV_TIME_ZONE)
                                 .stream()
                                 .map(Record1::component1)
-                                .map(TimeZone::new)
+                                .map(TimeZoneId::new)
                                 .collect(Collectors.toList()));
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZoneId.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZoneId.java
@@ -21,15 +21,15 @@ import java.time.ZoneId;
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class TimeZone extends CwmsDTOBase {
+public final class TimeZoneId extends CwmsDTOBase {
     @JsonProperty(required = true)
     private String timeZone;
 
-    public TimeZone() {
+    public TimeZoneId() {
         super();
     }
 
-    public TimeZone(String timeZone) {
+    public TimeZoneId(String timeZone) {
         this();
         this.timeZone = timeZone;
     }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZoneIds.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/TimeZoneIds.java
@@ -7,6 +7,7 @@
 
 package cwms.cda.data.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
@@ -21,23 +22,24 @@ import java.util.List;
 @FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
 @FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
-public final class TimeZones extends CwmsDTOBase
+public final class TimeZoneIds extends CwmsDTOBase
 {
-	private List<TimeZone> timeZones;
+	@JsonProperty("time-zones")
+	private List<TimeZoneId> timeZoneIds;
 
 	@SuppressWarnings("unused")
-	private TimeZones()
+	private TimeZoneIds()
 	{
 		// for JAXB to handle marshalling
 	}
 
-	public TimeZones(List<TimeZone> timeZones)
+	public TimeZoneIds(List<TimeZoneId> timeZoneIds)
 	{
-		this.timeZones = timeZones;
+		this.timeZoneIds = timeZoneIds;
 	}
 
-	public List<TimeZone> getTimeZones()
+	public List<TimeZoneId> getTimeZones()
 	{
-		return timeZones;
+		return timeZoneIds;
 	}
 }

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeZoneIdControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeZoneIdControllerTestIT.java
@@ -13,7 +13,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
 
 @Tag("integration")
-class TimeZoneControllerTestIT extends DataApiTestIT
+class TimeZoneIdControllerTestIT extends DataApiTestIT
 {
 	@ParameterizedTest
 	@EnumSource(GetAllTest.class)

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/TimeZoneIdTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/TimeZoneIdTest.java
@@ -9,10 +9,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.util.List;
@@ -21,7 +18,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class TimeZoneTest
+class TimeZoneIdTest
 {
 
 	@ParameterizedTest
@@ -29,9 +26,9 @@ class TimeZoneTest
 	void test_serialization(SerializationType test)
 	{
 		String tz = "UTC";
-		TimeZone expectedTz = new TimeZone(tz);
+		TimeZoneId expectedTz = new TimeZoneId(tz);
 		String json = Formats.format(test._contentType, expectedTz);
-		TimeZone receivedTz = Formats.parseContent(test._contentType, json, TimeZone.class);
+		TimeZoneId receivedTz = Formats.parseContent(test._contentType, json, TimeZoneId.class);
 		assertEquals(expectedTz.getTimeZone(), receivedTz.getTimeZone());
 	}
 
@@ -39,7 +36,7 @@ class TimeZoneTest
 	void test_getTimeZone()
 	{
 		String expectedTz = "UTC";
-		TimeZone zone = new TimeZone(expectedTz);
+		TimeZoneId zone = new TimeZoneId(expectedTz);
 		String receivedZone = zone.getTimeZone();
 		assertEquals(expectedTz, receivedZone);
 	}
@@ -47,7 +44,7 @@ class TimeZoneTest
 	@Test
 	void test_getTimeZone_null()
 	{
-		TimeZone zone = new TimeZone();
+		TimeZoneId zone = new TimeZoneId();
 		String receivedZone = zone.getTimeZone();
 		assertNull(receivedZone);
 	}
@@ -56,7 +53,7 @@ class TimeZoneTest
 	void test_validate()
 	{
 		String expectedTz = "UTC";
-		TimeZone zone = new TimeZone(expectedTz);
+		TimeZoneId zone = new TimeZoneId(expectedTz);
 		assertDoesNotThrow(zone::validate);
 	}
 
@@ -64,7 +61,7 @@ class TimeZoneTest
 	void test_validate_failure()
 	{
 		String expectedTz = "Not a Time Zone";
-		TimeZone zone = new TimeZone(expectedTz);
+		TimeZoneId zone = new TimeZoneId(expectedTz);
 		assertThrows(FieldException.class, zone::validate);
 	}
 
@@ -72,15 +69,15 @@ class TimeZoneTest
 	void test_serialize_list()
 	{
 		ContentType contentType = new ContentType(Formats.JSONV2);
-		TimeZones tzs = new TimeZones(ZoneId.getAvailableZoneIds()
+		TimeZoneIds tzs = new TimeZoneIds(ZoneId.getAvailableZoneIds()
 									   .stream()
-									   .map(TimeZone::new)
+									   .map(TimeZoneId::new)
 									   .collect(Collectors.toList()));
 		String json = Formats.format(contentType, tzs);
-		TimeZones receivedTzs = Formats.parseContent(contentType, json, TimeZones.class);
+		TimeZoneIds receivedTzs = Formats.parseContent(contentType, json, TimeZoneIds.class);
 
-		List<TimeZone> expectedZones = tzs.getTimeZones();
-		List<TimeZone> receivedZones = receivedTzs.getTimeZones();
+		List<TimeZoneId> expectedZones = tzs.getTimeZones();
+		List<TimeZoneId> receivedZones = receivedTzs.getTimeZones();
 
 		assertEquals(expectedZones.size(), receivedZones.size());
 
@@ -96,11 +93,11 @@ class TimeZoneTest
 		assertNotNull(resource);
 		String json = IOUtils.toString(resource, StandardCharsets.UTF_8);
 		ContentType contentType = new ContentType(Formats.JSONV2);
-		TimeZones receivedTzs = Formats.parseContent(contentType, json, TimeZones.class);
+		TimeZoneIds receivedTzs = Formats.parseContent(contentType, json, TimeZoneIds.class);
 		assertTrue(!receivedTzs.getTimeZones().isEmpty());
 	}
 
-	private Executable testZone(TimeZone expected, TimeZone received)
+	private Executable testZone(TimeZoneId expected, TimeZoneId received)
 	{
 		return () -> assertEquals(expected.getTimeZone(), received.getTimeZone());
 	}


### PR DESCRIPTION
this prevents confusion with `java.util.TimeZone` and clarifies that only the id is collected