### PR TITLE
Removed TS Code from TimeSeriesGroup getOne method

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesGroupDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesGroupDao.java
@@ -199,7 +199,7 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
             if (attrBD != null) {
                 attr = attrBD.intValue();
             }
-            retval = new AssignedTimeSeries(officeId, timeseriesId, tsCode, aliasId, refTsId, attr);
+            retval = new AssignedTimeSeries(officeId, timeseriesId, aliasId, refTsId, attr);
         }
 
         return retval;

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
@@ -26,6 +26,9 @@ package cwms.cda.data.dto;
 
 import java.math.BigDecimal;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(value = {"ts-code"})
 public class AssignedTimeSeries extends CwmsDTOBase {
     private String officeId;
     private String timeseriesId;

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
@@ -24,15 +24,10 @@
 
 package cwms.cda.data.dto;
 
-import java.math.BigDecimal;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-
-@JsonIgnoreProperties(value = {"ts-code"})
 public class AssignedTimeSeries extends CwmsDTOBase {
     private String officeId;
     private String timeseriesId;
-    private BigDecimal tsCode;
     private String aliasId;
     private String refTsId;
     private Integer attribute;
@@ -42,11 +37,10 @@ public class AssignedTimeSeries extends CwmsDTOBase {
     }
 
 
-    public AssignedTimeSeries(String officeId, String timeseriesId, BigDecimal tsCode,
+    public AssignedTimeSeries(String officeId, String timeseriesId,
                               String aliasId, String refTsId, Integer attr) {
         this.officeId = officeId;
         this.timeseriesId = timeseriesId;
-        this.tsCode = tsCode;
         this.aliasId = aliasId;
         this.refTsId = refTsId;
         this.attribute = attr;
@@ -58,10 +52,6 @@ public class AssignedTimeSeries extends CwmsDTOBase {
 
     public String getTimeseriesId() {
         return timeseriesId;
-    }
-
-    public BigDecimal getTsCode() {
-        return tsCode;
     }
 
     public String getAliasId() {

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
@@ -291,7 +291,8 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             .body("description", equalTo(group.getDescription()))
             .body("assigned-time-series[0].timeseries-id", equalTo(timeSeriesId))
             .body("assigned-time-series[0].alias-id", equalTo("AliasId"))
-            .body("assigned-time-series[0].ref-ts-id", equalTo(timeSeriesId));
+            .body("assigned-time-series[0].ref-ts-id", equalTo(timeSeriesId))
+            .body("assigned-time-series[0].ts-code", nullValue());
         //Clear Assigned TS
         group.getAssignedTimeSeries().clear();
         groupXml = Formats.format(contentType, group);

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
@@ -44,9 +44,7 @@ import io.restassured.filter.log.LogDetail;
 import io.restassured.path.json.JsonPath;
 import io.restassured.response.Response;
 import java.io.InputStream;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,15 +57,12 @@ import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matchers;
 import org.jooq.Configuration;
 import org.jooq.impl.DSL;
-import org.jooq.util.oracle.OracleDSL;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import usace.cwms.db.jooq.codegen.packages.CWMS_TS_PACKAGE;
-import usace.cwms.db.jooq.codegen.packages.CWMS_UTIL_PACKAGE;
 
 import static cwms.cda.api.Controllers.*;
 import static cwms.cda.data.dao.JooqDao.formatBool;
@@ -231,8 +226,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             "sharedTsAliasId", timeSeriesId);
         List<AssignedTimeSeries> assignedTimeSeries = group.getAssignedTimeSeries();
 
-        BigDecimal tsCode = getTsCode(officeId, timeSeriesId);
-        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, tsCode, "AliasId", timeSeriesId, 1));
+        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, "AliasId", timeSeriesId, 1));
         ContentType contentType = Formats.parseHeader(Formats.JSON, TimeSeriesCategory.class);
         String categoryXml = Formats.format(contentType, cat);
         String groupXml = Formats.format(contentType, group);
@@ -382,8 +376,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
                 "sharedTsAliasId", timeSeriesId);
         TimeSeriesGroup group4 = new TimeSeriesGroup(group, null);
         List<AssignedTimeSeries> assignedTimeSeries = group.getAssignedTimeSeries();
