### PR TITLE
CDA-41: Add Location Alias Inclusion Flag to getOne

### DIFF
--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -97,6 +97,8 @@ dependencies {
     // https://mvnrepository.com/artifact/de.grundid.opendatalab/geojson-jackson
     implementation(libs.geojson.jackson)
 
+    implementation(libs.jackson.datatype.jdk8)
+
     implementation(libs.javalin.core) {
         exclude group: "org.eclipse.jetty"
         exclude group: "org.eclipse.jetty.websocket"

--- a/cwms-data-api/src/main/java/cwms/cda/api/LocationController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LocationController.java
@@ -215,7 +215,9 @@ public class LocationController implements CrudHandler {
                         + "\n* `EN`  Specifies English unit system.  Location values will be in the "
                         + "default English units for their parameters. This is the default behavior."
                         + "\n* `SI`  Specifies the SI unit system.  Location values will be in the "
-                        + "default SI units for their parameters.")
+                        + "default SI units for their parameters."),
+                @OpenApiParam(name = INCLUDE_ALIASES, type = Boolean.class, description = "Specifies whether to "
+                        + "include location aliases in the response. Default: false"),
             },
             responses = {
                 @OpenApiResponse(status = STATUS_200,
@@ -238,11 +240,13 @@ public class LocationController implements CrudHandler {
             String units =
                     ctx.queryParamAsClass(UNIT, String.class).getOrDefault(UnitSystem.EN.value());
             String office = ctx.queryParam(OFFICE);
+            boolean includeAliases =
+                    ctx.queryParamAsClass(INCLUDE_ALIASES, Boolean.class).getOrDefault(false);
             String formatHeader = ctx.header(Header.ACCEPT);
             ContentType contentType = Formats.parseHeader(formatHeader, Location.class);
             ctx.contentType(contentType.toString());
             LocationsDao locationDao = getLocationsDao(dsl);
-            Location location = locationDao.getLocation(name, units, office);
+            Location location = locationDao.getLocation(name, units, office, includeAliases);
             String serializedLocation = Formats.format(contentType, location);
             ctx.result(serializedLocation);
             addDeprecatedContentTypeWarning(ctx, contentType);
@@ -330,7 +334,7 @@ public class LocationController implements CrudHandler {
             Location locationFromBody = Formats.parseContent(contentType, ctx.body(), Location.class);
             //getLocation will throw an error if location does not exist
             Location existingLocation = locationsDao.getLocation(locationId,
-                    UnitSystem.EN.getValue(), locationFromBody.getOfficeId());
+                    UnitSystem.EN.getValue(), locationFromBody.getOfficeId(), false);
             existingLocation = updatedClearedFields(ctx.body(), contentType.getType(),
                     existingLocation);
             //only store (update) if location does exist

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationLevelsDaoImpl.java
@@ -63,7 +63,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -308,10 +307,12 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
         String attributeUnits = row.get(map.getAttributeUnit(), String.class);
         Date effectiveDate = row.get(map.getLevelDate(), Date.class);
         String aliasId = row.get(DSL.name(TABLE_ALIAS2, "ALIAS_ID"), String.class);
+        String categoryId = row.get(DSL.name(TABLE_ALIAS2, "CATEGORY_ID"), String.class);
+        String groupId = row.get(DSL.name(TABLE_ALIAS2, "GROUP_ID"), String.class);
 
         LevelLookup key = new LevelLookup(officeId, locationLevelId, attributeId, String.valueOf(attributeValue),
                                              attributeUnits, effectiveDate);
-        LocationAlias alias = new LocationAlias(locationLevelId, aliasId);
+        LocationAlias alias = new LocationAlias(categoryId + "-" + groupId, aliasId);
 
         if (aliasMap.containsKey(key)) {
             aliasMap.get(key).add(alias);
@@ -1443,5 +1444,7 @@ public class LocationLevelsDaoImpl extends JooqDao<LocationLevel> implements Loc
         LOCATION_ALIAS_FIELDS.add(field(aliasView.ALIAS_ID.getUnqualifiedName()));
         LOCATION_ALIAS_FIELDS.add(field(aliasView.LOCATION_CODE.getUnqualifiedName()));
         LOCATION_ALIAS_FIELDS.add(field(aliasView.DB_OFFICE_ID.getUnqualifiedName()));
+        LOCATION_ALIAS_FIELDS.add(field(aliasView.CATEGORY_ID.getUnqualifiedName()));
+        LOCATION_ALIAS_FIELDS.add(field(aliasView.GROUP_ID.getUnqualifiedName()));
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDao.java
@@ -38,6 +38,8 @@ public interface LocationsDao {
 
     List<CwmsIdLocationKind> getLocationKinds(String idRegexMask, String kindRegexMask, String officeId);
 
+    Location getLocation(String locationName, String unitSystem, String officeId, boolean includeAliases) throws IOException;
+
     Location getLocation(String locationName, String unitSystem, String officeId) throws IOException;
 
     void deleteLocation(String locationName, String officeId);

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
@@ -40,6 +40,7 @@ import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.name;
 import static org.jooq.impl.DSL.select;
 import static usace.cwms.db.jooq.codegen.tables.AV_LOC.AV_LOC;
+import static usace.cwms.db.jooq.codegen.tables.AV_LOC_ALIAS.AV_LOC_ALIAS;
 
 import cwms.cda.api.enums.Nation;
 import cwms.cda.api.enums.Unit;
@@ -156,17 +157,39 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
 
     @Override
     public Location getLocation(String locationName, String unitSystem, String officeId) {
-        Record loc = dsl.select(AV_LOC.asterisk())
+        return getLocation(locationName, unitSystem, officeId, false);
+    }
+
+    @Override
+    public Location getLocation(String locationName, String unitSystem, String officeId, boolean includeAliases) {
+        if (includeAliases) {
+            List<Record> locs = dsl.select(asterisk())
+                .from(AV_LOC2.AV_LOC2)
+                .leftJoin(AV_LOC_ALIAS)
+                .on(AV_LOC2.AV_LOC2.BASE_LOCATION_ID.eq(AV_LOC_ALIAS.BASE_LOCATION_ID).and(
+                    AV_LOC2.AV_LOC2.LOCATION_CODE.eq(AV_LOC_ALIAS.LOCATION_CODE.cast(Long.class))))
+                .where(AV_LOC2.AV_LOC2.DB_OFFICE_ID.equalIgnoreCase(officeId)
+                    .and(AV_LOC2.AV_LOC2.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
+                        .and(AV_LOC2.AV_LOC2.LOCATION_ID.equalIgnoreCase(locationName))))
+                .fetch();
+            if (locs.isEmpty()) {
+                throw new NotFoundException("Location not found for office:" + officeId + " and unit "
+                    + "system:" + unitSystem + " and id:" + locationName);
+            }
+            return buildLocation(null, locs, true);
+        } else {
+            Record loc = dsl.select(AV_LOC.asterisk())
                 .from(AV_LOC)
                 .where(AV_LOC.DB_OFFICE_ID.equalIgnoreCase(officeId)
-                        .and(AV_LOC.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
-                                .and(AV_LOC.LOCATION_ID.equalIgnoreCase(locationName))))
+                    .and(AV_LOC.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
+                        .and(AV_LOC.LOCATION_ID.equalIgnoreCase(locationName))))
                 .fetchOne();
-        if (loc == null) {
-            throw new NotFoundException("Location not found for office:" + officeId + " and unit "
+            if (loc == null) {
+                throw new NotFoundException("Location not found for office:" + officeId + " and unit "
                     + "system:" + unitSystem + " and id:" + locationName);
+            }
+            return buildLocation(loc);
         }
-        return buildLocation(loc);
     }
 
     private CwmsIdLocationKind buildLocationKind(Record loc) {
@@ -177,56 +200,84 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
     }
 
     private Location buildLocation(Record loc) {
-        String timeZoneName = loc.get(AV_LOC.TIME_ZONE_NAME); // may be null...
+        return buildLocation(loc, null, false);
+    }
+
+    private Location buildLocation(Record singleLoc, List<Record> locWithAliases, boolean includeAliases) {
+        FieldMapping map;
+        Record loc;
+        if (includeAliases) {
+            map = new AvLoc2FieldMapping();
+            loc = locWithAliases.get(0);
+        } else {
+            map = new AvLocFieldMapping();
+            loc = singleLoc;
+        }
+
+        String timeZoneName = loc.get(map.getTimeZoneName()); // may be null...
         ZoneId zone = null;
         if (timeZoneName != null) {
             zone = ZoneIdHelper.parseZoneIdWithAliases(timeZoneName);
         }
 
         Double latDouble = null;
-        BigDecimal latBigDec = loc.get(AV_LOC.LATITUDE);
+        BigDecimal latBigDec = loc.get(map.getLatitude());
         if (latBigDec != null) {
             latDouble = latBigDec.doubleValue();
         }
 
         Double longDouble = null;
-        BigDecimal longBigDec = loc.get(AV_LOC.LONGITUDE);
+        BigDecimal longBigDec = loc.get(map.getLongitude());
         if (longBigDec != null) {
             longDouble = longBigDec.doubleValue();
         }
 
-        Location.Builder locationBuilder = new Location.Builder(
-                loc.get(AV_LOC.LOCATION_ID),
-                loc.get(AV_LOC.LOCATION_KIND_ID),
-                zone,
-                latDouble,
-                longDouble,
-                loc.get(AV_LOC.HORIZONTAL_DATUM),
-                loc.get(AV_LOC.DB_OFFICE_ID)
-        )
-                .withLocationType(loc.get(AV_LOC.LOCATION_TYPE))
-                .withElevation(loc.get(AV_LOC.ELEVATION))
-                .withElevationUnits(loc.get(AV_LOC.UNIT_ID))
-                .withVerticalDatum(loc.get(AV_LOC.VERTICAL_DATUM))
-                .withPublicName(loc.get(AV_LOC.PUBLIC_NAME))
-                .withLongName(loc.get(AV_LOC.LONG_NAME))
-                .withDescription(loc.get(AV_LOC.DESCRIPTION))
-                .withCountyName(loc.get(AV_LOC.COUNTY_NAME))
-                .withStateInitial(loc.get(AV_LOC.STATE_INITIAL))
-                .withActive(loc.get(AV_LOC.ACTIVE_FLAG).equalsIgnoreCase("T"))
-                .withMapLabel(loc.get(AV_LOC.MAP_LABEL))
-                .withBoundingOfficeId(loc.get(AV_LOC.BOUNDING_OFFICE_ID))
-                .withNearestCity(loc.get(AV_LOC.NEAREST_CITY))
-                .withNation(Nation.nationForName(loc.get(AV_LOC.NATION_ID)))
-                ;
+        String locationId = loc.get(map.getLocationId());
 
-        BigDecimal pubLatitude = loc.get(AV_LOC.PUBLISHED_LATITUDE);
-        BigDecimal pubLongitude = loc.get(AV_LOC.PUBLISHED_LONGITUDE);
+        Location.Builder locationBuilder = new Location.Builder(
+            locationId,
+            loc.get(map.getLocationKind()),
+            zone,
+            latDouble,
+            longDouble,
+            loc.get(map.getHorizontalDatum()),
+            loc.get(map.getDbOfficeId())
+        )
+            .withLocationType(loc.get(map.getLocationType()))
+            .withElevation(loc.get(map.getElevation()))
+            .withElevationUnits(loc.get(map.getUnit()))
+            .withVerticalDatum(loc.get(map.getVerticalDatum()))
+            .withPublicName(loc.get(map.getPublicName()))
+            .withLongName(loc.get(map.getLongName()))
+            .withDescription(loc.get(map.getDescription()))
+            .withCountyName(loc.get(map.getCountyName()))
+            .withStateInitial(loc.get(map.getStateInitial()))
+            .withActive(loc.get(map.getActiveFlag()).equalsIgnoreCase("T"))
+            .withMapLabel(loc.get(map.getMapLabel()))
+            .withBoundingOfficeId(loc.get(map.getBoundingOfficeId()))
+            .withNearestCity(loc.get(map.getNearestCity()))
+            .withNation(Nation.nationForName(loc.get(map.getNation())))
+            ;
+
+        BigDecimal pubLatitude = loc.get(map.getPublishedLatitude());
+        BigDecimal pubLongitude = loc.get(map.getPublishedLongitude());
         if (pubLatitude != null) {
             locationBuilder.withPublishedLatitude(pubLatitude.doubleValue());
         }
         if (pubLongitude != null) {
             locationBuilder.withPublishedLongitude(pubLongitude.doubleValue());
+        }
+
+        if (includeAliases) {
+            List<LocationAlias> aliases = new ArrayList<>();
+            for (Record r : locWithAliases) {
+                String alias = r.get(AV_LOC_ALIAS.ALIAS_ID);
+                if (alias != null && !alias.isEmpty()) {
+                    LocationAlias locationAlias = new LocationAlias(locationId, alias);
+                    aliases.add(locationAlias);
+                }
+            }
+            locationBuilder.withAliases(aliases);
         }
         return locationBuilder.build();
     }
@@ -428,7 +479,7 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
     }
 
     private Catalog getLocationCatalog(Catalog.CatalogPage catPage, int pageSize, CatalogRequestParameters params) {
-        FieldMapping fieldMapping = null;
+        FieldMapping fieldMapping;
         if (params.includeAliases()) {
             fieldMapping = new AvLoc2FieldMapping();
         } else {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
@@ -273,7 +273,8 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
             for (Record r : locWithAliases) {
                 String alias = r.get(AV_LOC_ALIAS.ALIAS_ID);
                 if (alias != null && !alias.isEmpty()) {
-                    LocationAlias locationAlias = new LocationAlias(locationId, alias);
+                    LocationAlias locationAlias = new LocationAlias(r.get(AV_LOC_ALIAS.CATEGORY_ID)
+                        + "-" + r.get(AV_LOC_ALIAS.GROUP_ID), alias);
                     aliases.add(locationAlias);
                 }
             }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Location.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Location.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import cwms.cda.api.enums.Nation;
+import cwms.cda.data.dto.catalog.LocationAlias;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.annotations.FormattableWith;
 import cwms.cda.formatters.json.JsonV1;
@@ -17,7 +18,9 @@ import cwms.cda.formatters.json.JsonV2;
 import cwms.cda.formatters.xml.XMLv1;
 import cwms.cda.formatters.xml.XMLv2;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -54,6 +57,8 @@ public final class Location extends CwmsDTO {
     private final String mapLabel;
     private final String boundingOfficeId;
     private final String elevationUnits;
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<LocationAlias> aliases;
 
     private Location() {
         this(new Builder(null, null, null, null, null,null, null));
@@ -83,6 +88,7 @@ public final class Location extends CwmsDTO {
         this.mapLabel = builder.mapLabel;
         this.boundingOfficeId = builder.boundingOfficeId;
         this.elevationUnits = builder.elevationUnits;
+        this.aliases = builder.aliases;
     }
 
     public String getName() {
@@ -173,6 +179,10 @@ public final class Location extends CwmsDTO {
         return boundingOfficeId;
     }
 
+    public List<LocationAlias> getAliases() {
+        return aliases;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -182,6 +192,20 @@ public final class Location extends CwmsDTO {
             return false;
         }
         Location location = (Location) o;
+
+        for (LocationAlias alias : aliases) {
+            boolean found = false;
+            for (LocationAlias alias2 : location.getAliases()) {
+                if (alias.equals(alias2)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+
         return Double.compare(location.getLatitude(), getLatitude()) == 0
                 && getActive() == location.getActive()
                 && getName().equals(location.getName())
@@ -212,7 +236,7 @@ public final class Location extends CwmsDTO {
                 getLocationType(), getLocationKind(), getNation(), getStateInitial(),
                 getCountyName(), getHorizontalDatum(), getPublishedLongitude(),
                 getPublishedLatitude(), getVerticalDatum(), getElevation(), getMapLabel(),
-                getBoundingOfficeId(), getOfficeId(), getElevationUnits());
+                getBoundingOfficeId(), getOfficeId(), getElevationUnits(), getAliases());
     }
 
     @Override
@@ -270,6 +294,7 @@ public final class Location extends CwmsDTO {
         private String mapLabel;
         private String boundingOfficeId;
         private String elevationUnits;
+        private List<LocationAlias> aliases = new ArrayList<>();
         private static final String MISSING_NAME_ERROR_MSG = "Location name is a required field";
         private final Map<String, Consumer<Object>> propertyFunctionMap = new HashMap<>();
 
@@ -328,6 +353,7 @@ public final class Location extends CwmsDTO {
             this.mapLabel = location.getMapLabel();
             this.boundingOfficeId = location.getBoundingOfficeId();
             this.elevationUnits = location.getElevationUnits();
+            this.aliases = location.getAliases();
             buildPropertyFunctions();
         }
 
@@ -503,6 +529,11 @@ public final class Location extends CwmsDTO {
 
         public Builder withBoundingOfficeId(String boundingOfficeId) {
             this.boundingOfficeId = boundingOfficeId;
+            return this;
+        }
+
+        public Builder withAliases(List<LocationAlias> aliases) {
+            this.aliases = aliases;
             return this;
         }
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/Location.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/Location.java
@@ -18,11 +18,11 @@ import cwms.cda.formatters.json.JsonV2;
 import cwms.cda.formatters.xml.XMLv1;
 import cwms.cda.formatters.xml.XMLv2;
 import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 @JsonRootName("Location")
@@ -57,7 +57,7 @@ public final class Location extends CwmsDTO {
     private final String mapLabel;
     private final String boundingOfficeId;
     private final String elevationUnits;
-    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    @JsonInclude(JsonInclude.Include.NON_ABSENT)
     private final List<LocationAlias> aliases;
 
     private Location() {
@@ -179,8 +179,8 @@ public final class Location extends CwmsDTO {
         return boundingOfficeId;
     }
 
-    public List<LocationAlias> getAliases() {
-        return aliases;
+    public Optional<List<LocationAlias>> getAliases() {
+        return Optional.ofNullable(aliases);
     }
 
     @Override
@@ -193,16 +193,23 @@ public final class Location extends CwmsDTO {
         }
         Location location = (Location) o;
 
-        for (LocationAlias alias : aliases) {
-            boolean found = false;
-            for (LocationAlias alias2 : location.getAliases()) {
-                if (alias.equals(alias2)) {
-                    found = true;
-                    break;
+        if (location.getAliases().isPresent() && !getAliases().isPresent()) {
+            return false;
+        }
+        if (aliases != null) {
+            for (LocationAlias alias : aliases) {
+                boolean found = false;
+                if (location.getAliases().isPresent()) {
+                    for (LocationAlias alias2 : location.getAliases().get()) {
+                        if (alias.equals(alias2)) {
+                            found = true;
+                            break;
+                        }
+                    }
                 }
-            }
-            if (!found) {
-                return false;
+                if (!found) {
+                    return false;
+                }
             }
         }
 
@@ -294,7 +301,7 @@ public final class Location extends CwmsDTO {
         private String mapLabel;
         private String boundingOfficeId;
         private String elevationUnits;
-        private List<LocationAlias> aliases = new ArrayList<>();
+        private List<LocationAlias> aliases;
         private static final String MISSING_NAME_ERROR_MSG = "Location name is a required field";
         private final Map<String, Consumer<Object>> propertyFunctionMap = new HashMap<>();
 
@@ -353,7 +360,7 @@ public final class Location extends CwmsDTO {
             this.mapLabel = location.getMapLabel();
             this.boundingOfficeId = location.getBoundingOfficeId();
             this.elevationUnits = location.getElevationUnits();
-            this.aliases = location.getAliases();
+            this.aliases = location.getAliases().orElse(null);
             buildPropertyFunctions();
         }
 

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV1.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV1.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.Office;
@@ -46,6 +47,7 @@ public class JsonV1 implements OutputFormatter {
         retVal.disable(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS);
         retVal.disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS);
         retVal.registerModule(new JavaTimeModule());
+        retVal.registerModule(new Jdk8Module());
 
         SimpleModule module = new SimpleModule();
         module.addDeserializer(ZoneId.class, new ZoneIdDeserializer());

--- a/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV2.java
+++ b/cwms-data-api/src/main/java/cwms/cda/formatters/json/JsonV2.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.formatters.Formats;
@@ -67,6 +68,7 @@ public class JsonV2 implements OutputFormatter {
         retVal.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
         retVal.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         retVal.registerModule(new JavaTimeModule());
+        retVal.registerModule(new Jdk8Module());
 
         SimpleModule module = new SimpleModule();
         module.addDeserializer(ZoneId.class, new ZoneIdDeserializer());

--- a/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
@@ -2123,9 +2123,9 @@ public class LevelsControllerTestIT extends DataApiTestIT {
             .body("levels[0].aliases", notNullValue())
             .body("levels[0].aliases.size()", is(2))
             .body("levels[0].aliases[0].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("levels[0].aliases[0].name", is(levelId1))
+            .body("levels[0].aliases[0].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
             .body("levels[0].aliases[1].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("levels[0].aliases[1].name", is(levelId1))
+            .body("levels[0].aliases[1].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
             ;
 
         // verify the results for a single level
@@ -2150,9 +2150,9 @@ public class LevelsControllerTestIT extends DataApiTestIT {
             .body("levels[0].aliases", notNullValue())
             .body("levels[0].aliases.size()", is(2))
             .body("levels[0].aliases[0].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("levels[0].aliases[0].name", is(levelId2))
+            .body("levels[0].aliases[0].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
             .body("levels[0].aliases[1].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("levels[0].aliases[1].name", is(levelId2))
+            .body("levels[0].aliases[1].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
         ;
 
         // verify the results for a single level
@@ -2177,9 +2177,9 @@ public class LevelsControllerTestIT extends DataApiTestIT {
             .body("levels[0].aliases", notNullValue())
             .body("levels[0].aliases.size()", is(2))
             .body("levels[0].aliases[0].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("levels[0].aliases[0].name", is(levelId2))
+            .body("levels[0].aliases[0].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
             .body("levels[0].aliases[1].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("levels[0].aliases[1].name", is(levelId2))
+            .body("levels[0].aliases[1].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
         ;
 
         // verify that alias as level-id mask does not return results

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -24,6 +24,7 @@
 
 package cwms.cda.api;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import cwms.cda.data.dao.LocationCategoryDao;
 import cwms.cda.data.dao.LocationGroupDao;
 import fixtures.CwmsDataApiSetupCallback;
@@ -131,7 +132,7 @@ class LocationControllerTestIT extends DataApiTestIT {
                 .withOfficeId(officeId)
                 //withName(getClass().getSimpleName())
                 .build();
-        String serializedLocation = JsonV1.buildObjectMapper().writeValueAsString(location);
+        String serializedLocation = JsonV1.buildObjectMapper().registerModule(new Jdk8Module()).writeValueAsString(location);
 
         KeyUser user = KeyUser.SPK_NORMAL;
         // create location
@@ -236,7 +237,7 @@ class LocationControllerTestIT extends DataApiTestIT {
                 json, Location.class))
                 .withOfficeId(officeId)
                 .build();
-        String serializedLocation = JsonV1.buildObjectMapper().writeValueAsString(location);
+        String serializedLocation = JsonV1.buildObjectMapper().registerModule(new Jdk8Module()).writeValueAsString(location);
 
         // create location
         String locationId = "Test_Location_1080";
@@ -347,7 +348,7 @@ class LocationControllerTestIT extends DataApiTestIT {
                 .withOfficeId(officeId)
                 //withName(getClass().getSimpleName())
                 .build();
-        String serializedLocation = JsonV1.buildObjectMapper().writeValueAsString(location);
+        String serializedLocation = JsonV1.buildObjectMapper().registerModule(new Jdk8Module()).writeValueAsString(location);
 
         KeyUser user = KeyUser.SPK_NORMAL;
         // create location
@@ -606,7 +607,7 @@ class LocationControllerTestIT extends DataApiTestIT {
                 .withOfficeId(officeId)
                 .withName(invalidLongName)
                 .build();
-        String serializedLocation = JsonV1.buildObjectMapper().writeValueAsString(location);
+        String serializedLocation = JsonV1.buildObjectMapper().registerModule(new Jdk8Module()).writeValueAsString(location);
 
         KeyUser user = KeyUser.SPK_NORMAL;
         // create location

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -645,12 +645,9 @@ class LocationControllerTestIT extends DataApiTestIT {
             DSLContext dsl = dslContext(c, officeId);
             LocationCategory category = new LocationCategory(officeId, categoryName, "A test category");
             LocationCategoryDao catDao = new LocationCategoryDao(dsl);
-            try {
-                catDao.delete(category.getId(), true, officeId);
-            } catch (Exception e) {
-                // ignore
-            }
+
             catDao.create(category);
+            categoriesToCleanup.add(category);
 
             LocationGroupDao groupDao = new LocationGroupDao(dsl);
             LocationGroup baseGroup1 = new LocationGroup(category, officeId, groupName1, "A test group",
@@ -660,6 +657,9 @@ class LocationControllerTestIT extends DataApiTestIT {
 
             groupDao.create(baseGroup1);
             groupDao.create(baseGroup2);
+            groupsToCleanup.add(baseGroup1);
+            groupsToCleanup.add(baseGroup2);
+
             List<AssignedLocation> locations = new ArrayList<>();
             AssignedLocation assignedLocation = new AssignedLocation(locationName, officeId, sharedLocAlias1, null, null);
             locations.add(assignedLocation);
@@ -709,8 +709,8 @@ class LocationControllerTestIT extends DataApiTestIT {
             .statusCode(is(HttpServletResponse.SC_OK))
             .body("aliases.size()", is(2))
             .body("aliases[0].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
-            .body("aliases[0].name", is(locationName))
-            .body("aliases[1].name", is(locationName))
+            .body("aliases[0].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
+            .body("aliases[1].name", isOneOf(categoryName + "-" + groupName1, categoryName + "-" + groupName2))
             .body("aliases[1].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
         ;
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -24,6 +24,9 @@
 
 package cwms.cda.api;
 
+import cwms.cda.data.dao.LocationCategoryDao;
+import cwms.cda.data.dao.LocationGroupDao;
+import fixtures.CwmsDataApiSetupCallback;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +37,7 @@ import cwms.cda.data.dto.LocationGroup;
 import cwms.cda.formatters.ContentType;
 import fixtures.TestAccounts.KeyUser;
 import io.restassured.filter.log.LogDetail;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -53,6 +57,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isOneOf;
 
 @Tag("integration")
 class LocationControllerTestIT extends DataApiTestIT {
@@ -620,6 +625,128 @@ class LocationControllerTestIT extends DataApiTestIT {
         .assertThat()
             .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
             .body(containsString("One or more provided values exceeds the maximum length for the parameter."));
+    }
+
+    @Test
+    void testIncludeAliases() throws Exception {
+        String officeId = "SPK";
+        String locationName = "TestBaseLocation";
+        String controlLocationName = "TestBaseLocControl";
+        createLocation(controlLocationName, true, officeId);
+        createLocation(locationName, true, officeId);
+
+        String categoryName = "TestAliasesCategory1";
+        String groupName1 = "TestAliasesGroup3";
+        String groupName2 = "TestAliasesGroup4";
+        String sharedLocAlias1 = "TESTBASELOCALIAS1";
+        String sharedLocAlias2 = "LOCALIAS1";
+
+        CwmsDataApiSetupCallback.getDatabaseLink().connection(c -> {
+            DSLContext dsl = dslContext(c, officeId);
+            LocationCategory category = new LocationCategory(officeId, categoryName, "A test category");
+            LocationCategoryDao catDao = new LocationCategoryDao(dsl);
+            try {
+                catDao.delete(category.getId(), true, officeId);
+            } catch (Exception e) {
+                // ignore
+            }
+            catDao.create(category);
+
+            LocationGroupDao groupDao = new LocationGroupDao(dsl);
+            LocationGroup baseGroup1 = new LocationGroup(category, officeId, groupName1, "A test group",
+                sharedLocAlias1, null, 0);
+            LocationGroup baseGroup2 = new LocationGroup(category, officeId, groupName2, "Another test group",
+                sharedLocAlias2, null, 0);
+
+            groupDao.create(baseGroup1);
+            groupDao.create(baseGroup2);
+            List<AssignedLocation> locations = new ArrayList<>();
+            AssignedLocation assignedLocation = new AssignedLocation(locationName, officeId, sharedLocAlias1, null, null);
+            locations.add(assignedLocation);
+            LocationGroup group = new LocationGroup(baseGroup1, locations);
+            groupDao.assignLocs(group, officeId);
+
+            locations = new ArrayList<>();
+            assignedLocation = new AssignedLocation(locationName, officeId, sharedLocAlias2, null, null);
+            locations.add(assignedLocation);
+            LocationGroup group2 = new LocationGroup(baseGroup2, locations);
+            groupDao.assignLocs(group2, officeId);
+        });
+
+        // verify that the control location can be retrieved
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
+            .queryParam(UNIT, "SI")
+            .queryParam(INCLUDE_ALIASES, "false")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/" + controlLocationName)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+        ;
+
+        // verify that the aliased level can be retrieved
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
+            .queryParam(UNIT, "SI")
+            .queryParam(INCLUDE_ALIASES, "true")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/" + locationName)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("aliases.size()", is(2))
+            .body("aliases[0].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
+            .body("aliases[0].name", is(locationName))
+            .body("aliases[1].name", is(locationName))
+            .body("aliases[1].value", isOneOf(sharedLocAlias1, sharedLocAlias2))
+        ;
+
+        // verify that alias as location ID does not return results
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
+            .queryParam(UNIT, "SI")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/" + sharedLocAlias1)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+        ;
+
+        // verify that alias as location ID will not return results
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
+            .queryParam(UNIT, "SI")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/" + sharedLocAlias2)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+        ;
     }
 
     enum GetAllTest

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -55,8 +55,10 @@ import javax.servlet.http.HttpServletResponse;
 import static cwms.cda.api.Controllers.*;
 import static cwms.cda.data.dao.JsonRatingUtilsTest.loadResourceAsString;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
 
@@ -690,6 +692,7 @@ class LocationControllerTestIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL, true)
         .assertThat()
             .statusCode(is(HttpServletResponse.SC_OK))
+            .body("$", not(hasKey("aliases")))
         ;
 
         // verify that the aliased level can be retrieved

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/LocationTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/LocationTest.java
@@ -3,6 +3,7 @@ package cwms.cda.data.dto;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import cwms.cda.api.enums.Nation;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.api.errors.RequiredFieldException;
@@ -10,6 +11,7 @@ import cwms.cda.data.dto.catalog.LocationAlias;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV1;
 
+import cwms.cda.helpers.DTOMatch;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +32,7 @@ class LocationTest
 		assertNotNull(location);
 
 		ObjectMapper om = new ObjectMapper();
+		om.registerModule(new Jdk8Module());	// Must be registered to handle Optionals correctly
 		String serializedLocation = om.writeValueAsString(location);
 		assertNotNull(serializedLocation);
 
@@ -44,6 +47,7 @@ class LocationTest
 		assertNotNull(location);
 
 		ObjectMapper om = JsonV1.buildObjectMapper();
+		om.registerModule(new Jdk8Module());
 		String serializedLocation = om.writeValueAsString(location);
 		assertNotNull(serializedLocation);
 
@@ -87,7 +91,7 @@ class LocationTest
 
 		Location deserialized = Formats.parseContent(Formats.parseHeader(format, Location.class),
 			serialized, Location.class);
-		assertEquals(location, deserialized);
+		DTOMatch.assertMatch(location, deserialized);
 	}
 
 	@Test
@@ -165,12 +169,39 @@ class LocationTest
 	{
 		Location location = buildTestLocation();
 		assertNotNull(location);
-		assertTrue(location.getAliases().isEmpty());
+		assertFalse(location.getAliases().isPresent());
 
 		String serialized = Formats.format(Formats.parseHeader(Formats.JSONV2, Location.class), location);
 		assertNotNull(serialized);
 
 		assertFalse(serialized.contains("aliases"));
+	}
+
+	@Test
+	void test_serialization_empty_alias()
+	{
+		Location location = new Location.Builder("TEST_LOCATION2", "SITE", ZoneId.of("UTC"),
+		50.0, 50.0, "NVGD29", "LRL")
+			.withElevation(10.0)
+			.withCountyName("Sacramento")
+			.withNation(Nation.US)
+			.withActive(true)
+			.withStateInitial("CA")
+			.withBoundingOfficeId("LRL")
+			.withLongName("TEST_LOCATION")
+			.withPublishedLatitude(50.0)
+			.withPublishedLongitude(50.0)
+			.withDescription("for testing")
+			.withElevationUnits("m")
+			.withAliases(new ArrayList<>())
+			.build();
+		assertNotNull(location);
+		assertTrue(location.getAliases().isPresent());
+
+		String serialized = Formats.format(Formats.parseHeader(Formats.JSONV2, Location.class), location);
+		assertNotNull(serialized);
+
+		assertTrue(serialized.contains("aliases"));
 	}
 
 	private Location buildTestLocation() {

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/LocationTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/LocationTest.java
@@ -6,10 +6,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cwms.cda.api.enums.Nation;
 import cwms.cda.api.errors.FieldException;
 import cwms.cda.api.errors.RequiredFieldException;
+import cwms.cda.data.dto.catalog.LocationAlias;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV1;
 
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -75,7 +77,7 @@ class LocationTest
 
 	@ParameterizedTest
 	@ValueSource(strings = { Formats.JSONV2, Formats.XMLV2 })
-	void testSerializationRoundTrip(String format) throws JsonProcessingException
+	void testSerializationRoundTrip(String format)
 	{
 		Location location = buildTestLocation();
 		assertNotNull(location);
@@ -123,6 +125,54 @@ class LocationTest
 		}
 	}
 
+	@Test
+	void test_alias_roundtrip() {
+		List<LocationAlias> aliases = new ArrayList<>();
+
+		aliases.add(new LocationAlias("alias1", "type1"));
+		aliases.add(new LocationAlias("alias2", "type2"));
+
+		Location location = new Location.Builder("TEST_LOCATION2", "SITE", ZoneId.of("UTC"),
+			null, null,  // lat/lon are null in this test
+			"NVGD29", "LRL")
+			.withElevation(10.0)
+			.withCountyName("Sacramento")
+			.withNation(Nation.US)
+			.withActive(true)
+			.withStateInitial("CA")
+			.withBoundingOfficeId("LRL")
+			.withLongName("TEST_LOCATION")
+			.withPublishedLatitude(50.0)
+			.withPublishedLongitude(50.0)
+			.withDescription("for testing")
+			.withLatitude(50.0)
+			.withLongitude(50.0)
+			.withAliases(aliases)
+			.build();
+
+		assertNotNull(location);
+
+		String serialized = Formats.format(Formats.parseHeader(Formats.JSONV2, Location.class), location);
+		assertNotNull(serialized);
+
+		Location deserialized = Formats.parseContent(Formats.parseHeader(Formats.JSONV2, Location.class),
+			serialized, Location.class);
+		assertEquals(location, deserialized);
+	}
+
+	@Test
+	void test_serialization_no_alias()
+	{
+		Location location = buildTestLocation();
+		assertNotNull(location);
+		assertTrue(location.getAliases().isEmpty());
+
+		String serialized = Formats.format(Formats.parseHeader(Formats.JSONV2, Location.class), location);
+		assertNotNull(serialized);
+
+		assertFalse(serialized.contains("aliases"));
+	}
+
 	private Location buildTestLocation() {
 		return new Location.Builder("TEST_LOCATION2", "SITE", ZoneId.of("UTC"),
 				50.0, 50.0, "NVGD29", "LRL")
@@ -155,9 +205,4 @@ class LocationTest
 				.withDescription("for testing\r\n  next line\nhas a double quote \"\r\n this line has a single quote '\r")
 				.build();
 	}
-
-
-
-
-
 }

--- a/cwms-data-api/src/test/java/cwms/cda/helpers/DTOMatch.java
+++ b/cwms-data-api/src/test/java/cwms/cda/helpers/DTOMatch.java
@@ -27,6 +27,7 @@ package cwms.cda.helpers;
 import cwms.cda.data.dto.CwmsIdTimeExtentsEntry;
 import cwms.cda.data.dto.TimeExtents;
 import cwms.cda.data.dto.TimeSeriesExtents;
+import cwms.cda.data.dto.catalog.LocationAlias;
 import cwms.cda.data.dto.location.kind.Lock;
 import cwms.cda.data.dto.CwmsDTOBase;
 import cwms.cda.data.dto.location.kind.GateChange;
@@ -294,7 +295,25 @@ public final class DTOMatch {
                 () -> assertEquals(first.getCountyName(), second.getCountyName()),
                 () -> assertEquals(first.getTimezoneName(), second.getTimezoneName()),
                 () -> assertEquals(first.getOfficeId(), second.getOfficeId()),
-                () -> assertEquals(first.getLocationType(), second.getLocationType())
+                () -> assertEquals(first.getLocationType(), second.getLocationType()),
+                () -> {
+                        if (first.getAliases().isPresent() && second.getAliases().isPresent()) {
+                            assertEquals(first.getAliases().get().size(), second.getAliases().get().size(),
+                                "Alias list sizes do not match");
+                            for (LocationAlias alias : first.getAliases().get()) {
+                                boolean matched = false;
+                                for (LocationAlias alias2 : second.getAliases().get()) {
+                                    if (alias.equals(alias2)) {
+                                        matched = true;
+                                        break;
+                                    }
+                                }
+                                assertTrue(matched, "Aliases do not match");
+                            }
+                        } else if (first.getAliases().isPresent() || second.getAliases().isPresent()) {
+                            fail("One of the LocationAlias lists is null");
+                        }
+                }
         );
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ jackson-core = { module = "com.fasterxml.jackson.core:jackson-databind", version
 jackson-dataformat-csv = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-csv", version.ref = "jackson" }
 jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 jackson-dataformat-xml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-xml", version.ref = "jackson" }
+jackson-datatype-jdk8 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jdk8", version.ref = "jackson" }
 
 
 


### PR DESCRIPTION
Fixes #1036 

Adds support for including aliases in location getOne results.

Includes alias formatting fixes for location level DAO and tests.