### PR TITLE
1253 make issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug, priority:medium'
+labels: 'bug, priority:medium, Security, documentation, enhancement, blob, catalog, clobs, ratings, timeseries, web-ui'
 assignees: '@CWMS Developers'
 
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug, priority-medium'
+assignees: '@CWMS Developers'
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is. This should include the instance of CDA tried, the endpoints, and what you were intending to do.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Logs/Incident Identifier**
+When you receive an error if possible add your corresponding log output. This will be from the Tomcat logs. 
+**If you do not have access to this, ignore this section!**
+
+**CURL Commands**
+If applicable, add the curl command from the SWAGGER UI to help reproduce your problem.  
+**REDACT** any internal domains/IP addresses.
+
+**CDA Version (please complete the following information):**
+At the top of any instance of CDA you will see a version. Please provide that version.
+
+- Version [e.g. 2025.08.18 ]
+
+**Additional context**
+Add any other context about the problem here.  

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'bug, priority-medium'
+labels: 'bug, priority:medium'
 assignees: '@CWMS Developers'
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: priority:low, enhancement
+labels: 'priority:low, documentation, enhancement, blob, catalog, clobs, ratings, timeseries, web-ui'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: priority:low, enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
Copied from https://github.com/opendcs/opendcs/tree/main/.github/ISSUE_TEMPLATE and tweaked ever so slightly. 

Debated making separate templates for the web-gui but decided just adding the label should be sufficient and prevent any confusion. 