### PR TITLE
Fixes 1017: TimeSeries retrieval unit conversion error handling

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
@@ -71,6 +71,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -505,6 +506,21 @@ public class TimeSeriesController implements CrudHandler {
             }
             addDeprecatedContentTypeWarning(ctx, contentType);
             requestResultSize.update(results.length());
+        } catch (DataAccessException ex) {
+            if (ex.getCause() instanceof SQLException) {
+                SQLException sqlEx = (SQLException) ex.getCause();
+                if (sqlEx.getErrorCode() == 20998 && sqlEx.getMessage().contains("Cannot convert from unit")) {
+                    CdaError re = new CdaError("Unable to convert to the requested unit, "
+                            + "please verify the unit parameter.");
+                    logger.log(Level.WARNING, re.toString(), ex);
+                    ctx.status(HttpServletResponse.SC_BAD_REQUEST);
+                    ctx.json(re);
+                } else {
+                    throw ex;
+                }
+            } else {
+                throw ex;
+            }
         } catch (NotFoundException e) {
             CdaError re = new CdaError("Not found.");
             logger.log(Level.WARNING, re.toString(), e);

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -9,7 +9,6 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.isNull;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -45,7 +44,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         try {
@@ -60,7 +59,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization",user.toHeaderValue())
-                .queryParam("office",officeId)
+                .queryParam(Controllers.OFFICE,officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -77,11 +76,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .accept(Formats.JSONV2)
 //                .body(tsData)
                 .header("Authorization",user.toHeaderValue())
-                .queryParam("office",officeId)
-                .queryParam("units","cfs")
-                .queryParam("name",ts.get("name").asText())
-                .queryParam("begin","2023-01-11T12:00:00-00:00")
-                .queryParam("end","2023-01-11T13:00:00-00:00")
+                .queryParam(Controllers.OFFICE,officeId)
+                .queryParam(Controllers.UNIT,"cfs")
+                .queryParam(Controllers.NAME,ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN,"2023-01-11T12:00:00-00:00")
+                .queryParam(Controllers.END,"2023-01-11T13:00:00-00:00")
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -112,7 +111,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         createLocation(location, true, officeId);
@@ -126,7 +125,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization",user.toHeaderValue())
-                .queryParam("office",officeId)
+                .queryParam(Controllers.OFFICE,officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -145,11 +144,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .accept(Formats.JSONV2)
 //                .body(tsData)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
-                .queryParam("units", "F")
-                .queryParam("name", ts.get("name").asText())
-                .queryParam("begin", firstPoint)
-                .queryParam("end", firstPoint)
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT, "F")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, firstPoint)
+                .queryParam(Controllers.END, firstPoint)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -176,7 +175,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         createLocation(location, true, officeId);
@@ -190,7 +189,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
+                .queryParam(Controllers.OFFICE, officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -215,7 +214,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         createLocation(location, true, officeId);
@@ -229,7 +228,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
+                .queryParam(Controllers.OFFICE, officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -254,7 +253,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
         createLocation(location, true, officeId);
 
@@ -267,7 +266,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
+                .queryParam(Controllers.OFFICE, officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -281,16 +280,16 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .log().ifValidationFails(LogDetail.ALL, true)
                 .accept(Formats.JSONV2)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
-                .queryParam("begin", "2023-02-02T11:00:00+00:00")
-                .queryParam("end", "2023-02-02T11:00:00+00:00")
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.BEGIN, "2023-02-02T11:00:00+00:00")
+                .queryParam(Controllers.END, "2023-02-02T11:00:00+00:00")
                 .queryParam("start-time-inclusive", "true")
                 .queryParam("end-time-inclusive", "true")
                 .queryParam("override-protection", "true")
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
-                .delete("/timeseries/" + ts.get("name").asText())
+                .delete("/timeseries/" + ts.get(Controllers.NAME).asText())
             .then()
                 .log().ifValidationFails(LogDetail.ALL, true)
                 .assertThat()
@@ -305,11 +304,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .accept(Formats.JSONV2)
 //                .body(tsData)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
-                .queryParam("units", "F")
-                .queryParam("name", ts.get("name").asText())
-                .queryParam("begin", "2023-02-02T11:00:00+00:00")
-                .queryParam("end", "2023-02-03T11:00:00+00:00")
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT, "F")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, "2023-02-02T11:00:00+00:00")
+                .queryParam(Controllers.END, "2023-02-03T11:00:00+00:00")
                 .queryParam(Controllers.TRIM, false)
             .when()
                 .redirects().follow(true)
@@ -333,7 +332,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         createLocation(location, true, officeId);
@@ -347,7 +346,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
+                .queryParam(Controllers.OFFICE, officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -366,8 +365,8 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
             .accept(Formats.JSONV2)
             .contentType(Formats.JSONV2)
             //Purposefully misspelled office id
-            .queryParam("office", "NWDW")
-            .queryParam("name", "Buckhorn.Temp-Water.Inst.1Day.0.cda-test")
+            .queryParam(Controllers.OFFICE, "NWDW")
+            .queryParam(Controllers.NAME, "Buckhorn.Temp-Water.Inst.1Day.0.cda-test")
         .when()
             .redirects().follow(true)
             .redirects().max(3)
@@ -389,7 +388,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
         createLocation(location, true, officeId);
 
@@ -399,11 +398,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
                 .log().ifValidationFails(LogDetail.ALL, true)
                 .accept(Formats.JSONV1)
-                .queryParam("office", officeId)
-                .queryParam("units", "F")
-                .queryParam("name", ts.get("name").asText())
-                .queryParam("begin", firstPoint)
-                .queryParam("end", firstPoint)
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT, "F")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, firstPoint)
+                .queryParam(Controllers.END, firstPoint)
                 .queryParam("trim", "true")
             .when()
                 .redirects().follow(true)
@@ -426,7 +425,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
         createLocation(location, true, officeId);
 
@@ -438,11 +437,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
             .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
             .log().ifValidationFails(LogDetail.ALL, true)
             .accept(Formats.JSONV1)
-            .queryParam("office", officeId)
-            .queryParam("units", "F")
-            .queryParam("name", ts.get("name").asText())
-            .queryParam("begin", firstPoint)
-            .queryParam("end", firstPoint)
+            .queryParam(Controllers.OFFICE, officeId)
+            .queryParam(Controllers.UNIT, "F")
+            .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+            .queryParam(Controllers.BEGIN, firstPoint)
+            .queryParam(Controllers.END, firstPoint)
             .queryParam("version-date", version)
         .when()
             .redirects().follow(true)
@@ -465,7 +464,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
         createLocation(location, true, officeId);
 
@@ -475,11 +474,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
                 .log().ifValidationFails(LogDetail.ALL, true)
                 .accept(Formats.JSONV2)
-                .queryParam("office", officeId)
-                .queryParam("units", "F")
-                .queryParam("name", ts.get("name").asText())
-                .queryParam("begin", firstPoint)
-                .queryParam("end", firstPoint)
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT, "F")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, firstPoint)
+                .queryParam(Controllers.END, firstPoint)
                 .queryParam("datum", "NAVD88")
             .when()
                 .redirects().follow(true)
