### PR TITLE
Set the level date to the actual date rather than parameterized date

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
@@ -356,7 +356,9 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
                 logger.info("Default units are " + defaultUnits);
                 units = defaultUnits;
             }
-            return new LocationLevel.Builder(locationLevelName, effectiveDate)
+            Timestamp pEffectiveDate = level.getP_EFFECTIVE_DATE();
+            ZonedDateTime realEffectiveDate = ZonedDateTime.ofInstant(pEffectiveDate.toInstant(), effectiveDate.getZone());
+            return new LocationLevel.Builder(locationLevelName, realEffectiveDate)
                 .withLevelUnitsId(units)
                 .withAttributeUnitsId(units)
                 .withInterpolateString(level.getP_INTERPOLATE())

--- a/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
@@ -132,6 +132,44 @@ public class LevelsControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    void test_retrieve_effective_date() throws Exception {
+        createLocation("level_with_effective_date", true, OFFICE);
+        String levelId = "level_with_effective_date.Stor.Ave.1Day.Regulating";
+        ZonedDateTime time = ZonedDateTime.of(2023, 6, 1, 0, 0, 0, 0, ZoneId.of("America/Los_Angeles"));
+        CwmsDataApiSetupCallback.getDatabaseLink().connection(c -> {
+            LocationLevel level = new LocationLevel.Builder(levelId, time)
+                    .withOfficeId(OFFICE)
+                    .withConstantValue(1.0)
+                    .withLevelUnitsId("ft")
+                    .build();
+            levelList.add(level);
+            DSLContext dsl = dslContext(c, OFFICE);
+            LocationLevelsDaoImpl dao = new LocationLevelsDaoImpl(dsl);
+            dao.storeLocationLevel(level);
+        });
+
+        ExtractableResponse<Response> response = given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, OFFICE)
+            .queryParam(LEVEL_ID_MASK, "level_get_all_loc_*")
+            .queryParam(BEGIN, "2020-06-01T00:00:00Z")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/levels/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .extract();
+
+        assertEquals("2023-06-01T07:00:00Z", response.path("levels[0].level-date"));
+    }
+
+
+    @Test
     void test_retrieve_time_window() throws Exception {
         createLocation("level_get_all_loc_1", true, OFFICE);
         String levelId = "level_get_all_loc_1.Flow.Ave.1Day.Regulating";

--- a/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
@@ -133,14 +133,14 @@ public class LevelsControllerTestIT extends DataApiTestIT {
 
     @Test
     void test_retrieve_effective_date() throws Exception {
-        createLocation("level_with_effective_date", true, OFFICE);
-        String levelId = "level_with_effective_date.Stor.Ave.1Day.Regulating";
+        createLocation("level_with_effect", true, OFFICE);
+        String levelId = "level_with_effect.Flow.Ave.1Day.Regulating";
         ZonedDateTime time = ZonedDateTime.of(2023, 6, 1, 0, 0, 0, 0, ZoneId.of("America/Los_Angeles"));
         CwmsDataApiSetupCallback.getDatabaseLink().connection(c -> {
             LocationLevel level = new LocationLevel.Builder(levelId, time)
                     .withOfficeId(OFFICE)
                     .withConstantValue(1.0)
-                    .withLevelUnitsId("ft")
+                    .withLevelUnitsId("cms")
                     .build();
             levelList.add(level);
             DSLContext dsl = dslContext(c, OFFICE);
@@ -153,7 +153,7 @@ public class LevelsControllerTestIT extends DataApiTestIT {
             .accept(Formats.JSONV2)
             .contentType(Formats.JSONV2)
             .queryParam(Controllers.OFFICE, OFFICE)
-            .queryParam(LEVEL_ID_MASK, "level_get_all_loc_*")
+            .queryParam(LEVEL_ID_MASK, "level_with_effect*")
             .queryParam(BEGIN, "2020-06-01T00:00:00Z")
         .when()
             .redirects().follow(true)


### PR DESCRIPTION
Set the level date to the actual date rather than parameterized date.

Includes integration test.

Fixes #662 

Supersedes: https://github.com/USACE/cwms-data-api/pull/1079