### PR TITLE
Bugfix/996 default formats

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/formatters/ContentTypeAliasMap.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/ContentTypeAliasMap.java
@@ -14,41 +14,38 @@ import org.jetbrains.annotations.NotNull;
 import java.util.HashMap;
 import java.util.Map;
 
-final class ContentTypeAliasMap
-{
-	private final Map<String, ContentType> _contentTypeMap = new HashMap<>();
-	private static final Map<Class<? extends CwmsDTOBase>, ContentTypeAliasMap> ALIAS_MAP = new HashMap<>();
+final class ContentTypeAliasMap {
+    private final Map<ContentType, ContentType> contentTypeMap = new HashMap<>();
+    private static final Map<Class<? extends CwmsDTOBase>, ContentTypeAliasMap> ALIAS_MAP = new HashMap<>();
 
-	private ContentTypeAliasMap()
-	{
-	}
+    private ContentTypeAliasMap()
+    {
+    }
 
-	private ContentTypeAliasMap(Class<? extends CwmsDTOBase> dtoClass)
-	{
-		FormattableWith[] formats = dtoClass.getAnnotationsByType(FormattableWith.class);
-		for (FormattableWith format : formats)
-		{
-			ContentType type = new ContentType(format.contentType());
+    private ContentTypeAliasMap(Class<? extends CwmsDTOBase> dtoClass) {
+        FormattableWith[] formats = dtoClass.getAnnotationsByType(FormattableWith.class);
+        for (FormattableWith format : formats) {
+            ContentType type = new ContentType(format.contentType());
 
-			for (String alias : format.aliases())
-			{
-				_contentTypeMap.put(alias, type);
-			}
-		}
-	}
+            for (String alias : format.aliases()) {
+                contentTypeMap.put(new ContentType(alias), type);
+            }
+        }
+    }
 
-	public static ContentTypeAliasMap forDtoClass(@NotNull Class<? extends CwmsDTOBase> dtoClass)
-	{
-		return ALIAS_MAP.computeIfAbsent(dtoClass, ContentTypeAliasMap::new);
-	}
+    public static ContentTypeAliasMap forDtoClass(@NotNull Class<? extends CwmsDTOBase> dtoClass) {
+        return ALIAS_MAP.computeIfAbsent(dtoClass, ContentTypeAliasMap::new);
+    }
 
-	public static ContentTypeAliasMap empty()
-	{
-		return new ContentTypeAliasMap();
-	}
+    public static ContentTypeAliasMap empty() {
+        return new ContentTypeAliasMap();
+    }
 
-	public ContentType getContentType(String alias)
-	{
-		return _contentTypeMap.get(alias);
-	}
+    public ContentType getContentType(ContentType alias) {
+        return contentTypeMap.get(alias);
+    }
+
+    public ContentType getContentType(String alias) {
+        return contentTypeMap.get(new ContentType(alias));
+    }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/Formats.java
@@ -116,7 +116,7 @@ public class Formats {
     private String getFormatted(ContentType type, CwmsDTOBase toFormat) throws FormattingException {
         Objects.requireNonNull(toFormat, "Object to be formatted should not be null");
         formatters.keySet().forEach(k -> logger.fine(k::toString));
-        OutputFormatter outputFormatter = getOutputFormatter(type, toFormat.getClass());
+        OutputFormatter outputFormatter = getOutputFormatterInternal(type, toFormat.getClass());
 
         if (outputFormatter != null) {
             return outputFormatter.format(toFormat);
@@ -134,7 +134,7 @@ public class Formats {
             logger.finest(() -> key.toString());
         }
 
-        OutputFormatter outputFormatter = getOutputFormatter(type, rootType);
+        OutputFormatter outputFormatter = getOutputFormatterInternal(type, rootType);
 
         if (outputFormatter != null) {
             return outputFormatter.format(dtos);
@@ -147,7 +147,7 @@ public class Formats {
 
     private <T extends CwmsDTOBase> T parseContentFromType(ContentType type, String content, Class<T> rootType)
             throws FormattingException {
-        OutputFormatter outputFormatter = getOutputFormatter(type, rootType);
+        OutputFormatter outputFormatter = getOutputFormatterInternal(type, rootType);
         if (outputFormatter != null) {
             T retval = outputFormatter.parseContent(content, rootType);
             retval.validate();
@@ -161,7 +161,7 @@ public class Formats {
 
     private <T extends CwmsDTOBase> T parseContentFromType(ContentType type, InputStream content, Class<T> rootType)
             throws FormattingException {
-        OutputFormatter outputFormatter = getOutputFormatter(type, rootType);
+        OutputFormatter outputFormatter = getOutputFormatterInternal(type, rootType);
         if (outputFormatter != null) {
             T retval = outputFormatter.parseContent(content, rootType);
             retval.validate();
@@ -175,7 +175,7 @@ public class Formats {
 
     private <T extends CwmsDTOBase> List<T> parseContentListFromType(ContentType type, String content, Class<T> rootType)
         throws FormattingException {
-        OutputFormatter outputFormatter = getOutputFormatter(type, rootType);
+        OutputFormatter outputFormatter = getOutputFormatterInternal(type, rootType);
         if (outputFormatter != null) {
             List<T> retval = outputFormatter.parseContentList(content, rootType);
             if (retval == null) {
@@ -192,7 +192,7 @@ public class Formats {
         }
     }
 
-    private OutputFormatter getOutputFormatter(ContentType type,
+    private OutputFormatter getOutputFormatterInternal(ContentType type,
                                                Class<? extends CwmsDTOBase> klass) {
         OutputFormatter outputFormatter = null;
         Map<Class<? extends CwmsDTOBase>, OutputFormatter> contentFormatters = formatters.get(type);
@@ -217,6 +217,10 @@ public class Formats {
             }
         }
         return outputFormatter;
+    }
+
+    public static OutputFormatter getOutputFormatter(ContentType ct, Class<? extends CwmsDTOBase> klass) {
+            return formats.getOutputFormatterInternal(ct, klass);
     }
 
     public static String format(ContentType type, CwmsDTOBase toFormat) throws FormattingException {

--- a/cwms-data-api/src/test/java/cwms/cda/formatters/FormatsTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/formatters/FormatsTest.java
@@ -16,6 +16,11 @@ import cwms.cda.data.dto.State;
 import cwms.cda.data.dto.basinconnectivity.Basin;
 import cwms.cda.data.dto.project.LockRevokerRights;
 import cwms.cda.data.dto.project.Project;
+import cwms.cda.formatters.json.JsonV2;
+import cwms.cda.formatters.xml.XMLv2;
+import cwms.cda.formatters.xml.XMLv2Office;
+import io.swagger.v3.oas.annotations.Parameter;
+
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -183,7 +188,7 @@ class FormatsTest {
         //The following header comes from firefox
         ContentType contentType = Formats.parseHeader(FIREFOX_HEADER, Catalog.class);
         assertNotNull(contentType);
-        assertEquals(Formats.DEFAULT, contentType.toString());
+        assertEquals(Formats.XML, contentType.toString());
     }
 
     @EnumSource(ParseHeaderClassAliasTest.class)
@@ -270,7 +275,6 @@ class FormatsTest {
         final String query;
         final Class<? extends CwmsDTOBase> dto;
         final String type;
-        
 
         ParseQueryOrParamTest(String header, String query, Class<? extends CwmsDTOBase> dto, String type)
         {
@@ -279,7 +283,32 @@ class FormatsTest {
             this.dto = dto;
             this.type = type;
         }
-        
 
+    }
+
+
+    @ParameterizedTest
+    @EnumSource(ContentTypeFormatterSource.class)
+    void test_formatter_retrieval(ContentTypeFormatterSource test) {
+        ContentType ct = Formats.parseHeader(test.contentType, test.dto);
+        OutputFormatter formatterActual = Formats.getOutputFormatter(ct, test.dto);
+        assertNotNull(formatterActual, "No formatters available for given Content-Type and DTO.");
+        assertEquals(test.formatter, formatterActual.getClass(), "Expected Formatter was not returned.");
+    }
+
+    public enum ContentTypeFormatterSource {
+        OFFICE_DEFAULT("*/*", Office.class, JsonV2.class),
+        OFFICE_FIREFOX_DEFAULT("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8", Office.class, XMLv2Office.class)
+
+        ;
+        final String contentType;
+        final Class<? extends CwmsDTOBase> dto;
+        final Class<? extends OutputFormatter> formatter;
+
+        ContentTypeFormatterSource(String contentType, Class<? extends CwmsDTOBase> dto, Class<? extends OutputFormatter> formatter) {
+            this.contentType = contentType;
+            this.dto = dto;
+            this.formatter = formatter;
+        }
     }
 }


### PR DESCRIPTION
After deploying and querying data in a browser I notice we were getting a not formatter available message. This was caused by, at least in firefox, the catch all being `*/*;q=0.8` instead of just `*/*` so with the ContentTypeAliasMap being `String,ContentType`.

Changed it to `ContentType,ContentType` so that our looser equals (ignoring all parameters except version) would apply. 

Also had to update some tests as the FireFox Accept string I borrowed has `application/xml` at a higher priority than the catch all.