### PR TITLE
[WebUI] Fix legacy web UI mobile menu + Add menu items

### DIFF
--- a/cwms-data-api/src/main/webapp/css/HEC.header.css
+++ b/cwms-data-api/src/main/webapp/css/HEC.header.css
@@ -373,14 +373,14 @@ a {
 	color: #f1f1f1;
 }
 
-.overlay .closebtn {
+.overlay .closeBtn {
 	position: absolute;
 	top: 20px;
 	right: 45px;
 	font-size: 60px;
 }
 
-.closebtn:hover::before {
+.closeBtn:hover::before {
 	content: "";
 }
 
@@ -598,7 +598,7 @@ a {
 		display: inline-block;
 	}
 
-	.overlay .closebtn {
+	.overlay .closeBtn {
 		font-size: 40px;
 		top: -5px;
 		right: 5px;

--- a/cwms-data-api/src/main/webapp/css/HEC.header.css
+++ b/cwms-data-api/src/main/webapp/css/HEC.header.css
@@ -455,7 +455,7 @@ a {
 
 .top-level-menu {
 	list-style: none;
-	display: block;
+	display: flex;
 	padding: 0;
 	color: #d0d0d0;
 	font-size: 13.6px;
@@ -482,6 +482,11 @@ a {
 	z-index: 99;
 	background-color: rgba(85, 85, 85, 0.98);
 	line-height: initial;
+}
+
+/* Bootstrap/tailwind-esq classes */
+.ml-auto {
+    margin-left: auto;
 }
 
 /* Menu Link Styles */

--- a/cwms-data-api/src/main/webapp/js/header.js
+++ b/cwms-data-api/src/main/webapp/js/header.js
@@ -1,9 +1,9 @@
 window.addEventListener("load", function () {
-    var coll_mob = document.getElementsByClassName("collapsible-mobile");
-    for (let col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
+    let coll_mob = document.getElementsByClassName("collapsible-mobile");
+    for (const col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
         coll_mob[col_m_idx].addEventListener("click", function (e) {
             this.classList.toggle("active");
-            var content = this.nextElementSibling;
+            const content = this.nextElementSibling;
             if (content.style.display == "none") {
                 content.style.display = "block";
             } else {
@@ -15,17 +15,16 @@ window.addEventListener("load", function () {
 
 // Mobile Burger Bar
 function openNav() {
-    var mobileNav = document.getElementById("mobileNav");
+    const mobileNav = document.getElementById("mobileNav");
     mobileNav.classList.add("open");
-    var child = document.getElementById("mobileNavContent");
+    const child = document.getElementById("mobileNavContent");
     mobileNav.style.right = child.clientWidth - child.offsetWidth + "px";
-    var open = document.getElementById("burgerBtn");
+    const open = document.getElementById("burgerBtn");
     open.style.display = "none";
-    var child = document.getElementById("overlay-content");
 }
 
 function closeNav() {
     mobileNav.classList.remove("open");
-    var open = document.getElementById("burgerBtn");
+    const open = document.getElementById("burgerBtn");
     open.style.display = null;
 }

--- a/cwms-data-api/src/main/webapp/js/header.js
+++ b/cwms-data-api/src/main/webapp/js/header.js
@@ -1,6 +1,6 @@
 // Setup the page's collapses
 let coll_mob = document.getElementsByClassName("collapsible-mobile");
-for (const col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
+for (let col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
     coll_mob[col_m_idx].addEventListener("click", function (e) {
         this.classList.toggle("active");
         const content = this.nextElementSibling;

--- a/cwms-data-api/src/main/webapp/js/header.js
+++ b/cwms-data-api/src/main/webapp/js/header.js
@@ -1,31 +1,31 @@
-window.addEventListener("load", function() {
-  var coll_mob = document.getElementsByClassName("collapsible-mobile");
-  for (let col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
-    coll_mob[col_m_idx].addEventListener("click", function (e) {
-      this.classList.toggle("active");
-      var content = this.nextElementSibling;
-      if (content.style.display == "none") {
-        content.style.display = "block";
-      } else {
-        content.style.display = "none";
-      }
-    });
-  }
+window.addEventListener("load", function () {
+    var coll_mob = document.getElementsByClassName("collapsible-mobile");
+    for (let col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
+        coll_mob[col_m_idx].addEventListener("click", function (e) {
+            this.classList.toggle("active");
+            var content = this.nextElementSibling;
+            if (content.style.display == "none") {
+                content.style.display = "block";
+            } else {
+                content.style.display = "none";
+            }
+        });
+    }
 }, false);
 
 // Mobile Burger Bar
 function openNav() {
-  var mobileNav = document.getElementById("mobileNav");
-  mobileNav.classList.add("open");
-  var child = document.getElementById("mobileNavContent");
-  mobileNav.style.right = child.clientWidth - child.offsetWidth + "px";
-  var open = document.getElementById("burgerBtn");
-  open.style.display = "none";
-  var child = document.getElementById("overlay-content");
+    var mobileNav = document.getElementById("mobileNav");
+    mobileNav.classList.add("open");
+    var child = document.getElementById("mobileNavContent");
+    mobileNav.style.right = child.clientWidth - child.offsetWidth + "px";
+    var open = document.getElementById("burgerBtn");
+    open.style.display = "none";
+    var child = document.getElementById("overlay-content");
 }
 
 function closeNav() {
-  mobileNav.classList.remove("open");
-  var open = document.getElementById("burgerBtn");
-  open.style.display = null;
+    mobileNav.classList.remove("open");
+    var open = document.getElementById("burgerBtn");
+    open.style.display = null;
 }

--- a/cwms-data-api/src/main/webapp/js/header.js
+++ b/cwms-data-api/src/main/webapp/js/header.js
@@ -1,17 +1,24 @@
-window.addEventListener("load", function () {
-    let coll_mob = document.getElementsByClassName("collapsible-mobile");
-    for (const col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
-        coll_mob[col_m_idx].addEventListener("click", function (e) {
-            this.classList.toggle("active");
-            const content = this.nextElementSibling;
-            if (content.style.display == "none") {
-                content.style.display = "block";
-            } else {
-                content.style.display = "none";
-            }
-        });
-    }
-}, false);
+// Setup the page's collapses
+let coll_mob = document.getElementsByClassName("collapsible-mobile");
+for (const col_m_idx = 0; col_m_idx < coll_mob.length; col_m_idx++) {
+    coll_mob[col_m_idx].addEventListener("click", function (e) {
+        this.classList.toggle("active");
+        const content = this.nextElementSibling;
+        if (content.style.display == "none") {
+            content.style.display = "block";
+        } else {
+            content.style.display = "none";
+        }
+    });
+}
+const burgerBtn = document.getElementById("burgerBtn");
+if (burgerBtn) {
+    burgerBtn.addEventListener("click", openNav);
+}
+const closeBtn = document.querySelector(".closeBtn");
+if (closeBtn) {
+    closeBtn.addEventListener("click", closeNav);
+}
 
 // Mobile Burger Bar
 function openNav() {
@@ -19,12 +26,13 @@ function openNav() {
     mobileNav.classList.add("open");
     const child = document.getElementById("mobileNavContent");
     mobileNav.style.right = child.clientWidth - child.offsetWidth + "px";
-    const open = document.getElementById("burgerBtn");
-    open.style.display = "none";
+    const BURGER_BTN = document.getElementById("burgerBtn");
+    BURGER_BTN.style.display = "none";
 }
 
 function closeNav() {
+    const mobileNav = document.getElementById("mobileNav")
     mobileNav.classList.remove("open");
-    const open = document.getElementById("burgerBtn");
-    open.style.display = null;
+    const BURGER_BTN = document.getElementById("burgerBtn");
+    BURGER_BTN.style.display = null;
 }

--- a/cwms-data-api/src/main/webapp/js/util.js
+++ b/cwms-data-api/src/main/webapp/js/util.js
@@ -1,14 +1,41 @@
-function load (id, url) {
-	var con = document.getElementById(id)
-	var xhr = new XMLHttpRequest();
+function load(id, url) {
+  var con = document.getElementById(id);
+  var xhr = new XMLHttpRequest();
 
-	xhr.onreadystatechange = function (e) { 
-		if (xhr.readyState == 4 && xhr.status == 200) {
-			con.innerHTML = xhr.responseText;
-		}
-	}
+  xhr.onreadystatechange = function () {
+    // Check if the request is complete and was successful
+    if (xhr.readyState == 4 && xhr.status == 200) {
+      con.innerHTML = xhr.responseText;
 
-	xhr.open("GET", url, true);
-	xhr.setRequestHeader('Content-type', 'text/html');
-	xhr.send();
+      // Reinitialize any scripts in the loaded content
+      // This is necessary because innerHTML does not execute scripts
+      // We create new script elements and replace the old ones
+      // to ensure they are executed.
+      const scripts = con.querySelectorAll("script");
+      scripts.forEach((oldScript) => {
+        const newScript = document.createElement("script");
+
+        // Add attributes from the old script to the new one
+        Array.from(oldScript.attributes).forEach(attr =>
+          newScript.setAttribute(attr.name, attr.value)
+        );
+
+        // If the old script has inline code, set it as the text content of the new script
+        if (oldScript.innerHTML) {
+          newScript.textContent = oldScript.innerHTML;
+        }
+
+        // Replace the old script with the new one
+        oldScript.parentNode.replaceChild(newScript, oldScript);
+      });
+    }
+    else if (xhr.readyState == 4) {
+      console.error("Error loading content from " + url + ": " + xhr.statusText);
+      con.innerHTML = "<p>Error loading content. Please try again later.</p>";
+    }
+  };
+
+  xhr.open("GET", url, true);
+  xhr.setRequestHeader("Content-type", "text/html");
+  xhr.send();
 }

--- a/cwms-data-api/src/main/webapp/templates/HEC.header.html
+++ b/cwms-data-api/src/main/webapp/templates/HEC.header.html
@@ -20,11 +20,11 @@
                                     </ul>
                                 </div>
                                 <div id="mobile-menu">
-                                    <span class="burger-bar" id="burgerBtn" onclick="openNav()">&#9776;</span>
+                                    <span class="burger-bar" id="burgerBtn">&#9776;</span>
                                 </div>
                             </div>
                             <div id="mobileNav" class="overlay">
-                                <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+                                <a href="javascript:void(0)" class="closeBtn">&times;</a>
                                 <div id="mobileNavContent" class="overlay-content">
                                     <a class="home mobile-top-level-menu" href="./swagger-docs">Swagger Docs</a>
                                     <a class="home mobile-top-level-menu" href="./swagger-ui.html">Swagger UI</a>
@@ -48,8 +48,9 @@
                 </div>
 
                 <!-- Burger Bar Control -->
-                <script defer type="text/javascript" src="./js/header.js"></script>
+                <script defer type="text/javascript" src="./js/header.js?_=2"></script>
                 <script type="text/javascript">
+                    console.log("test2")
                     // Setup the page's collapses
                     let coll_legend = document.getElementsByClassName("collapsible-legend");
                     for (var i = 0; i < coll_legend.length; i++) {

--- a/cwms-data-api/src/main/webapp/templates/HEC.header.html
+++ b/cwms-data-api/src/main/webapp/templates/HEC.header.html
@@ -18,11 +18,11 @@
                                         <li><a href="./swagger-ui.html">Swagger UI</a></li>
                                         <li><a>Client Libraries <i class="fas fa-caret-down"></i></a>
                                             <ul class="second-level-menu">
-                                                <li><a href="https://github.com/HydrologicEngineeringCenter/cwms-python">Python</a></li>
-                                                <li><a href="/charts">JavaScript <i class="fas fa-caret-right"></i></a>
+                                                <li><a href="https://github.com/HydrologicEngineeringCenter/cwms-python"><i class="fab fa-python"></i> Python</a></li>
+                                                <li><a href="/charts"><i class="fab fa-js-square"></i> JavaScript <i class="fas fa-caret-right"></i></a>
                                                     <ul class="third-level-menu">
-                                                        <li><a href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-javascript/">User Docs</a></li>
-                                                        <li><a href="https://github.com/hydrologicengineeringcenter/cwms-data-api-client-javascript">Github</a></li>
+                                                        <li><a href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-javascript/"> User Docs</a></li>
+                                                        <li><a href="https://github.com/hydrologicengineeringcenter/cwms-data-api-client-javascript"><i class="fab fa-github"></i> Github</a></li>
                                                     </ul>
                                                 </li>
                                             </ul>
@@ -40,7 +40,15 @@
                                 <div id="mobileNavContent" class="overlay-content">
                                     <a class="home mobile-top-level-menu" href="./swagger-docs">Swagger Docs</a>
                                     <a class="home mobile-top-level-menu" href="./swagger-ui.html">Swagger UI</a>
-                                </div>
+                                    <a class="home mobile-top-level-menu" href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-java/"><i class="fab fa-github"></i> CDA GitHub</a>
+                                    <div title="Click to Expand" class="collapsible-mobile mobile-top-level-menu active">
+										Client Libraries <i class="fas fa-caret-down"></i>
+									</div>
+                                    <div class="content-mobile" style="display: block;">
+                                        <a class="menu-item" href="https://github.com/HydrologicEngineeringCenter/cwms-python"><i class="fab fa-python"></i> Python</a>
+                                        <a class="menu-item" href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-javascript/"><i class="fab fa-js-square"></i> JavaScript - User Docs</a>
+										<a class="menu-item" href="https://github.com/HydrologicEngineeringCenter/cwms-data-api-client-javascript"><i class="fab fa-github"></i> JavaScript - Github</a>
+									</div>
                             </div>
                         </div>
                     </div>

--- a/cwms-data-api/src/main/webapp/templates/HEC.header.html
+++ b/cwms-data-api/src/main/webapp/templates/HEC.header.html
@@ -19,7 +19,7 @@
                                         <li><a>Client Libraries <i class="fas fa-caret-down"></i></a>
                                             <ul class="second-level-menu">
                                                 <li><a href="https://github.com/HydrologicEngineeringCenter/cwms-python"><i class="fab fa-python"></i> Python</a></li>
-                                                <li><a href="/charts"><i class="fab fa-js-square"></i> JavaScript <i class="fas fa-caret-right"></i></a>
+                                                <li><a href="#"><i class="fab fa-js-square"></i> JavaScript <i class="fas fa-caret-right"></i></a>
                                                     <ul class="third-level-menu">
                                                         <li><a href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-javascript/"> User Docs</a></li>
                                                         <li><a href="https://github.com/hydrologicengineeringcenter/cwms-data-api-client-javascript"><i class="fab fa-github"></i> Github</a></li>

--- a/cwms-data-api/src/main/webapp/templates/HEC.header.html
+++ b/cwms-data-api/src/main/webapp/templates/HEC.header.html
@@ -62,7 +62,6 @@
                 <!-- Burger Bar Control -->
                 <script defer type="text/javascript" src="./js/header.js?_=2"></script>
                 <script type="text/javascript">
-                    console.log("test2")
                     // Setup the page's collapses
                     let coll_legend = document.getElementsByClassName("collapsible-legend");
                     for (var i = 0; i < coll_legend.length; i++) {

--- a/cwms-data-api/src/main/webapp/templates/HEC.header.html
+++ b/cwms-data-api/src/main/webapp/templates/HEC.header.html
@@ -16,6 +16,18 @@
                                     <ul class="top-level-menu">
                                         <li><a href="./swagger-docs">Swagger Docs</a></li>
                                         <li><a href="./swagger-ui.html">Swagger UI</a></li>
+                                        <li><a>Client Libraries <i class="fas fa-caret-down"></i></a>
+                                            <ul class="second-level-menu">
+                                                <li><a href="https://github.com/HydrologicEngineeringCenter/cwms-python">Python</a></li>
+                                                <li><a href="/charts">JavaScript <i class="fas fa-caret-right"></i></a>
+                                                    <ul class="third-level-menu">
+                                                        <li><a href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-javascript/">User Docs</a></li>
+                                                        <li><a href="https://github.com/hydrologicengineeringcenter/cwms-data-api-client-javascript">Github</a></li>
+                                                    </ul>
+                                                </li>
+                                            </ul>
+                                        </li>
+                                        <li class="ml-auto"><a href="https://hydrologicengineeringcenter.github.io/cwms-data-api-client-java/"><i class="fab fa-github"></i> CDA GitHub</a></li>
                                         <li id="sphinx-docs" />
                                     </ul>
                                 </div>


### PR DESCRIPTION
This PR adds new header links for the client-side libraries.

I also noticed the mobile menu was not working. If you attempt to tap it currently nothing happens visually. 

It looks as if the JavaScript for the event listener was not being loaded. Updated the `load()` method to account for this. 

# Brief Summary of Changes
- Update touched files to newer const/let
- Update `load` method for html files with JS
- Update header to include github + client library links to desktop and mobile

## Testing
I ran the index.html using VSCode's live server to ensure it rendered as expected on mobile and desktop:

### Mobile Menu
<img width="408" height="584" alt="image" src="https://github.com/user-attachments/assets/a6754da5-576a-47e3-87b2-811a412511e3" />

### Desktop Menu
<img width="1181" height="482" alt="image" src="https://github.com/user-attachments/assets/5749c3c7-c71c-437a-8fef-65fc799130e5" />
