### PR TITLE
Correct logic to only run one version step.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,10 @@ jobs:
           java-version: '8'
           cache: 'gradle'
       - name: Set version
-        if: inputs.nightly
+        if: inputs.nightly == true
         run: echo "VERSION=${{inputs.branch}}-nightly" >> $GITHUB_ENV
       - name: Set version
+        if: inputs.nightly == false
         run: echo "VERSION=${{inputs.branch}}" >> $GITHUB_ENV
       - name: show version
         run: echo ${VERSION}


### PR DESCRIPTION
Realized that the version would always be the non-nightly variant.