### PR TITLE
Add npm audit to the build steps action for CDA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,18 @@ jobs:
           distribution: 'temurin'
           java-version: ${{matrix.jdk}}
           cache: 'gradle'
+      - name: install node for cda-gui audit
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: cda-gui/package-lock.json
+
+      - name: run cda-gui audit for high CVE
+        working-directory: ./cda-gui
+        run: |
+          npm install --package-lock-only
+          npm audit --audit-level=high
       - name: build and test
         id: thebuild
         run: ./gradlew build --info --init-script init.gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: install node for cda-gui audit
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: cda-gui/package-lock.json
 


### PR DESCRIPTION
Ran this locally to test, currently with the dependabot changes merged

#1243 

Reporting 
```
npm audit --audit-level=high
found 0 vulnerabilities
```

Note: I went with node 20 in the actions, but we could probably bump that up? 