### PR TITLE
Reduce log entries for client info errors.

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -201,7 +201,7 @@ public abstract class JooqDao<T> extends Dao<T> {
             connection.setClientInfo("OCSID.ACTION", ctx.method());
             connection.setClientInfo("OCSID.CLIENTID", ctx.url().replace(ctx.path(), "") + ctx.contextPath());
         } catch (SQLClientInfoException ex) {
-            logger.atWarning()
+            logger.atFinest() // this is usually useless information
                     .withCause(ex)
                     .log("Unable to set client info on connection.");
         }


### PR DESCRIPTION
We're all getting annoyed with this in the cloud env, the internal DNS entries that this block sees are rather long so literally every call puts an error message that we really don't need to care about.