-        BigDecimal tsCode = getTsCode(officeId, timeSeriesId);
-        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, tsCode, "AliasId", timeSeriesId, 1));
+        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, "AliasId", timeSeriesId, 1));
         ContentType contentType = Formats.parseHeader(Formats.JSON, TimeSeriesCategory.class);
         String groupXml = Formats.format(contentType, group);
         groupsToCleanup.add(group);
@@ -708,15 +701,6 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
     }
 
-    private static BigDecimal getTsCode(String officeId, String timeSeriesId) throws SQLException {
-        CwmsDatabaseContainer<?> db = CwmsDataApiSetupCallback.getDatabaseLink();
-        return db.connection(c -> {
-            Configuration configuration = OracleDSL.using(c).configuration();
-            BigDecimal officeCode = CWMS_UTIL_PACKAGE.call_GET_OFFICE_CODE(configuration, officeId);
-            return CWMS_TS_PACKAGE.call_GET_TS_CODE(configuration, timeSeriesId, officeCode);
-        }, db.getPdUser());
-    }
-
     @Test
     void test_rename_group() throws Exception {
         String officeId = user.getOperatingOffice();
@@ -729,8 +713,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             "sharedTsAliasId", timeSeriesId);
         List<AssignedTimeSeries> assignedTimeSeries = group.getAssignedTimeSeries();
 
-        BigDecimal tsCode = getTsCode(officeId, timeSeriesId);
-        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, tsCode, "AliasId", timeSeriesId, 1));
+        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, "AliasId", timeSeriesId, 1));
         ContentType contentType = Formats.parseHeader(Formats.JSON, TimeSeriesCategory.class);
         String categoryXml = Formats.format(contentType, cat);
         String groupXml = Formats.format(contentType, group);
@@ -868,7 +851,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
     }
 
     @Test