@@ -493,6 +492,64 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    void test_wrong_units() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        InputStream resource = this.getClass().getResourceAsStream(
+                "/cwms/cda/api/lrl/1day_offset.json");
+        assertNotNull(resource);
+        String tsData = IOUtils.toString(resource, "UTF-8");
+
+        JsonNode ts = mapper.readTree(tsData);
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
+        String officeId = ts.get("office-id").asText();
+
+        createLocation(location, true, officeId);
+
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+
+        // inserting the time series
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .body(tsData)
+            .header("Authorization",user.toHeaderValue())
+            .queryParam(Controllers.OFFICE, officeId)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/timeseries/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK));
+
+        // get it back
+        String firstPoint = "2023-02-02T06:00:00-05:00"; //aka 2023-02-02T11:00:00.000Z or
+        // 1675335600000
+        given()
+            .config(RestAssured.config().jsonConfig(jsonConfig().numberReturnType(JsonPathConfig.NumberReturnType.DOUBLE)))
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(Controllers.OFFICE, officeId)
+            .queryParam(Controllers.UNIT, "m")
+            .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+            .queryParam(Controllers.BEGIN, firstPoint)
+            .queryParam(Controllers.END, firstPoint)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/timeseries/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
+        ;
+    }
+
+    @Test
     void test_lrl_trim() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
