### PR TITLE
Don't change the session office for information retrieval.

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -451,7 +451,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
         Boolean cachedValue = isVersionedCache.getIfPresent(cacheKey);
         if (cachedValue == null) {
             cachedValue = connectionResult(dsl, connection -> {
-                Configuration configuration = getDslContext(connection, office).configuration();
+                Configuration configuration = getDslContext(connection, null).configuration();
                 boolean isVersioned =
                         OracleTypeMap.parseBool(CWMS_TS_PACKAGE.call_IS_TSID_VERSIONED(configuration,
                                 tsId, office));

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -419,11 +419,8 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
     }
 
     public static String getTimeZoneId(DSLContext dsl, String tsId, String officeId) {
-        return dsl.connectionResult(c -> {
-            Configuration config = getDslContext(c, officeId).configuration();
-            String locationId = TimeSeriesDaoImpl.parseLocFromTimeSeriesId(tsId);
-            return CWMS_LOC_PACKAGE.call_GET_LOCAL_TIMEZONE__2(config, locationId, officeId);
-        });
+        String locationId = TimeSeriesDaoImpl.parseLocFromTimeSeriesId(tsId);
+        return CWMS_LOC_PACKAGE.call_GET_LOCAL_TIMEZONE__2(dsl.configuration(), locationId, officeId);
     }
 
     public static VersionType getVersionType(DSLContext dsl, String names, String office, boolean dateProvided) {
@@ -450,14 +447,11 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 
         Boolean cachedValue = isVersionedCache.getIfPresent(cacheKey);
         if (cachedValue == null) {
-            cachedValue = connectionResult(dsl, connection -> {
-                Configuration configuration = getDslContext(connection, null).configuration();
-                boolean isVersioned =
-                        OracleTypeMap.parseBool(CWMS_TS_PACKAGE.call_IS_TSID_VERSIONED(configuration,
-                                tsId, office));
-                isVersionedCache.put(cacheKey, isVersioned);
-                return isVersioned;
-            });
+            boolean isVersioned =
+                    OracleTypeMap.parseBool(CWMS_TS_PACKAGE.call_IS_TSID_VERSIONED(dsl.configuration(),
+                            tsId, office));
+            isVersionedCache.put(cacheKey, isVersioned);
+            return isVersioned;
         }
         return cachedValue;
     }


### PR DESCRIPTION
Actually going to try another fix, but just using the configuration directly caused the connection to stay open. Wanted to get this in due to other timing.

But in short the issue is that during the retrieval of isVersioned the connection session is set to the data set office when it doesn't need to be. So going to try the connectionResult in a different way to see if I can get it to behave.