### PR TITLE
CWMS-2172: Enabled LRTS tests for Forecast Spec

### DIFF
--- a/cwms-data-api/src/test/java/cwms/cda/api/ForecastSpecControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/ForecastSpecControllerTestIT.java
@@ -8,7 +8,6 @@ import cwms.cda.formatters.Formats;
 import fixtures.CwmsDataApiSetupCallback;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
-import org.junit.jupiter.api.Disabled;
 import usace.cwms.db.jooq.codegen.packages.CWMS_FCST_PACKAGE;
 
 import org.apache.commons.io.IOUtils;
@@ -253,7 +252,6 @@ final class ForecastSpecControllerTestIT extends DataApiTestIT {
     }
 
     @Test
-    @Disabled("Disabled until the retrieval returns the new LRTS interval identifier")
     void test_create_get_delete_get_lrts() throws Exception {
 
         // Structure of test:

--- a/cwms-data-api/src/test/java/cwms/cda/api/ForecastSpecControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/ForecastSpecControllerTestIT.java
@@ -253,16 +253,13 @@ final class ForecastSpecControllerTestIT extends DataApiTestIT {
 
     @Test
     void test_create_get_delete_get_lrts() throws Exception {
-
         // Structure of test:
-        //
-        // 1)Create the spec
-        // 2)Retrieve the spec and assert that it exists
-        // 3)Delete the spec
-        // 4)Retrieve the spec and assert that it does not exist
+        // 1) Create the spec
+        // 2) Retrieve the spec and assert that it exists
+        // 3) Delete the spec
+        // 4) Retrieve the spec and assert that it does not exist
 
         String specId = "TEST-SPEC-LRTS";
-
         TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
 
         // Step 1)
@@ -314,7 +311,9 @@ final class ForecastSpecControllerTestIT extends DataApiTestIT {
             .body("time-series-ids[1]", equalTo("TsBinTestLoc.Flow.Ave.1DayLocal.1Day.tsid2"))
             .body("time-series-ids[2]", equalTo("TsBinTestLoc.Flow.Ave.1DayLocal.1Day.tsid3"))
         ;
+
         truncateFcstTimeSeries();
+
         // Step 3)
         // Delete the spec
         given()

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -123,7 +123,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
                             .withOfficeId("HQ")
                             .withVolumeName(TeamCityUtilities.cleanupBranchName(ORACLE_VOLUME))
                             .withSchemaImage(CWMS_DB_IMAGE);
-            cwmsDb.withImagePullPolicy(PullPolicy.alwaysPull());
+            cwmsDb.withImagePullPolicy(PullPolicy.defaultPolicy());
             cwmsDb.start();
 
             final String jdbcUrl = cwmsDb.getJdbcUrl();

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -49,7 +49,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
 
     private static final String ORACLE_IMAGE =
         System.getProperty("CDA.oracle.database.image",
-                           "registry-public.hecdev.net/cwms/database-ready-ora-23.5:latest-dev"
+                           "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:latest-dev"
                        );
     private static final String ORACLE_VOLUME =
         System.getProperty("CDA.oracle.database.volume",
@@ -57,7 +57,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
                           );
     static final String CWMS_DB_IMAGE =
         System.getProperty("CDA.cwms.database.image",
-                           "registry.hecdev.net/cwms/schema_installer:99.99.99.11-CDA_STAGING"
+                           "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/schema_installer:latest-dev"
                           );
 
 

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -123,7 +123,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
                             .withOfficeId("HQ")
                             .withVolumeName(TeamCityUtilities.cleanupBranchName(ORACLE_VOLUME))
                             .withSchemaImage(CWMS_DB_IMAGE);
-            cwmsDb.withImagePullPolicy(PullPolicy.defaultPolicy());
+            cwmsDb.withImagePullPolicy(PullPolicy.alwaysPull());
             cwmsDb.start();
 
             final String jdbcUrl = cwmsDb.getJdbcUrl();


### PR DESCRIPTION
Fixes https://github.com/HydrologicEngineeringCenter/cwms-database/issues/24.

Enables LRTS interval identifier integration tests for Forecast spec retrieval.