### PR TITLE
CWMS-2194: Bugfix/ts retrieve entry date

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -456,7 +456,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
         );
 
         String retrievalMethod;
-        if (entryDateSupport != null) {
+        if (includeEntryDate) {
             retrievalMethod = "cwms_20.cwms_ts.retrieve_ts_entry_out_tab";  // New method that supports entry date
         } else {
             retrievalMethod = "cwms_20.cwms_ts.retrieve_ts_out_tab";    // Legacy method without entry date
@@ -508,7 +508,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 
             if (pageSize > 0) {
                 query.limit(DSL.val(pageSize + 1));
-                if (entryDateSupport != null) {
+                if (includeEntryDate) {
                     query2.limit(DSL.val(pageSize + 1));
                 }
             }
@@ -516,7 +516,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
             if (requestParameters.isIncludeEntryDate()) {
                 logger.fine(() -> query2.getSQL(ParamType.INLINED));
                 try (Cursor<Record4<Timestamp, Double, BigDecimal, Timestamp>> recCursor = query2.fetchLazy()) {
-                    for(Record tsRecord: recCursor){
+                    for (Record tsRecord: recCursor) {
                         timeseries.addValue(
                                 tsRecord.getValue(dateTimeCol),
                                 tsRecord.getValue(valueCol),
@@ -527,7 +527,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
             } else {
                 logger.fine(() -> query.getSQL(ParamType.INLINED));
                 try (Cursor<Record3<Timestamp, Double, BigDecimal>> recCursor = query.fetchLazy()) {
-                    for(Record tsRecord: recCursor){
+                    for (Record tsRecord: recCursor) {
                         timeseries.addValue(
                                 tsRecord.getValue(dateTimeCol),
                                 tsRecord.getValue(valueCol),

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -172,14 +172,12 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
         Timestamp tsCursor = null;
         Integer total = null;
 
-        if (includeEntryDate) {
-            Record entryDateSupport = dsl.select(asterisk()).from(table("ALL_TYPES"))
-                    .where(field("TYPE_NAME").eq("ZTSV_ENTRY_TYPE"))
-                    .and(field("OWNER").eq("CWMS_20")).fetchOne();
+        Record entryDateSupport = dsl.select(asterisk()).from(table("ALL_TYPES"))
+            .where(field("TYPE_NAME").eq("ZTSV_ENTRY_TYPE"))
+            .and(field("OWNER").eq("CWMS_20")).fetchOne();
 
-            if (entryDateSupport == null) {
-                throw new DataAccessException("Data entry date retrieval is not supported by this database");
-            }
+        if (includeEntryDate && entryDateSupport == null) {
+            throw new DataAccessException("Data entry date retrieval is not supported by this database");
         }
 
         if (page != null && !page.isEmpty()) {
@@ -364,11 +362,18 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
             }
         );
 
+        String retrievalMethod;
+        if (entryDateSupport != null) {
+            retrievalMethod = "cwms_20.cwms_ts.retrieve_ts_entry_out_tab";  // New method that supports entry date
+        } else {
+            retrievalMethod = "cwms_20.cwms_ts.retrieve_ts_out_tab";    // Legacy method without entry date
+        }
+
         // Now we're going to call the retrieve_ts_entry_out_tab function to get the data and build an
         // internal table from it so we can manipulate it further
         // This code assumes the database timezone is in UTC (per Oracle recommendation)
         SQL retrieveSelectData = DSL.sql(
-                "table(cwms_20.cwms_ts.retrieve_ts_entry_out_tab(?,?,"
+                "table(" + retrievalMethod + "(?,?,"
                         + "cwms_20.cwms_util.to_timestamp(?), cwms_20.cwms_util.to_timestamp(?), 'UTC',"
                         + "?,?,?,?,?,"
                         + getVersionPart(versionDate) + ",?,?) ) retrieveTs",
@@ -410,7 +415,9 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 
             if (pageSize > 0) {
                 query.limit(DSL.val(pageSize + 1));
-                query2.limit(DSL.val(pageSize + 1));
+                if (entryDateSupport != null) {
+                    query2.limit(DSL.val(pageSize + 1));
+                }
             }
 
             if (includeEntryDate) {

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cwms.cda.ApiServlet;
 import cwms.cda.formatters.Formats;
 import fixtures.CwmsDataApiSetupCallback;
+import fixtures.MinimumSchema;
 import fixtures.TestAccounts;
 import io.restassured.RestAssured;
 import io.restassured.filter.log.LogDetail;
@@ -41,6 +42,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 @Tag("integration")
 class TimeseriesControllerTestIT extends DataApiTestIT {
+    public static final int MINIMUM_SCHEMA = 999999;
+
     @Test
     void test_lrl_timeseries_psuedo_reg1hour() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
@@ -108,6 +111,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    @MinimumSchema(MINIMUM_SCHEMA)
     void test_local_regular_new_LRTS_ID() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
@@ -380,6 +384,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    @MinimumSchema(MINIMUM_SCHEMA)
     void test_lrl_1day_max_version_with_entry_date() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 
@@ -709,6 +714,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    @MinimumSchema(MINIMUM_SCHEMA)
     void test_include_data_entry_date() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -909,6 +909,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    @MinimumSchema(MINIMUM_SCHEMA)
     void test_attempt_store_with_entry_date() throws Exception
     {
         ObjectMapper mapper = new ObjectMapper();
@@ -1295,6 +1296,7 @@ class TimeseriesControllerTestIT extends DataApiTestIT {
     }
 
     @Test
+    @MinimumSchema(MINIMUM_SCHEMA)
     void test_lrl_trim_with_data_entry_date() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
 


### PR DESCRIPTION
Fixes #1174 

Moves schema check to be executed on each retrieval. Now successfully handles retrieval requests without data entry date correctly.