### PR TITLE
Fix Typo in Adding 'm5testadmin' in users.sql

### DIFF
--- a/compose_files/sql/users.sql
+++ b/compose_files/sql/users.sql
@@ -23,7 +23,7 @@ begin
     execute immediate 'grant execute on cwms_20.cwms_upass to web_user';
 
 
-    cwms_sec.add_user_cwms('m5testadmin', NULL, 'LRL');
+    cwms_sec.add_cwms_user('m5testadmin', NULL, 'LRL');
     cwms_sec.add_user_to_group('m5testadmin','All Users', 'LRL');
     cwms_sec.add_user_to_group('m5testadmin','CWMS Users', 'LRL');
     cwms_sec.add_user_to_group('m5testadmin','CWMS User Admins', 'LRL');


### PR DESCRIPTION
Small bug here, instead of cwms_sec.add_cwms_user it was cwms_sec.add_user_cwms