### PR TITLE
Devops/enable forecast operations

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/ForecastInstanceDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/ForecastInstanceDao.java
@@ -211,7 +211,7 @@ public final class ForecastInstanceDao extends JooqDao<ForecastInstance> {
             if (attributes != null) {
                 fileName = (String) attributes[0];
                 mediaType = (String) attributes[1];
-                Blob blob = (Blob) attributes[4];
+                Blob blob = (Blob) attributes[5];
                 if (blob.length() > byteLimit) {
                     String param = "&%s=%s";
                     String utf8 = "UTF-8";
@@ -322,7 +322,7 @@ public final class ForecastInstanceDao extends JooqDao<ForecastInstance> {
                                 if (mediaType == null) {
                                     mediaType = "application/octet-stream";
                                 }
-                                Blob blob = (Blob) attributes[4];
+                                Blob blob = (Blob) attributes[5];
                                 consumer.accept(blob, mediaType);
                                 return;
                             }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/ForecastInstanceDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/ForecastInstanceDao.java
@@ -9,8 +9,13 @@ import cwms.cda.data.dto.forecast.ForecastSpec;
 import cwms.cda.formatters.UnsupportedFormatException;
 import cwms.cda.formatters.json.JsonV2;
 import cwms.cda.helpers.ReplaceUtils;
+import usace.cwms.db.jooq.codegen.packages.CWMS_FCST_PACKAGE;
+import usace.cwms.db.jooq.codegen.udt.records.BLOB_FILE_T;
+
 import java.util.TimeZone;
 import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
+import org.jooq.impl.DefaultBinding;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -111,21 +116,25 @@ public final class ForecastInstanceDao extends JooqDao<ForecastInstance> {
     }
 
     public void create(ForecastInstance forecastInst) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        String officeId = forecastInst.getSpec().getOfficeId();
-//        Timestamp forecastDate = Timestamp.from(forecastInst.getDateTime());
-//        Timestamp issueDate = Timestamp.from(forecastInst.getIssueDateTime());
-//        String forecastInfo = mapToJson(forecastInst.getMetadata());
-//        byte[] fileData = forecastInst.getFileData();
-//        BLOB_FILE_T blob = new BLOB_FILE_T(forecastInst.getFilename(), forecastInst.getFileMediaType(), OffsetDateTime.now(), 0L, fileData);
-//        connection(dsl, conn -> {
-//            setOffice(conn, officeId);
-//            DefaultBinding.THREAD_LOCAL.set(UTC_CALENDAR);
-//            CWMS_FCST_PACKAGE.call_STORE_FCST(DSL.using(conn).configuration(), forecastInst.getSpec().getSpecId(),
-//                    forecastInst.getSpec().getDesignator(), forecastDate, issueDate,
-//                    "UTC", forecastInst.getMaxAge(), forecastInst.getNotes(), forecastInfo,
-//                    blob, "F", "T", officeId);
-//        });
+       String officeId = forecastInst.getSpec().getOfficeId();
+       Timestamp forecastDate = Timestamp.from(forecastInst.getDateTime());
+       Timestamp issueDate = Timestamp.from(forecastInst.getIssueDateTime());
+       String forecastInfo = mapToJson(forecastInst.getMetadata());
+       byte[] fileData = forecastInst.getFileData();
+       BLOB_FILE_T blob = new BLOB_FILE_T();
+       blob.setFILENAME(forecastInst.getFilename());
+       blob.setMEDIA_TYPE(forecastInst.getFileMediaType());
+       blob.setDATA_ENTRY_DATE(OffsetDateTime.now());
+       blob.setQUALITY_CODE(0L);
+       blob.setTHE_BLOB(fileData);
+       connection(dsl, conn -> {
+           setOffice(conn, officeId);
+           DefaultBinding.THREAD_LOCAL.set(UTC_CALENDAR);
+           CWMS_FCST_PACKAGE.call_STORE_FCST(DSL.using(conn).configuration(), forecastInst.getSpec().getSpecId(),
+                   forecastInst.getSpec().getDesignator(), forecastDate, issueDate,
+                   "UTC", forecastInst.getMaxAge(), forecastInst.getNotes(), forecastInfo,
+                   blob, "F", "T", officeId);
+       });
     }
 
     private static String mapToJson(Map<String, String> metadata) {
@@ -283,13 +292,13 @@ public final class ForecastInstanceDao extends JooqDao<ForecastInstance> {
 
     public void delete(String office, String name, String designator,
             Instant forecastDate, Instant issueDate) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        connection(dsl, conn -> {
-//            setOffice(conn, office);
-//            DefaultBinding.THREAD_LOCAL.set(UTC_CALENDAR);
-//            CWMS_FCST_PACKAGE.call_DELETE_FCST(DSL.using(conn).configuration(), name, designator,
-//                    Timestamp.from(forecastDate), Timestamp.from(issueDate), "UTC", office);
-//        });
+       connection(dsl, conn -> {
+           setOffice(conn, office);
+           
+           DefaultBinding.THREAD_LOCAL.set(UTC_CALENDAR);
+           CWMS_FCST_PACKAGE.call_DELETE_FCST(getDslContext(conn, office).configuration(), name, designator,
+                   Timestamp.from(forecastDate), Timestamp.from(issueDate), "UTC", office);
+       });
     }
 
     public void getFileBlob(String office, String name, String designator,

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/ForecastSpecDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/ForecastSpecDao.java
@@ -3,6 +3,12 @@ package cwms.cda.data.dao;
 import cwms.cda.api.errors.NotFoundException;
 import cwms.cda.data.dto.forecast.ForecastSpec;
 import cwms.cda.formatters.UnsupportedFormatException;
+
+import usace.cwms.db.jooq.codegen.packages.CWMS_FCST_PACKAGE;
+import usace.cwms.db.jooq.codegen.tables.AV_FCST_LOCATION;
+import usace.cwms.db.jooq.codegen.tables.AV_FCST_SPEC;
+import usace.cwms.db.jooq.codegen.tables.AV_FCST_TIME_SERIES;
+
 import org.jooq.DSLContext;
 import org.jooq.Record2;
 import org.jooq.Record7;
@@ -25,64 +31,61 @@ public final class ForecastSpecDao extends JooqDao<ForecastSpec> {
 
 
     public void create(ForecastSpec forecastSpec) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        connection(dsl, conn -> {
-//            setOffice(conn, forecastSpec.getOfficeId());
-//
-//            String timeSeriesIds = null;
-//            if (forecastSpec.getTimeSeriesIds() != null) {
-//                timeSeriesIds = String.join("\n", forecastSpec.getTimeSeriesIds());
-//            }
-//            CWMS_FCST_PACKAGE.call_STORE_FCST_SPEC(DSL.using(conn).configuration(), forecastSpec.getSpecId(),
-//                    forecastSpec.getDesignator(), forecastSpec.getSourceEntityId(),
-//                    forecastSpec.getDescription(), forecastSpec.getLocationId(),
-//                    timeSeriesIds, "F", "F", forecastSpec.getOfficeId());
-//        });
+
+       connection(dsl, conn -> {
+           setOffice(conn, forecastSpec.getOfficeId());
+
+           String timeSeriesIds = null;
+           if (forecastSpec.getTimeSeriesIds() != null) {
+               timeSeriesIds = String.join("\n", forecastSpec.getTimeSeriesIds());
+           }
+           CWMS_FCST_PACKAGE.call_STORE_FCST_SPEC(DSL.using(conn).configuration(), forecastSpec.getSpecId(),
+                   forecastSpec.getDesignator(), forecastSpec.getSourceEntityId(),
+                   forecastSpec.getDescription(), forecastSpec.getLocationId(),
+                   timeSeriesIds, "F", "F", forecastSpec.getOfficeId());
+       });
     }
 
     public void delete(String office, String specId, String designator, DeleteRule deleteRule) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        connection(dsl, conn -> {
-//            setOffice(conn, office);
-//            CWMS_FCST_PACKAGE.call_DELETE_FCST_SPEC(DSL.using(conn).configuration(), specId, designator,
-//                    deleteRule.getRule(), office);
-//        });
+       connection(dsl, conn -> {
+           setOffice(conn, office);
+           CWMS_FCST_PACKAGE.call_DELETE_FCST_SPEC(DSL.using(conn).configuration(), specId, designator,
+                   deleteRule.getRule(), office);
+       });
     }
 
     public List<ForecastSpec> getForecastSpecs(String office, String specIdRegex,
             String designator, String sourceEntity) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        AV_FCST_SPEC spec = AV_FCST_SPEC.AV_FCST_SPEC;
-//        return forecastSpecQuery(dsl)
-//                .where(JooqDao.caseInsensitiveLikeRegex(spec.OFFICE_ID, office))
-//                .and(JooqDao.caseInsensitiveLikeRegex(spec.FCST_SPEC_ID, specIdRegex))
-//                .and(JooqDao.caseInsensitiveLikeRegex(spec.FCST_DESIGNATOR, designator))
-//                .and(JooqDao.caseInsensitiveLikeRegex(spec.ENTITY_ID, sourceEntity))
-//                .fetch()
-//                .map(ForecastSpecDao::map);
+       AV_FCST_SPEC spec = AV_FCST_SPEC.AV_FCST_SPEC;
+       return forecastSpecQuery(dsl)
+               .where(JooqDao.caseInsensitiveLikeRegex(spec.OFFICE_ID, office))
+               .and(JooqDao.caseInsensitiveLikeRegex(spec.FCST_SPEC_ID, specIdRegex))
+               .and(JooqDao.caseInsensitiveLikeRegex(spec.FCST_DESIGNATOR, designator))
+               .and(JooqDao.caseInsensitiveLikeRegex(spec.ENTITY_ID, sourceEntity))
+               .fetch()
+               .map(ForecastSpecDao::map);
     }
 
     private static SelectOnConditionStep<Record7<String, String, String, String,
             String, String, String>> forecastSpecQuery(DSLContext dsl) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        AV_FCST_SPEC spec = AV_FCST_SPEC.AV_FCST_SPEC;
-//        AV_FCST_TIME_SERIES timeSeries = AV_FCST_TIME_SERIES.AV_FCST_TIME_SERIES;
-//        AV_FCST_LOCATION loc = AV_FCST_LOCATION.AV_FCST_LOCATION;
-//        //Group all the timeseries ids into a "\n" delimited list
-//        Table<Record2<String, String>> tsidTable = dsl.select(timeSeries.FCST_SPEC_CODE,
-//                        DSL.listAgg(timeSeries.CWMS_TS_ID, "\n")
-//                                .withinGroupOrderBy(timeSeries.CWMS_TS_ID)
-//                                .as("time_series_list"))
-//                .from(timeSeries)
-//                .groupBy(timeSeries.FCST_SPEC_CODE)
-//                .asTable("tsids");
-//        return dsl.select(spec.FCST_SPEC_ID, spec.DESCRIPTION, spec.FCST_DESIGNATOR,
-//                        spec.OFFICE_ID, tsidTable.field("time_series_list", String.class), spec.ENTITY_ID, loc.LOCATION_ID)
-//                .from(spec)
-//                .leftJoin(tsidTable)
-//                .on(spec.FCST_SPEC_CODE.eq(tsidTable.field("FCST_SPEC_CODE", String.class)))
-//                .leftJoin(loc)
-//                .on(spec.FCST_SPEC_CODE.eq(loc.FCST_SPEC_CODE));
+       AV_FCST_SPEC spec = AV_FCST_SPEC.AV_FCST_SPEC;
+       AV_FCST_TIME_SERIES timeSeries = AV_FCST_TIME_SERIES.AV_FCST_TIME_SERIES;
+       AV_FCST_LOCATION loc = AV_FCST_LOCATION.AV_FCST_LOCATION;
+       //Group all the timeseries ids into a "\n" delimited list
+       Table<Record2<String, String>> tsidTable = dsl.select(timeSeries.FCST_SPEC_CODE,
+                       DSL.listAgg(timeSeries.CWMS_TS_ID, "\n")
+                               .withinGroupOrderBy(timeSeries.CWMS_TS_ID)
+                               .as("time_series_list"))
+               .from(timeSeries)
+               .groupBy(timeSeries.FCST_SPEC_CODE)
+               .asTable("tsids");
+       return dsl.select(spec.FCST_SPEC_ID, spec.DESCRIPTION, spec.FCST_DESIGNATOR,
+                       spec.OFFICE_ID, tsidTable.field("time_series_list", String.class), spec.ENTITY_ID, loc.LOCATION_ID)
+               .from(spec)
+               .leftJoin(tsidTable)
+               .on(spec.FCST_SPEC_CODE.eq(tsidTable.field("FCST_SPEC_CODE", String.class)))
+               .leftJoin(loc)
+               .on(spec.FCST_SPEC_CODE.eq(loc.FCST_SPEC_CODE));
     }
 
     private static ForecastSpec map(Record7<String, String, String, String, String, String, String> r) {
@@ -101,21 +104,20 @@ public final class ForecastSpecDao extends JooqDao<ForecastSpec> {
                 .build();
     }
 
-    public ForecastSpec getForecastSpec(String office, String name, String designator) {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        AV_FCST_SPEC spec = AV_FCST_SPEC.AV_FCST_SPEC;
-//
-//        Record7<String, String, String, String, String, String, String> fetch = forecastSpecQuery(dsl)
-//                .where(spec.OFFICE_ID.eq(office))
-//                .and(spec.FCST_SPEC_ID.eq(name))
-//                .and(spec.FCST_DESIGNATOR.eq(designator))
-//                .fetchOne();
-//        if (fetch == null) {
-//            throw new NotFoundException(
-//                    format("Could not find forecast instance for office id: %s, spec id: %s, designator: %s",
-//                            office, name, designator));
-//        }
-//        return map(fetch);
+    public ForecastSpec getForecastSpec(String office, String name, String designator) {        
+       AV_FCST_SPEC spec = AV_FCST_SPEC.AV_FCST_SPEC;
+
+       Record7<String, String, String, String, String, String, String> fetch = forecastSpecQuery(dsl)
+               .where(spec.OFFICE_ID.eq(office))
+               .and(spec.FCST_SPEC_ID.eq(name))
+               .and(spec.FCST_DESIGNATOR.eq(designator))
+               .fetchOne();
+       if (fetch == null) {
+           throw new NotFoundException(
+                   format("Could not find forecast instance for office id: %s, spec id: %s, designator: %s",
+                           office, name, designator));
+       }
+       return map(fetch);
     }
 
     public void update(ForecastSpec forecastSpec) {

--- a/cwms-data-api/src/test/java/cwms/cda/api/ForecastInstanceControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/ForecastInstanceControllerTestIT.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
-@Disabled("Full implementation not in available database schemas.")
 public class ForecastInstanceControllerTestIT extends DataApiTestIT {
     private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
     private static final String OFFICE = "SPK";

--- a/cwms-data-api/src/test/java/cwms/cda/api/ForecastSpecControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/ForecastSpecControllerTestIT.java
@@ -8,6 +8,8 @@ import cwms.cda.formatters.UnsupportedFormatException;
 import fixtures.CwmsDataApiSetupCallback;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
+import usace.cwms.db.jooq.codegen.packages.CWMS_FCST_PACKAGE;
+
 import org.apache.commons.io.IOUtils;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -31,7 +33,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Tag("integration")
-@Disabled("Full implementation not in available database schemas.")
 public class ForecastSpecControllerTestIT extends DataApiTestIT {
     private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
     private static final String OFFICE = "SPK";
@@ -73,16 +74,15 @@ public class ForecastSpecControllerTestIT extends DataApiTestIT {
     }
 
     static void deleteSpec() throws SQLException {
-        throw new UnsupportedFormatException("The Forecast API is not yet implemented in CWMS");
-//        try {
-//            CwmsDataApiSetupCallback.getDatabaseLink()
-//                    .connection(c -> {
-//                        CWMS_FCST_PACKAGE.call_DELETE_FCST_SPEC(OracleDSL.using(c).configuration(), SPEC_ID, designator,
-//                                DeleteRule.DELETE_ALL.getRule(), OFFICE);
-//                    });
-//        } catch (DataAccessException e) {
-//            LOGGER.atFine().withCause(e).log("Couldn't clean up forecast spec before executing tests. Probably didn't exist");
-//        }
+       try {
+           CwmsDataApiSetupCallback.getDatabaseLink()
+                   .connection(c -> {
+                       CWMS_FCST_PACKAGE.call_DELETE_FCST_SPEC(OracleDSL.using(c).configuration(), SPEC_ID, designator,
+                               DeleteRule.DELETE_ALL.getRule(), OFFICE);
+                   });
+       } catch (DataAccessException e) {
+           LOGGER.atFine().withCause(e).log("Couldn't clean up forecast spec before executing tests. Probably didn't exist");
+       }
     }
 
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 jaxb-api = "2.3.1"
 jaxb-impl = "3.0.2"
-jooq-codegen = "24.12.04-RC3-24.12.04-RC3-PRtest"
+jooq-codegen = "24.12.04-2025.01.21"
 jooq = "3.18.7-jdk8"
 hec-data-access = "9.8.0"
 slf4j = "1.7.36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 jaxb-api = "2.3.1"
 jaxb-impl = "3.0.2"
-jooq-codegen = "99.99.99.9-CDA_STAGING"
+jooq-codegen = "24.12.04-RC3-24.12.04-RC3-PRtest"
 jooq = "3.18.7-jdk8"
 hec-data-access = "9.8.0"
 slf4j = "1.7.36"


### PR DESCRIPTION
The forecast operations were disabled due to the database not having the feature fully integrated yet.

Not that it is and a new codegen is available, enabled the forecast endpoints.

Only one code change was required. The index of the blob in the oracle struct for the datatype has shifted by one since initial development... which frankly is pretty damn good, all things considered.
