### PR TITLE
Issue #1113 - Updates to use 'units' as a query parameter to match timeseries json payload 'units'.

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
@@ -66,6 +66,7 @@ public final class Controllers {
     public static final String CATEGORY_OFFICE_ID = "category-office-id";
     public static final String GROUP_OFFICE_ID = "group-office-id";
     public static final String UNIT = "unit";
+    public static final String UNITS = "units";
     public static final String COUNT = "count";
     public static final String TIME = "time";
     public static final String RESULTS = "results";

--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
@@ -287,8 +287,8 @@ public class TimeSeriesController implements CrudHandler {
                         + "Required for:" + Formats.JSONV2 + " and " + Formats.XMLV2 + ". "
                         + "For other formats, if this field is not specified, matching location "
                         + "level information from all offices shall be returned."),
-                @OpenApiParam(name = UNIT,  description = "Specifies the "
-                        + "unit or unit system of the response. Valid values for the unit "
+                @OpenApiParam(name = UNITS,  description = "Specifies the "
+                        + "units or unit system of the response. Valid values for the units "
                         + "field are: "
                         + "\n* `EN`  (default) Specifies English unit system.  "
                         + "Location level values will be in the default English units for "
@@ -296,7 +296,7 @@ public class TimeSeriesController implements CrudHandler {
                         + "\n* `SI`  Specifies the SI unit system.  "
                         + "Location level values will be in the default SI units for their "
                         + "parameters."
-                        + "\n* `Other`  Any unit returned in the response to the units URI "
+                        + "\n* `Other`  Any units returned in the response to the units URI "
                         + "request that is appropriate for the requested parameters."),
                 @OpenApiParam(name = VERSION_DATE, description = "Specifies the version date of a "
                         + "time series trace to be selected. The format for this field is ISO 8601 "
@@ -388,8 +388,10 @@ public class TimeSeriesController implements CrudHandler {
             String format = ctx.queryParamAsClass(FORMAT, String.class).getOrDefault("");
             String names = requiredParam(ctx, NAME);
 
-            String unit = ctx.queryParamAsClass(UNIT, String.class)
-                    .getOrDefault(UnitSystem.EN.getValue());
+            //try 'unit' if 'units' is not provided as that was the original parameter name
+            String units = ctx.queryParamAsClass(UNITS, String.class)
+                    .getOrDefault(ctx.queryParamAsClass(UNIT, String.class)
+                            .getOrDefault(UnitSystem.EN.getValue()));
             String datum = ctx.queryParam(DATUM);
             String begin = ctx.queryParam(BEGIN);
             String end = ctx.queryParam(END);
@@ -433,7 +435,7 @@ public class TimeSeriesController implements CrudHandler {
                 }
 
                 String office = requiredParam(ctx, OFFICE);
-                TimeSeries ts = dao.getTimeseries(cursor, pageSize, names, office, unit,
+                TimeSeries ts = dao.getTimeseries(cursor, pageSize, names, office, units,
                         beginZdt, endZdt, versionDate, trim.getOrDefault(true), includeEntryDate);
 
                 results = Formats.format(contentType, ts);
@@ -470,7 +472,7 @@ public class TimeSeriesController implements CrudHandler {
                 }
 
                 String office = ctx.queryParam(OFFICE);
-                results = dao.getTimeseries(format, names, office, unit, datum, beginZdt, endZdt, tz);
+                results = dao.getTimeseries(format, names, office, units, datum, beginZdt, endZdt, tz);
                 ctx.status(HttpServletResponse.SC_OK);
                 ctx.result(results);
             }

--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesController.java
@@ -287,6 +287,17 @@ public class TimeSeriesController implements CrudHandler {
                         + "Required for:" + Formats.JSONV2 + " and " + Formats.XMLV2 + ". "
                         + "For other formats, if this field is not specified, matching location "
                         + "level information from all offices shall be returned."),
+                @OpenApiParam(name = UNIT, deprecated = true, description = "Specifies the "
+                        + "unit or unit system of the response. Valid values for the unit "
+                        + "field are: "
+                        + "\n* `EN`  (default) Specifies English unit system.  "
+                        + "Location level values will be in the default English units for "
+                        + "their parameters."
+                        + "\n* `SI`  Specifies the SI unit system.  "
+                        + "Location level values will be in the default SI units for their "
+                        + "parameters."
+                        + "\n* `Other`  Any unit returned in the response to the units URI "
+                        + "request that is appropriate for the requested parameters."),
                 @OpenApiParam(name = UNITS,  description = "Specifies the "
                         + "units or unit system of the response. Valid values for the units "
                         + "field are: "

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -553,6 +553,111 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    void test_get_with_units() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        InputStream resource = this.getClass().getResourceAsStream(
+                "/cwms/cda/api/spk/num_ts_create2.json");
+        assertNotNull(resource);
+
+        String tsData = IOUtils.toString(resource, StandardCharsets.UTF_8);
+
+        JsonNode ts = mapper.readTree(tsData);
+        String location = ts.get(Controllers.NAME).asText().split("\\.")[0];
+        String officeId = ts.get("office-id").asText();
+        createLocation(location, true, officeId);
+
+        TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
+
+        // inserting the time series
+        given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.JSONV2)
+                .contentType(Formats.JSONV2)
+                .body(tsData)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(Controllers.OFFICE, officeId)
+        .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/")
+        .then()
+                .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+                .statusCode(is(HttpServletResponse.SC_OK))
+        ;
+
+        // get it back using 'units' parameter
+        given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.JSONV2)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNITS, "CFS")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, "2007-02-02T11:00:00Z")
+                .queryParam(Controllers.END, "2010-02-03T11:00:00Z")
+                .queryParam(Controllers.VERSION_DATE, "2021-06-20T08:00:00-0000[UTC]")
+        .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .get("/timeseries/")
+       .then()
+                .log().ifValidationFails(LogDetail.ALL, true)
+       .assertThat()
+                .statusCode(is(HttpServletResponse.SC_OK))
+                .body("values.size()", equalTo(4))
+                .body("values[0][1]", equalTo(4.0F))
+                .body("values[0].size()", equalTo(3));
+
+       // get it back using old 'unit' parameter
+       given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.JSONV2)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNIT, "CFS")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, "2007-02-02T11:00:00Z")
+                .queryParam(Controllers.END, "2010-02-03T11:00:00Z")
+                .queryParam(Controllers.VERSION_DATE, "2021-06-20T08:00:00-0000[UTC]")
+       .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .get("/timeseries/")
+       .then()
+                .log().ifValidationFails(LogDetail.ALL, true)
+       .assertThat()
+                .statusCode(is(HttpServletResponse.SC_OK))
+                .body("values.size()", equalTo(4))
+                .body("values[0][1]", equalTo(4.0F))
+                .body("values[0].size()", equalTo(3));
+
+       // get it back using unit system for 'units'
+       given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.JSONV2)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(Controllers.OFFICE, officeId)
+                .queryParam(Controllers.UNITS, "EN")
+                .queryParam(Controllers.NAME, ts.get(Controllers.NAME).asText())
+                .queryParam(Controllers.BEGIN, "2007-02-02T11:00:00Z")
+                .queryParam(Controllers.END, "2010-02-03T11:00:00Z")
+                .queryParam(Controllers.VERSION_DATE, "2021-06-20T08:00:00-0000[UTC]")
+       .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .get("/timeseries/")
+       .then()
+                .log().ifValidationFails(LogDetail.ALL, true)
+       .assertThat()
+                .statusCode(is(HttpServletResponse.SC_OK))
+                .body("values.size()", equalTo(4))
+                .body("values[0][1]", equalTo(4.0F))
+                .body("values[0].size()", equalTo(3));
+    }
+
+    @Test
     void test_attempt_store_with_entry_date() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
Fixes https://github.com/USACE/cwms-data-api/issues/1113