### PR TITLE
Change group name for clarity

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      alldependencies:
+      github-action-dependencies:
         patterns:
           - "*"
         update-types:


### PR DESCRIPTION
Realized when we get the emails about dependencies every batch is called "alldependencies", changed the group name for the github actions so the reader of the email knows more directly what they'll be looking at.