-    void test_add_assigned_locs() throws Exception {
+    void test_add_assigned_locs() {
         String officeId = user.getOperatingOffice();
         String timeSeriesId = "Alder Springs.Precip-Cumulative.Inst.15Minutes.0.raw-cda";
         TimeSeriesCategory cat = new TimeSeriesCategory(officeId, "test_add_assigned_locs", "IntegrationTesting");
@@ -876,8 +859,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             "sharedTsAliasId", timeSeriesId);
         List<AssignedTimeSeries> assignedTimeSeries = group.getAssignedTimeSeries();
 
-        BigDecimal tsCode = getTsCode(officeId, timeSeriesId);
-        assignedTimeSeries.add(new AssignedTimeSeries(officeId, timeSeriesId, tsCode, "AliasId", timeSeriesId, 1));
+        assignedTimeSeries.add(new AssignedTimeSeries(officeId, timeSeriesId, "AliasId", timeSeriesId, 1));
         ContentType contentType = Formats.parseHeader(Formats.JSON, TimeSeriesCategory.class);
         String categoryXml = Formats.format(contentType, cat);
         String groupXml = Formats.format(contentType, group);
@@ -916,8 +898,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             .statusCode(is(HttpServletResponse.SC_CREATED));
         assignedTimeSeries.clear();
         String timeSeriesId2 = "Pine Flat-Outflow.Stage.Inst.15Minutes.0.raw-cda";
-        BigDecimal tsCode2 = getTsCode(officeId, timeSeriesId2);
-        assignedTimeSeries.add(new AssignedTimeSeries(officeId, timeSeriesId2, tsCode2, "AliasId2", timeSeriesId2, 2));
+        assignedTimeSeries.add(new AssignedTimeSeries(officeId, timeSeriesId2, "AliasId2", timeSeriesId2, 2));
         groupXml = Formats.format(contentType, group);
         //Add Assigned Locs
         given()
@@ -1057,7 +1038,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
         String tsId = ts.get("name").asText();
         TimeSeriesCategory category = new TimeSeriesCategory(CWMS_OFFICE, categoryName, "Default");
         TimeSeriesGroup group = new TimeSeriesGroup(category, CWMS_OFFICE, groupId, "All Time Series", null, null);
-        AssignedTimeSeries assignedTimeSeries = new AssignedTimeSeries(officeId, tsId, null, null, null, null);
+        AssignedTimeSeries assignedTimeSeries = new AssignedTimeSeries(officeId, tsId, null, null, null);
         TimeSeriesGroup newGroup = new TimeSeriesGroup(group, Collections.singletonList(assignedTimeSeries));
 
         String newGroupJson = Formats.format(new ContentType(Formats.JSONV1), newGroup);
@@ -1187,8 +1168,8 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
         String tsId2 = ts2.get("name").asText();
         TimeSeriesCategory category = new TimeSeriesCategory(CWMS_OFFICE, categoryName, "Default");
         TimeSeriesGroup group = new TimeSeriesGroup(category, CWMS_OFFICE, groupId, "All Time Series", null, null);
-        AssignedTimeSeries assignedTimeSeries = new AssignedTimeSeries(officeId, tsId, null, null, null, null);
-        AssignedTimeSeries assignedTimeSeries2 = new AssignedTimeSeries(officeId, tsId2, null, null, null, null);
+        AssignedTimeSeries assignedTimeSeries = new AssignedTimeSeries(officeId, tsId, null, null, null);
+        AssignedTimeSeries assignedTimeSeries2 = new AssignedTimeSeries(officeId, tsId2, null, null, null);
         TimeSeriesGroup newGroup = new TimeSeriesGroup(group, Arrays.asList(assignedTimeSeries2, assignedTimeSeries));
 
         String newGroupJson2 = Formats.format(new ContentType(Formats.JSONV1), newGroup);
@@ -1257,7 +1238,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
 
         TimeSeriesCategory category = new TimeSeriesCategory(CWMS_OFFICE, "Default", "Default");
         TimeSeriesGroup districtGroup = new TimeSeriesGroup(category, CWMS_OFFICE, "Default", "All Time Series", null, null);
-        AssignedTimeSeries assignedTimeSeries = new AssignedTimeSeries(officeId, tsId, null, null, null, null);
+        AssignedTimeSeries assignedTimeSeries = new AssignedTimeSeries(officeId, tsId, null, null, null);
         TimeSeriesGroup newDistrictGroup = new TimeSeriesGroup(districtGroup, Collections.singletonList(assignedTimeSeries));
         groupsToCleanup.add(newDistrictGroup);
 
@@ -1349,8 +1330,7 @@ class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
                 "sharedTsAliasId", timeSeriesId);
         List<AssignedTimeSeries> assignedTimeSeries = group.getAssignedTimeSeries();
 
-        BigDecimal tsCode = getTsCode(officeId, timeSeriesId);
-        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, tsCode, "AliasId", timeSeriesId, 1));
+        assignedTimeSeries.add(new AssignedTimeSeries(officeId,timeSeriesId, "AliasId", timeSeriesId, 1));
         ContentType contentType = Formats.parseHeader(Formats.JSON, TimeSeriesCategory.class);
         String groupXml = Formats.format(contentType, group);
         //Create Group

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesRecentControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesRecentControllerIT.java
@@ -160,7 +160,7 @@ class TimeSeriesRecentControllerIT extends DataApiTestIT {
 
         group = new TimeSeriesGroup(category, OFFICE_ID, GROUP_ID, "USACE Include group", null, TS_ID);
         List<AssignedTimeSeries> tsList = Collections
-                .singletonList(new AssignedTimeSeries(OFFICE_ID, TS_ID, null, null, TS_ID, 0));
+                .singletonList(new AssignedTimeSeries(OFFICE_ID, TS_ID, null, TS_ID, 0));
         group = new TimeSeriesGroup(group, tsList);
         json = JsonV1.buildObjectMapper().writeValueAsString(group);
 


### PR DESCRIPTION
Fixes #978.

Adds an ignore annotation to the TS code field of the AssignedTimeSeries data encompassed by the TimeSeriesGroup DTO.

Now, the TS code is not returned as part of the response when serialized. Adds check to existing tests.