### PR TITLE
Restrict access to the auth end point to users that are directly auth…

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -12,6 +12,7 @@ import cwms.cda.datasource.SessionTimeZonePreparer;
 import cwms.cda.helpers.ResourceHelper;
 import cwms.cda.security.CwmsAuthException;
 import cwms.cda.security.DataApiPrincipal;
+import cwms.cda.security.MissingRolesException;
 import cwms.cda.security.Role;
 import io.javalin.core.security.RouteRole;
 import io.javalin.http.Context;
@@ -35,6 +36,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import javax.sql.DataSource;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
@@ -321,8 +324,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                 logger.atFinest().log("User has required roles.");
                 return;
             } else {
-                logger.atFine().log();
-                throw new CwmsAuthException(getFailMessage(ctx,routeRoles,p),403);
+                throw new MissingRolesException(getMissingRoles(ctx, routeRoles, p));
             }
         } else {
             throw new CwmsAuthException("No credentials provided.",401);
@@ -351,14 +353,13 @@ public class AuthDao extends Dao<DataApiPrincipal> {
         }
     }
 
-    private static String getFailMessage(@NotNull Context ctx,
+    private static String[] getMissingRoles(@NotNull Context ctx,
                                         @NotNull Set<RouteRole> requiredRoles,
                                         @NotNull DataApiPrincipal p) {
         Set<RouteRole> specifiedRoles = p.getRoles();
         Set<RouteRole> missing = new LinkedHashSet<>(requiredRoles);
         missing.removeAll(specifiedRoles);
-
-        return "Request for: " + ctx.req.getRequestURI() + " denied. Missing roles: " + missing;
+        return missing.stream().map(r -> r.toString()).collect(Collectors.toList()).toArray(new String[0]);
     }
 
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -28,6 +28,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -353,13 +354,16 @@ public class AuthDao extends Dao<DataApiPrincipal> {
         }
     }
 
-    private static String[] getMissingRoles(@NotNull Context ctx,
+    private static List<String> getMissingRoles(@NotNull Context ctx,
                                         @NotNull Set<RouteRole> requiredRoles,
                                         @NotNull DataApiPrincipal p) {
         Set<RouteRole> specifiedRoles = p.getRoles();
         Set<RouteRole> missing = new LinkedHashSet<>(requiredRoles);
         missing.removeAll(specifiedRoles);
-        return missing.stream().map(r -> r.toString()).collect(Collectors.toList()).toArray(new String[0]);
+        return Collections.unmodifiableList(
+            missing.stream()
+                   .map(r -> r.toString())
+                   .collect(Collectors.toList()));
     }
 
 

--- a/cwms-data-api/src/main/java/cwms/cda/security/MissingRolesException.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/MissingRolesException.java
@@ -1,11 +1,13 @@
 package cwms.cda.security;
 
+import java.util.List;
+
 import javax.servlet.http.HttpServletResponse;
 
 public class MissingRolesException extends CwmsAuthException {
-    private String[] missingRoles;
+    private List<String> missingRoles;
 
-    public MissingRolesException(String []missingRoles) {
+    public MissingRolesException(List<String> missingRoles) {
         super("Missing Roles", HttpServletResponse.SC_FORBIDDEN);
         this.missingRoles = missingRoles;
     }

--- a/cwms-data-api/src/main/java/cwms/cda/security/MissingRolesException.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/MissingRolesException.java
@@ -1,0 +1,17 @@
+package cwms.cda.security;
+
+import javax.servlet.http.HttpServletResponse;
+
+public class MissingRolesException extends CwmsAuthException {
+    private String[] missingRoles;
+
+    public MissingRolesException(String []missingRoles) {
+        super("Missing Roles", HttpServletResponse.SC_FORBIDDEN);
+        this.missingRoles = missingRoles;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Missing roles {" + String.join(",",missingRoles) + "}";
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
@@ -284,9 +284,32 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
             .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()));
     }
 
+    @Order(6)
+    @ParameterizedTest
+	@ArgumentsSource(UserSpecSource.class)
+	@AuthType(user = TestAccounts.KeyUser.SPK_NORMAL)
+    public void test_api_key_cannot_create_new_key(String authType, TestAccounts.KeyUser theUser, RequestSpecification authSpec) {
+        final String KEY_NAME = "KeyFromKey";
+
+        // This doesn't need to be a user in the database, the check is done before it gets there
+        final ApiKey key = new ApiKey(theUser.getName(),KEY_NAME,null,null,ZonedDateTime.now());
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .header("Authorization", "apikey " + realKeys.get(0).getApiKey())
+            .contentType("application/json")
+            .body(key)
+        .when()
+            .post("/auth/keys")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpCode.FORBIDDEN.getStatus()))
+            .body("message",is("Missing roles {Role{name='cac_user'}}"));
+    }
+
     // delete api keys
     // List API keys
-    @Order(6)
+    @Order(7)
     @ParameterizedTest
 	@ArgumentsSource(UserSpecSource.class)
 	@AuthType(user = TestAccounts.KeyUser.SPK_NORMAL)

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -25,7 +25,9 @@ import fixtures.tomcat.SingleSignOnWrapper;
 import helpers.TsRandomSampler;
 import io.restassured.RestAssured;
 import io.restassured.config.JsonConfig;
+import io.restassured.filter.log.LogDetail;
 import io.restassured.path.json.config.JsonPathConfig;
+import io.restassured.response.ValidatableResponse;
 
 import javax.servlet.http.HttpServletResponse;
 
@@ -110,6 +112,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
                 .when()
                     .get("/offices/SPK")
                 .then()
+                    .log().ifValidationFails(LogDetail.ALL)
                     .assertThat()
                     .statusCode(is(HttpServletResponse.SC_OK));
                 logger.atInfo().log("Server is up!");


### PR DESCRIPTION
…enticated.

Fixes #906.

As the required roles are (or at least should be) listed on the openapi specification, there is no leak of information to inform the user exactly which role they are missing.