### PR TITLE
Don't create the test accounts.

### DIFF
--- a/.github/actions/database-migration-image/entry.sh
+++ b/.github/actions/database-migration-image/entry.sh
@@ -2,5 +2,6 @@
 
 # STOP GAP, need to reset the migration container mappings
 export BUILDUSER_PASSWORD=$SYS_PASSWORD
+export TEST_ACCOUNT="-notestaccount"
 
 exec $*


### PR DESCRIPTION
By default the schema install creates test accounts, these aren't required or wanted for a standard deployment environment.