### PR TITLE
Modify tags allowed on develop.

### DIFF
--- a/.github/workflows/get_version.sh
+++ b/.github/workflows/get_version.sh
@@ -1,4 +1,0 @@
-VERSION=`./gradlew --init-script init.gradle properties -q | grep "^version:" | awk '{ print $2}'`
-WARFILE="cwms-data-api/build/libs/cwms-data-api-tomcat-$VERSION.war"
-echo "VERSION=$VERSION" >> $GITHUB_ENV
-echo "WAR_FILE_NAME=$WARFILE" >> $GITHUB_ENV

--- a/.github/workflows/nightly-schedule.yml
+++ b/.github/workflows/nightly-schedule.yml
@@ -33,3 +33,18 @@ jobs:
       migration_image: ${{needs.develop.outputs.migration_image}}
       region: us-gov-west-1
       iam_role: arn:aws-us-gov:iam::718787032875:role/github-actions-ecr-cwms-data-api
+  
+  test:
+    permissions:
+      packages: write
+      contents: write
+    uses: ./.github/workflows/release.yml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      registry: ${{ secrets.HEC_PUB_REGISTRY}}
+      registry_user: ${{ secrets.ALT_REG_USER }}
+      registry_password: ${{ secrets.ALT_REG_PASSWORD }}
+    with:
+      branch: "test"
+      nightly: true
+  # May setup test nightly deploy in future, currently no permissions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ on:
         description: Which Branch to make the build from
         options:
           - develop
+          - test
       nightly:
         type: boolean
         required: true

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       # Allow an additional marker if multiple releases needed within a day.
-      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-dev[a-z]+'      
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-dev[a-z]*'      
 jobs:
   release:
     uses: ./.github/workflows/release.yml

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -3,8 +3,8 @@ name: Tagged Release
 on:
   push:
     tags:
-      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]'
-      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-[a-zA-Z0-9]+'
+      # Allow an additional marker if multiple releases needed within a day.
+      - '[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]-dev[a-z]+'      
 jobs:
   release:
     uses: ./.github/workflows/release.yml


### PR DESCRIPTION
Require tags for anything on the develop include include -dev to allow creating a 'dev' release but to avoid confusion with an final release.