### PR TITLE
update to perform location cleanup only after all integration tests

### DIFF
--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationCleanup.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationCleanup.java
@@ -1,0 +1,90 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2024 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.api;
+
+import cwms.cda.data.dto.Location;
+import fixtures.CwmsDataApiSetupCallback;
+import java.io.IOException;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
+import org.apache.commons.io.IOUtils;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+
+public class LocationCleanup implements TestExecutionListener {
+
+    /**
+     * List of locations that will need to be deleted when tests are done.
+     */
+    public static final Set<Location> locationsCreated = new LinkedHashSet<>();
+
+    @Override
+    public void testPlanExecutionFinished(TestPlan testPlan) {
+        try {
+            cleanupLocations();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Runs cascade delete on each location. Location not existing is not an error.
+     * All other errors will throw a runtime exception and may require manual database
+     * cleanup.
+     */
+    private static void cleanupLocations() throws IOException {
+
+        String deleteLocationQuery = IOUtils.toString(
+            CwmsDataApiSetupCallback.class
+                .getClassLoader()
+                .getResourceAsStream("cwms/cda/data/sql_templates/delete_location.sql"),"UTF-8"
+        );
+        Iterator<Location> it = locationsCreated.iterator();
+        while(it.hasNext()) {
+            try {
+                Location location = it.next();
+                CwmsDatabaseContainer<?> db = CwmsDataApiSetupCallback.getDatabaseLink();
+                db.connection((c)-> {
+                    try(PreparedStatement stmt = c.prepareStatement(deleteLocationQuery)) {
+                        stmt.setString(1,location.getName());
+                        stmt.setString(2,location.getOfficeId());
+                        stmt.execute();
+                    } catch (SQLException ex) {
+                        if (ex.getErrorCode() != 20025 /*does not exist*/) {
+                            throw new RuntimeException("Unable to remove location",ex);
+                        }
+                    }
+                },"cwms_20");
+                it.remove();
+            } catch(SQLException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/api/location/kind/GateChangeControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/location/kind/GateChangeControllerTestIT.java
@@ -131,11 +131,8 @@ class GateChangeControllerTestIT extends BaseOutletDaoIT {
             } catch (RuntimeException ex) {
                 LOGGER.atFinest().withCause(ex).log("We don't care about this...");
             }
-            deleteLocation(context, CONDUIT_GATE_1.getOfficeId(), CONDUIT_GATE_1.getName());
-            deleteLocation(context, CONDUIT_GATE_2.getOfficeId(), CONDUIT_GATE_2.getName());
             deleteLocationGroup(context, CONDUIT_GATE_1_OUTLET);
         }, CwmsDataApiSetupCallback.getWebUser());
-        tearDownProject();
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/location/kind/OutletControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/location/kind/OutletControllerTestIT.java
@@ -126,16 +126,7 @@ class OutletControllerTestIT extends BaseOutletDaoIT {
             deleteLocationGroup(context, EXISTING_CONDUIT_GATE_OUTLET);
             deleteLocationGroup(context, NEW_CONDUIT_GATE_1_OUTLET);
             deleteLocationGroup(context, NEW_CONDUIT_GATE_2_OUTLET);
-            deleteLocation(context, NEW_CONDUIT_GATE_1.getOfficeId(), NEW_CONDUIT_GATE_1.getName());
-            deleteLocation(context, NEW_CONDUIT_GATE_2.getOfficeId(), NEW_CONDUIT_GATE_2.getName());
-            deleteLocation(context, RENAMED_CONDUIT_GATE.getOfficeId(), RENAMED_CONDUIT_GATE.getName());
-            deleteLocation(context, EXISTING_CONDUIT_GATE.getOfficeId(), EXISTING_CONDUIT_GATE.getName());
-            deleteLocation(context, RATED_OUTLET_LOCATION_CONTROLLED.getOfficeId(),
-                           RATED_OUTLET_LOCATION_CONTROLLED.getName());
-            deleteLocation(context, RATED_OUTLET_LOCATION_UNCONTROLLED.getOfficeId(),
-                            RATED_OUTLET_LOCATION_UNCONTROLLED.getName());
         }, CwmsDataApiSetupCallback.getWebUser());
-        tearDownProject();
     }
 
     @Disabled("Disabled due to a DB issue.  See https://jira.hecdev.net/browse/CWDB-296")

--- a/cwms-data-api/src/test/java/cwms/cda/api/location/kind/VirtualOutletControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/location/kind/VirtualOutletControllerTestIT.java
@@ -169,19 +169,7 @@ class VirtualOutletControllerTestIT  extends ProjectStructureIT {
             outletDao.deleteOutlet(CO3_I2.getOfficeId(), CO3_I2.getName(), DeleteRule.DELETE_ALL);
             outletDao.deleteOutlet(CO3_I3.getOfficeId(), CO3_I3.getName(), DeleteRule.DELETE_ALL);
             outletDao.deleteOutlet(CO3_CONDUIT.getOfficeId(), CO3_CONDUIT.getName(), DeleteRule.DELETE_ALL);
-
-            deleteLocation(context, CO1_I25.getOfficeId(), CO1_I25.getName());
-            deleteLocation(context, CO1_I53.getOfficeId(), CO1_I53.getName());
-            deleteLocation(context, CO1_LOW_FLOW.getOfficeId(), CO1_LOW_FLOW.getName());
-            deleteLocation(context, CO2_CONDUIT.getOfficeId(), CO2_CONDUIT.getName());
-            deleteLocation(context, CO2_INTAKE.getOfficeId(), CO2_INTAKE.getName());
-            deleteLocation(context, CO2_WEIR.getOfficeId(), CO2_WEIR.getName());
-            deleteLocation(context, CO3_I1.getOfficeId(), CO3_I1.getName());
-            deleteLocation(context, CO3_I2.getOfficeId(), CO3_I2.getName());
-            deleteLocation(context, CO3_I3.getOfficeId(), CO3_I3.getName());
-            deleteLocation(context, CO3_CONDUIT.getOfficeId(), CO3_CONDUIT.getName());
         }, CwmsDataApiSetupCallback.getWebUser());
-        tearDownProject();
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/EmbankmentDaoIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/EmbankmentDaoIT.java
@@ -78,7 +78,6 @@ final class EmbankmentDaoIT extends ProjectStructureIT {
 
     @AfterAll
     public void tearDown() throws Exception {
-        tearDownProject();
         CwmsDatabaseContainer<?> databaseLink = CwmsDataApiSetupCallback.getDatabaseLink();
         databaseLink.connection(c -> {
             DSLContext context = getDslContext(c, OFFICE_ID);

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoChangeIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoChangeIT.java
@@ -126,10 +126,7 @@ class OutletDaoChangeIT extends BaseOutletDaoIT {
             outletDao.deleteOutlet(TAINTER_GATE_20_LOC.getOfficeId(), TAINTER_GATE_20_LOC.getName(),
                                    DeleteRule.DELETE_ALL);
             deleteLocationGroup(context, TAINTER_GATE_10_OUTLET);
-            deleteLocation(context, TAINTER_GATE_10_LOC.getOfficeId(), TAINTER_GATE_10_LOC.getName());
-            deleteLocation(context, TAINTER_GATE_20_LOC.getOfficeId(), TAINTER_GATE_20_LOC.getName());
         }, CwmsDataApiSetupCallback.getWebUser());
-        tearDownProject();
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoIT.java
@@ -100,12 +100,7 @@ class OutletDaoIT extends BaseOutletDaoIT {
             outletDao.deleteOutlet(TAINTER_GATE_2_LOC.getOfficeId(), TAINTER_GATE_2_LOC.getName(),
                                    DeleteRule.DELETE_ALL);
             outletDao.deleteOutlet(BOX_CULVERT_1_LOC.getOfficeId(), BOX_CULVERT_1_LOC.getName(), DeleteRule.DELETE_ALL);
-            deleteLocation(context, TAINTER_GATE_1_LOC.getOfficeId(), TAINTER_GATE_1_LOC.getName());
-            deleteLocation(context, TAINTER_GATE_2_LOC.getOfficeId(), TAINTER_GATE_2_LOC.getName());
-            deleteLocation(context, TAINTER_GATE_3_LOC.getOfficeId(), TAINTER_GATE_3_LOC.getName());
-            deleteLocation(context, BOX_CULVERT_1_LOC.getOfficeId(), BOX_CULVERT_1_LOC.getName());
         }, CwmsDataApiSetupCallback.getWebUser());
-        tearDownProject();
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoRatingIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoRatingIT.java
@@ -69,11 +69,6 @@ class OutletDaoRatingIT extends BaseOutletDaoIT {
         setupProject();
     }
 
-    @AfterAll
-    static void cleanup() throws Exception {
-        tearDownProject();
-    }
-
     @Test
     void test_uncontrolled_outlet() throws SQLException {
         CwmsDatabaseContainer<?> databaseLink = CwmsDataApiSetupCallback.getDatabaseLink();

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoVirtualIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoVirtualIT.java
@@ -170,19 +170,7 @@ class OutletDaoVirtualIT extends BaseOutletDaoIT {
             outletDao.deleteOutlet(CO3_I2.getOfficeId(), CO3_I2.getName(), DeleteRule.DELETE_ALL);
             outletDao.deleteOutlet(CO3_I3.getOfficeId(), CO3_I3.getName(), DeleteRule.DELETE_ALL);
             outletDao.deleteOutlet(CO3_CONDUIT.getOfficeId(), CO3_CONDUIT.getName(), DeleteRule.DELETE_ALL);
-
-            deleteLocation(context, CO1_I25.getOfficeId(), CO1_I25.getName());
-            deleteLocation(context, CO1_I53.getOfficeId(), CO1_I53.getName());
-            deleteLocation(context, CO1_LOW_FLOW.getOfficeId(), CO1_LOW_FLOW.getName());
-            deleteLocation(context, CO2_CONDUIT.getOfficeId(), CO2_CONDUIT.getName());
-            deleteLocation(context, CO2_INTAKE.getOfficeId(), CO2_INTAKE.getName());
-            deleteLocation(context, CO2_WEIR.getOfficeId(), CO2_WEIR.getName());
-            deleteLocation(context, CO3_I1.getOfficeId(), CO3_I1.getName());
-            deleteLocation(context, CO3_I2.getOfficeId(), CO3_I2.getName());
-            deleteLocation(context, CO3_I3.getOfficeId(), CO3_I3.getName());
-            deleteLocation(context, CO3_CONDUIT.getOfficeId(), CO3_CONDUIT.getName());
         }, CwmsDataApiSetupCallback.getWebUser());
-        tearDownProject();
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/ProjectStructureIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/ProjectStructureIT.java
@@ -9,9 +9,9 @@ package cwms.cda.data.dao.location.kind;
 
 import com.google.common.flogger.FluentLogger;
 import cwms.cda.api.DataApiTestIT;
+import cwms.cda.api.LocationCleanup;
 import cwms.cda.api.enums.Nation;
 import cwms.cda.api.errors.NotFoundException;
-import cwms.cda.data.dao.DeleteRule;
 import cwms.cda.data.dao.LocationsDaoImpl;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.data.dto.Location;
@@ -46,24 +46,10 @@ public abstract class ProjectStructureIT extends DataApiTestIT {
 		CwmsDatabaseContainer<?> databaseLink = CwmsDataApiSetupCallback.getDatabaseLink();
 		databaseLink.connection(c -> {
 			DSLContext context = getDslContext(c, OFFICE_ID);
-			CWMS_PROJECT_PACKAGE.call_STORE_PROJECT(context.configuration(), buildProject(PROJECT_LOC), "T");
-			CWMS_PROJECT_PACKAGE.call_STORE_PROJECT(context.configuration(), buildProject(PROJECT_LOC2), "T");
-		}, CwmsDataApiSetupCallback.getWebUser());
-	}
-
-	public static void tearDownProject() throws Exception
-	{
-		//Don't tag this as a @AfterAll - JUnit can't guarantee this occurs first.
-		CwmsDatabaseContainer<?> databaseLink = CwmsDataApiSetupCallback.getDatabaseLink();
-		databaseLink.connection(c -> {
-			DSLContext context = getDslContext(c, OFFICE_ID);
-			LocationsDaoImpl locationsDao = new LocationsDaoImpl(context);
-			CWMS_PROJECT_PACKAGE.call_DELETE_PROJECT(context.configuration(), PROJECT_LOC.getName(),
-					DeleteRule.DELETE_ALL.getRule(), OFFICE_ID);
-			CWMS_PROJECT_PACKAGE.call_DELETE_PROJECT(context.configuration(), PROJECT_LOC2.getName(),
-					DeleteRule.DELETE_ALL.getRule(), OFFICE_ID);
-			locationsDao.deleteLocation(PROJECT_LOC.getName(), OFFICE_ID, true);
-			locationsDao.deleteLocation(PROJECT_LOC2.getName(), OFFICE_ID, true);
+			CWMS_PROJECT_PACKAGE.call_STORE_PROJECT(context.configuration(), buildProject(PROJECT_LOC), "F");
+			LocationCleanup.locationsCreated.add(PROJECT_LOC);
+			CWMS_PROJECT_PACKAGE.call_STORE_PROJECT(context.configuration(), buildProject(PROJECT_LOC2), "F");
+			LocationCleanup.locationsCreated.add(PROJECT_LOC2);
 		}, CwmsDataApiSetupCallback.getWebUser());
 	}
 
@@ -134,6 +120,7 @@ public abstract class ProjectStructureIT extends DataApiTestIT {
 		LocationsDaoImpl locationsDao = new LocationsDaoImpl(context);
 		deleteLocation(context, loc.getOfficeId(), loc.getName());
 		locationsDao.storeLocation(loc);
+		LocationCleanup.locationsCreated.add(loc);
 	}
 
 	public static void deleteLocation(DSLContext context, String officeId, String locId) {

--- a/cwms-data-api/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/cwms-data-api/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,1 @@
+cwms.cda.api.LocationCleanup

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,8 @@ java-ee = "8.0.1"
 cwms-tomcat-auth = "1.1.0"
 jjwt = "0.11.5"
 jstl = "1.2"
-junit = "5.8.2"
+junit = "5.11.1"
+junit-launcher = "1.11.2"
 testcontainers = "1.17.1"
 cwms-testcontainers = "1.0.7"
 oracle-jdbc = "19.3.0.0"
@@ -96,6 +97,7 @@ junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-launcher" }
 
 
 testcontainers-base = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers"}
@@ -126,7 +128,7 @@ io-github-classgraph = { module = "io.github.classgraph:classgraph", version.ref
 io-swagger-parser = { module = "io.swagger.parser.v3:swagger-parser", version.ref = "swagger-parser" }
 
 [bundles]
-junit = ["junit-jupiter-api", "junit-jupiter-params", "junit-jupiter-engine"]
+junit = ["junit-jupiter-api", "junit-jupiter-params", "junit-jupiter-engine", "junit-platform-launcher"]
 tomcat-embedded = [ "tomcat-embedded-core", "tomcat-embedded-jasper" ]
 tomcat-support = [ "tomcat-juli", "tomcat-jdbc" ]
 testcontainers = [ "testcontainers-base", "testcontainers-database-commons", "testcontainers-jdbc", "testcontainers-junit-jupiter", "testcontainers-cwms"]


### PR DESCRIPTION
This fixed the failing gate/outlet integration tests. Project lock tests are waiting on a separate PR in BitBucket.