### PR TITLE
Update release actions to deploy to shared dev environment.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+---
+name: Deploy
+on:
+  workflow_call:
+    inputs:
+      api_image:
+        type: string
+        required: true
+      region:
+        type: string
+        required: true
+      iam_role:
+        type: string
+        required: true
+    secrets:
+      token:
+       required: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read # This is required for actions/checkout
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ inputs.region }}
+          role-to-assume: ${{ inputs.iam_role }}
+          output-credentials: true
+    # Hello from AWS: WhoAmI
+      - name: Sts GetCallerIdentity
+        run: |
+          aws sts get-caller-identity
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'true'
+      - name: Push API Image to ECR Repo
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: cwms-wmes-data-api
+          IMAGE_TAG: latest
+        run: |
+          docker pull ${{api.image}}
+          docker tag ${{api.image}} $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          docker tag ${{api.image}} $ECR_REGISTRY/$ECR_REPOSITORY::dev 
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:dev
+      - name: ECR Logout
+        if: always()
+        run: docker logout ${{ steps.login-ecr.outputs.registry }}
+    # TODO after verification this works: create or consume appropriate schema_installer image

--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -4,7 +4,7 @@ on:
     - cron: "3 0 * * *"
 
 jobs:
-  main:
+  develop:
     permissions:
       packages: write
       contents: write
@@ -17,3 +17,17 @@ jobs:
     with:
       branch: "develop"
       nightly: true
+  # Deploy CDA nightly. Keeps everyone on their toes with new updates and keeps the containers 
+  # Updated
+  deploy-develop:
+    permissions:
+      id-token: write
+      contents: read
+    needs: develop
+    uses: /.github/workflows/deploy.yml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      api_image: ${{develop.outputs.image_tag}}
+      region: us-gov-west-1
+      iam_role: arn:aws-us-gov:iam::718787032875:role/github-actions-ecr-cwms-data-api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ on:
         required: false
       registry_password:
         required: false
+    outputs:
+      image_tag:
+        description: GHCR.io image tag for downstream consumption
+        value: ${{ jobs.release.outputs.image_tag }}
   workflow_dispatch:
     inputs:
       branch:
@@ -33,11 +37,13 @@ on:
         default: true
 
 jobs:
-  release-nightly:
+  release:
     runs-on: ubuntu-latest
     permissions:
         packages: write
         contents: write
+    outputs:
+      image_tag: ${{steps.build_image.image_tag}}
     steps:
       - name: checkout code
         uses: actions/checkout@v4.2.2
@@ -82,6 +88,7 @@ jobs:
           username: ${{ secrets.registry_user != null && secrets.registry_user || secrets.ALT_REG_USER }}
           password: ${{ secrets.registry_password != null && secrets.registry_password || secrets.ALT_REG_PASSWORD }}
       - name: Build docker image
+        id: build_image
         env:
           IMAGE_TAG: ${{env.VERSION}}
           ALT_REGISTRY: ${{secrets.ALT_REGISTRY}}
@@ -94,6 +101,7 @@ jobs:
           docker tag cda:build-latest $HEC_PUB_REGISTRY/cwms/data-api:$VERSION
           docker push $HEC_PUB_REGISTRY/cwms/data-api:$VERSION
           docker push ghcr.io/${REPO}:$VERSION
+          echo "image_tag=$ghcr.io/${REPO}:$VERSION" >> $GITHUB_OUTPUT
       - name: Logout of HEC pub registry
         if: ${{ always() }}
         run: |


### PR DESCRIPTION
Set container to push to dev on the nightly build.

This will keep the container up-to-date for security and catch new changes on a reasonable interval.

Other option is to deploy on tag based versions; however, I believe that more appropriate for the test and prod environments, with prod definitely needing more than just a tag to approve.

Also updated some job names that were copy pasted from other projects.


Unfortunately due to how many secrets and package systems this all uses, there's not a good way to test it even with nektos/act.