### PR TITLE
Move tagged release job to it's own yaml file.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,21 +101,3 @@ jobs:
         if: ${{ always() }}
         run: |
           docker logout ${{ steps.login-ghcr.outputs.registry }}
----
-name: Tagged Release
-on:
-  push:
-    tags:
-      - '[0-9][0-9][0-9][0-9].[09][0-9].[0-9]'
-      - '[0-9][0-9][0-9][0-9].[09][0-9].[0-9]-*+'
-jobs:
-  release:
-    uses: ./.github/workflows/release.yml
-    secrets:
-      token: ${{ secrets.GITHUB_TOKEN }}
-      registry: ${{ secrets.HEC_PUB_REGISTRY}}
-      registry_user: ${{ secrets.ALT_REG_USER }}
-      registry_password: ${{ secrets.ALT_REG_PASSWORD }}
-    with:
-      branch: ${{github.ref_name}}
-      nightly: false

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -1,0 +1,18 @@
+---
+name: Tagged Release
+on:
+  push:
+    tags:
+      - '[0-9][0-9][0-9][0-9].[09][0-9].[0-9]'
+      - '[0-9][0-9][0-9][0-9].[09][0-9].[0-9]-*+'
+jobs:
+  release:
+    uses: ./.github/workflows/release.yml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      registry: ${{ secrets.HEC_PUB_REGISTRY}}
+      registry_user: ${{ secrets.ALT_REG_USER }}
+      registry_password: ${{ secrets.ALT_REG_PASSWORD }}
+    with:
+      branch: ${{github.ref_name}}
+      nightly: false


### PR DESCRIPTION
Immediately discovered that you can't have two job sets in the same yaml file... apparently I've been doing too much kubernetes work where multiple yaml blocks are rather common.