### PR TITLE
Create app user, or just update password.

### DIFF
--- a/.github/actions/database-migration-image/Dockerfile
+++ b/.github/actions/database-migration-image/Dockerfile
@@ -1,5 +1,5 @@
 # Variation specific to the deploy environment will go here
-ARG IMAGE
+ARG IMAGE=ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/schema_installer:latest-dev
 FROM ${IMAGE}
 
 COPY entry.sh /

--- a/.github/actions/database-migration-image/cda-user.sql
+++ b/.github/actions/database-migration-image/cda-user.sql
@@ -1,2 +1,17 @@
--- TODO; need to update cdk setup before this is useful
--- File here created as placeholder and reminder.
+set define on
+@/tmp/cda-user-info
+
+begin
+    -- create user
+    cwms_sec.add_cwms_user('&&cda_user', NULL, 'HQ');
+    -- set permissions for all offices
+    for ofc in (select office_id from av_office where office_id not in ('CWMS', 'UNK'))
+    loop
+        cwms_sec.add_user_to_group('&&cda_user','All Users', ofc.office_id);
+        cwms_sec.add_user_to_group('&&cda_user','CWMS Users', ofc.office_id);
+        cwms_sec.add_user_to_group('&&cda_user','CWMS DBA Users', ofc.office_id);
+        cwms_sec.add_user_to_group('&&cda_user','CWMS User Admins', ofc.office_id);
+        cwms_sec.add_user_to_group('&&cda_user','CWMS PD Users', ofc.office_id);
+    end loop;
+end;
+/

--- a/.github/actions/database-migration-image/entry.sh
+++ b/.github/actions/database-migration-image/entry.sh
@@ -1,7 +1,25 @@
 #!/bin/bash
 
-# STOP GAP, need to reset the migration container mappings
-export BUILDUSER_PASSWORD=$SYS_PASSWORD
-export TEST_ACCOUNT="-notestaccount"
+cat > /tmp/create-app-user.sql <<EOF
+declare
+    user_count integer;
+begin
+    select count(*) into user_count from dba_users where username='&1';
+    if (user_count = 0) then
+        execute immediate 'create user &1 identified by "&2"';
+    else
+        execute immediate 'alter user &1 identified by "&2"';
+    end if;
+end;
+/
+EOF
+
+cat > /tmp/cda-user-info.sql <<EOF
+define cda_user='$CDA_USERNAME';
+EOF
+
+# Create app user first, one of the migration steps is to update the "cwms user" information for that user
+
+sqlplus $BUILDUSER/$BUILDUSER_PASSWORD@$DB_HOST_PORT$DB_NAME @/tmp/create-app-user "$CDA_USERNAME" "$CDA_PASSWORD"
 
 exec $*


### PR DESCRIPTION
@adamscarberry if you're curious.

Definitely easier and more structured with flyway and the afterMigrate scripts. But same affect. 
Technically this would also allow automated updates of the app user password; at least if the particular container could be triggered in the appropriate way.