@@ -502,7 +559,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         try {
@@ -517,7 +574,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                     .contentType(Formats.JSONV2)
                     .body(tsData)
                     .header("Authorization", user.toHeaderValue())
-                    .queryParam("office", officeId)
+                    .queryParam(Controllers.OFFICE, officeId)
                 .when()
                     .redirects().follow(true)
                     .redirects().max(3)
@@ -544,11 +601,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                     .accept(Formats.JSONV2)
 //                    .body(tsData)
                     .header("Authorization", user.toHeaderValue())
-                    .queryParam("office", officeId)
-                    .queryParam("units", "F")
-                    .queryParam("name", ts.get("name").asText())
-                    .queryParam("begin", dayBeforeFirst.toInstant().toString())
-                    .queryParam("end", firstPoint)
+                    .queryParam(Controllers.OFFICE, officeId)
+                    .queryParam(Controllers.UNIT, "F")
+                    .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                    .queryParam(Controllers.BEGIN, dayBeforeFirst.toInstant().toString())
+                    .queryParam(Controllers.END, firstPoint)
                     .queryParam("trim", false)
                 .when()
                     .redirects().follow(true)
@@ -571,11 +628,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                     .accept(Formats.JSONV2)
 //                    .body(tsData)
                     .header("Authorization", user.toHeaderValue())
-                    .queryParam("office", officeId)
-                    .queryParam("units", "F")
-                    .queryParam("name", ts.get("name").asText())
-                    .queryParam("begin", dayBeforeFirst.toInstant().toString())
-                    .queryParam("end", firstPoint)
+                    .queryParam(Controllers.OFFICE, officeId)
+                    .queryParam(Controllers.UNIT, "F")
+                    .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                    .queryParam(Controllers.BEGIN, dayBeforeFirst.toInstant().toString())
+                    .queryParam(Controllers.END, firstPoint)
                     .queryParam("trim", true)
                 .when()
                     .redirects().follow(true)
@@ -611,7 +668,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         createLocation(location, true, officeId);
@@ -625,7 +682,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(giantString)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
+                .queryParam(Controllers.OFFICE, officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -639,9 +696,9 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     /**
      * Input looks like:
      * {
-     *     "name": "Buckhorn.Temp-Water.Inst.1Day.0.cda-test",
+     *     Controllers.NAME: "Buckhorn.Temp-Water.Inst.1Day.0.cda-test",
      *     "office-id": "SPK",
-     *     "units": "F",
+     *     Controllers.UNIT: "F",
      *     "values": [
      *         [
      *             1675335600000,
@@ -705,7 +762,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode ts = mapper.readTree(tsData);
-        String name = ts.get("name").asText();
+        String name = ts.get(Controllers.NAME).asText();
         String location = name.split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
@@ -725,7 +782,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(giantString)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
+                .queryParam(Controllers.OFFICE, officeId)
                 .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -741,11 +798,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .log().ifValidationFails(LogDetail.ALL,true)
                 .accept(Formats.JSONV2)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
-                .queryParam("units","mm")
-                .queryParam("name", name)
-                .queryParam("begin","2021-02-08T08:00:00Z")
-                .queryParam("end","2021-03-08T08:00:00Z")
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT,"mm")
+                .queryParam(Controllers.NAME, name)
+                .queryParam(Controllers.BEGIN,"2021-02-08T08:00:00Z")
+                .queryParam(Controllers.END,"2021-03-08T08:00:00Z")
                 .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -764,11 +821,11 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .log().ifValidationFails(LogDetail.ALL,true)
                 .accept(Formats.JSONV2)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
-                .queryParam("units","mm")
-                .queryParam("name", name)
-                .queryParam("begin","2021-03-08T08:00:00Z")
-                .queryParam("end","2021-03-15T08:00:00Z")
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT,"mm")
+                .queryParam(Controllers.NAME, name)
+                .queryParam(Controllers.BEGIN,"2021-03-08T08:00:00Z")
+                .queryParam(Controllers.END,"2021-03-15T08:00:00Z")
                 .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -817,7 +874,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
         String tsData = IOUtils.toString(resource, "UTF-8");
 
         JsonNode ts = mapper.readTree(tsData);
-        String location = ts.get("name").asText().split("\\.")[0];
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
         String officeId = ts.get("office-id").asText();
 
         createLocation(location, true, officeId);
@@ -831,7 +888,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .contentType(Formats.JSONV2)
                 .body(tsData)
                 .header("Authorization",user.toHeaderValue())
-                .queryParam("office",officeId)
+                .queryParam(Controllers.OFFICE,officeId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)
@@ -847,9 +904,9 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
                 .log().ifValidationFails(LogDetail.ALL, true)
                 .accept(Formats.JSONV2)
                 .header("Authorization", user.toHeaderValue())
-                .queryParam("office", officeId)
-                .queryParam("units", "F")
-                .queryParam("name", ts.get("name").asText())
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT, "F")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)


### PR DESCRIPTION
This is an initial solution targeting just TimeSeries as part of LOE investigation. Full implementation will cover unit conversion errors in the base class to cover more endpoints like levels, ratings, etc

Fixes #1017 

Adds exception handling for unit conversion error to timeseries retrieval endpoint. 

Swaps string query parameters in test for constants.