### PR TITLE
Test updates for latest schema and correct release schema image.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           - env: latest
             image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:latest-dev"
           - env: release
-            image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25-07-01-RC06"
+            image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25.07.01"
     name: build and test (jdk ${{matrix.jdk}}, schema ${{matrix.schema.env}})
     runs-on: ubuntu-latest
     outputs:

--- a/cda-client/package-lock.json
+++ b/cda-client/package-lock.json
@@ -198,15 +198,15 @@
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
-      "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.9.tgz",
+      "integrity": "sha512-zDntUTReRbAThIfSp3dQZ9kKqI+LjgLp5YZN5c1bgNRDuoeLySAoZg46Bg1a+uV8TMgIRziHocglKGNzr6l+bQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "file-type": "21.0.0",
+        "file-type": "21.1.0",
         "iterare": "1.2.1",
-        "load-esm": "1.0.2",
+        "load-esm": "1.0.3",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -230,9 +230,9 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "11.1.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.6.tgz",
-      "integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-a00B0BM4X+9z+t3UxJqIZlemIwCQdYoPKrMcM+ky4z3pkqqG1eTWexjs+YXpGObnLnjtMPVKWlcZHp3adDYvUw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -240,7 +240,7 @@
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "path-to-regexp": "8.2.0",
+        "path-to-regexp": "8.3.0",
         "tslib": "2.8.1",
         "uid": "2.0.2"
       },
@@ -315,25 +315,25 @@
       "license": "MIT"
     },
     "node_modules/@openapitools/openapi-generator-cli": {
-      "version": "2.23.4",
-      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.23.4.tgz",
-      "integrity": "sha512-9/sUf5q2j2waXUMF78sJjywQJOv2+cyPzabYsqou8AAuUOXQCfNRUzRP+Vxe05dodAtxBCE7Mi+JBuDRleDOEA==",
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.25.1.tgz",
+      "integrity": "sha512-IY0Vgnv//v2X7+gqAj+jE+CoygdeIx15ZaF2SK+/kQR/sHBJTgxOOc0V+ti2tfxv4pkOILcTcPhmuZIobxPQhg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nestjs/axios": "4.0.1",
-        "@nestjs/common": "11.1.6",
-        "@nestjs/core": "11.1.6",
+        "@nestjs/common": "11.1.9",
+        "@nestjs/core": "11.1.9",
         "@nuxtjs/opencollective": "0.3.2",
-        "axios": "1.12.2",
+        "axios": "1.13.2",
         "chalk": "4.1.2",
         "commander": "8.3.0",
         "compare-versions": "6.1.1",
         "concurrently": "9.2.1",
         "console.table": "0.10.0",
         "fs-extra": "11.3.2",
-        "glob": "11.0.3",
+        "glob": "12.0.0",
         "inquirer": "8.2.7",
         "proxy-agent": "6.5.0",
         "reflect-metadata": "0.2.2",
@@ -352,13 +352,13 @@
       }
     },
     "node_modules/@tokenizer/inflate": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
-      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.3.1.tgz",
+      "integrity": "sha512-4oeoZEBQdLdt5WmP/hx1KZ6D3/Oid/0cUb2nk4F0pTDAWy+KCH3/EnAkZF/bvckWo8I33EqBm01lIPgmgc8rCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "fflate": "^0.8.2",
         "token-types": "^6.0.0"
       },
@@ -369,31 +369,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
-    },
-    "node_modules/@tokenizer/inflate/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@tokenizer/inflate/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
@@ -482,9 +457,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -817,6 +792,24 @@
         "node": ">= 14"
       }
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -1067,14 +1060,14 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
-      "integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.1.0.tgz",
+      "integrity": "sha512-boU4EHmP3JXkwDo4uhyBhTt5pPstxB6eEXKJBu2yu2l7aAMMm7QQYQEzssJmKReZYrFdFOJS8koVo6bXIBGDqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tokenizer/inflate": "^0.2.7",
-        "strtok3": "^10.2.2",
+        "@tokenizer/inflate": "^0.3.1",
+        "strtok3": "^10.3.1",
         "token-types": "^6.0.0",
         "uint8array-extras": "^1.4.0"
       },
@@ -1229,63 +1222,22 @@
         "node": ">= 14"
       }
     },
-    "node_modules/get-uri/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/get-uri/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/glob": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-12.0.0.tgz",
+      "integrity": "sha512-5Qcll1z7IKgHr5g485ePDdHcNQY0k2dtv/bjYy0iuyGxQw2qSOiiXUXJ+AYQpg3HNoUMHqAruX478Jeev7UULw==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "foreground-child": "^3.3.1",
         "jackspeak": "^4.1.1",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.1.1",
         "minipass": "^7.1.2",
         "package-json-from-dist": "^1.0.0",
         "path-scurry": "^2.0.0"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.0"
       },
       "engines": {
         "node": "20 || >=22"
@@ -1380,31 +1332,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/http-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -1418,31 +1345,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/https-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.0",
@@ -1606,9 +1508,9 @@
       }
     },
     "node_modules/load-esm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
-      "integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.3.tgz",
+      "integrity": "sha512-v5xlu8eHD1+6r8EHTg6hfmO97LN8ugKtiXcy5e6oN72iD2r6u0RPfLl6fxM+7Wnh2ZRq15o0russMst44WauPA==",
       "dev": true,
       "funding": [
         {
@@ -1702,6 +1604,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+      "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/brace-expansion": "^5.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -1711,6 +1629,13 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -1810,31 +1735,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/pac-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
@@ -1867,9 +1767,9 @@
       }
     },
     "node_modules/path-scurry": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+      "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -1884,13 +1784,14 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "dev": true,
       "license": "MIT",
-      "engines": {
-        "node": ">=16"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/proxy-agent": {
@@ -1913,24 +1814,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -1940,13 +1823,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -2145,31 +2021,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/socks-proxy-agent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -41,6 +41,7 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
@@ -65,7 +66,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
         + "cwms_env.set_session_user_direct(upper(?),upper(?)); end;";
 
     private static final String CHECK_API_KEY =
-        "select userid from cwms_20.at_api_keys where apikey = ?";
+        "select userid from cwms_20.at_api_keys where apikey = ? and expires <= systimestamp";
 
     private static final String USER_FOR_EDIPI =
         "select userid from cwms_20.at_sec_cwms_users where edipi = ?";
@@ -201,7 +202,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                         if (rs.next()) {
                             return rs.getString(1);
                         } else {
-                            throw new CwmsAuthException("No user for key");
+                            throw new CwmsAuthException("No user for key", HttpServletResponse.SC_FORBIDDEN);
                         }
                     }
                 } catch (SQLException ex) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -66,7 +66,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
         + "cwms_env.set_session_user_direct(upper(?),upper(?)); end;";
 
     private static final String CHECK_API_KEY =
-        "select userid from cwms_20.at_api_keys where apikey = ? and expires <= systimestamp";
+        "select userid from cwms_20.at_api_keys where apikey = ? and (expires is null or expires <= systimestamp)";
 
     private static final String USER_FOR_EDIPI =
         "select userid from cwms_20.at_sec_cwms_users where edipi = ?";

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -66,7 +66,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
         + "cwms_env.set_session_user_direct(upper(?),upper(?)); end;";
 
     private static final String CHECK_API_KEY =
-        "select userid from cwms_20.at_api_keys where apikey = ? and (expires is null or expires <= systimestamp)";
+        "select userid from cwms_20.at_api_keys where apikey = ? and (expires is null or expires >= systimestamp)";
 
     private static final String USER_FOR_EDIPI =
         "select userid from cwms_20.at_sec_cwms_users where edipi = ?";
@@ -202,7 +202,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                         if (rs.next()) {
                             return rs.getString(1);
                         } else {
-                            throw new CwmsAuthException("No user for key", HttpServletResponse.SC_FORBIDDEN);
+                            throw new CwmsAuthException("No user for key");
                         }
                     }
                 } catch (SQLException ex) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/Dao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/Dao.java
@@ -42,7 +42,7 @@ import usace.cwms.db.jooq.codegen.packages.CWMS_ENV_PACKAGE;
 public abstract class Dao<T> {
     public static final int CWMS_18_1_8 = 180108;
     public static final int CWMS_21_1_1 = 210101;
-    public static final int CWMS_23_03_16 = 230316;
+    public static final int CWMS_23_03_16 = 230316;    
 
     public static final String PROP_BASE = "cwms.cda.data.dao.dao";
     public static final String VERSION_NAME = "version";
@@ -54,11 +54,17 @@ public abstract class Dao<T> {
             .build();
     private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
 
+    protected static Integer CURRENT_SCHEMA_VERSION = null;
+
     @SuppressWarnings("unused")
     protected DSLContext dsl;
 
     protected Dao(DSLContext dsl) {
         this.dsl = dsl;
+        if (CURRENT_SCHEMA_VERSION == null)
+        {
+            CURRENT_SCHEMA_VERSION = getDbVersion();
+        }
     }
 
     public static String getVersion(DSLContext dsl) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/Dao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/Dao.java
@@ -42,7 +42,7 @@ import usace.cwms.db.jooq.codegen.packages.CWMS_ENV_PACKAGE;
 public abstract class Dao<T> {
     public static final int CWMS_18_1_8 = 180108;
     public static final int CWMS_21_1_1 = 210101;
-    public static final int CWMS_23_03_16 = 230316;    
+    public static final int CWMS_23_03_16 = 230316;
 
     public static final String PROP_BASE = "cwms.cda.data.dao.dao";
     public static final String VERSION_NAME = "version";

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/Dao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/Dao.java
@@ -90,7 +90,7 @@ public abstract class Dao<T> {
     }
 
     public static int versionAsInteger(String version) {
-        String[] parts = version.split("\\.");
+        String[] parts = version.split("[\\.-]");
 
         return Integer.parseInt(parts[0]) * 10000
                 + Integer.parseInt(parts[1]) * 100

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -34,6 +34,7 @@ import cwms.cda.api.errors.FieldLengthExceededException;
 import cwms.cda.api.errors.InvalidItemException;
 import cwms.cda.api.errors.NotFoundException;
 import cwms.cda.datasource.ConnectionPreparingDataSource;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import cwms.cda.security.CwmsAuthException;
 import io.javalin.http.Context;
 import io.javalin.http.HandlerType;
@@ -396,9 +397,13 @@ public abstract class JooqDao<T> extends Dao<T> {
 
         if (localizedMessage != null) {
             String[] parts = localizedMessage.split("\n");
-            
+            String errorMessage = parts[0];
+            if (CURRENT_SCHEMA_VERSION > SCHEMA_VERSION.V2025_07_01.numeric())
+            {
+                errorMessage = parts[1];
+            }
             return new InvalidItemException(String.format("Invalid time series description: %s", 
-                                            parts[0]), cause);
+                                            errorMessage), cause);
         }
         return new InvalidItemException("Invalid time series description", cause);
     }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -376,8 +376,10 @@ public abstract class JooqDao<T> extends Dao<T> {
 
     public static boolean isTSIDInvalidIntervalException(RuntimeException input) {
         return getSqlException(input.getCause()).map(sqlException -> hasCodeAndMessage(sqlException,
-                Arrays.asList(20205),
-                Arrays.asList("Invalid Time Series Description", "is not a valid interval")))
+                Arrays.asList(20205, 20998),
+                Arrays.asList("Invalid Time Series Description",
+                              "is not a valid interval",
+                              "INVALID Time Series Identifier")))
             .orElse(false);
     }
 
@@ -386,16 +388,17 @@ public abstract class JooqDao<T> extends Dao<T> {
         if (input instanceof DataAccessException) {
             DataAccessException dae = (DataAccessException) input;
             cause = dae.getCause();
+        } else if (input.getCause() instanceof SQLException) {
+            cause = input.getCause();
         }
 
         String localizedMessage = cause.getLocalizedMessage();
 
         if (localizedMessage != null) {
             String[] parts = localizedMessage.split("\n");
-            if (parts.length > 2) {
-                return new InvalidItemException(String.format("Invalid time series description: %s",
-                    parts[1]), cause);
-            }
+            
+            return new InvalidItemException(String.format("Invalid time series description: %s", 
+                                            parts[0]), cause);
         }
         return new InvalidItemException("Invalid time series description", cause);
     }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -398,7 +398,7 @@ public abstract class JooqDao<T> extends Dao<T> {
         if (localizedMessage != null) {
             String[] parts = localizedMessage.split("\n");
             String errorMessage = parts[0];
-            if (CURRENT_SCHEMA_VERSION > SCHEMA_VERSION.V2025_07_01.numeric())
+            if (CURRENT_SCHEMA_VERSION <= SCHEMA_VERSION.V2025_07_01.numeric())
             {
                 errorMessage = parts[1];
             }

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -389,8 +389,6 @@ public abstract class JooqDao<T> extends Dao<T> {
         if (input instanceof DataAccessException) {
             DataAccessException dae = (DataAccessException) input;
             cause = dae.getCause();
-        } else if (input.getCause() instanceof SQLException) {
-            cause = input.getCause();
         }
 
         String localizedMessage = cause.getLocalizedMessage();
@@ -398,7 +396,7 @@ public abstract class JooqDao<T> extends Dao<T> {
         if (localizedMessage != null) {
             String[] parts = localizedMessage.split("\n");
             String errorMessage = parts[0];
-            if (CURRENT_SCHEMA_VERSION <= SCHEMA_VERSION.V2025_07_01.numeric())
+            if (CURRENT_SCHEMA_VERSION <= SCHEMA_VERSION.V2025_07_01.numeric() && parts.length > 2)
             {
                 errorMessage = parts[1];
             }

--- a/cwms-data-api/src/main/java/cwms/cda/helpers/DatabaseHelpers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/helpers/DatabaseHelpers.java
@@ -5,7 +5,7 @@ public class DatabaseHelpers {
 
     
     public static enum SCHEMA_VERSION {
-        V2025_07_02(20250702, "2025.07.02"),        
+        V2025_07_01(250702, "25.07.02"),        
         LATEST_DEV(999999, "99.99.99"),
         BYPASS(-1, "Bypass")
         ;

--- a/cwms-data-api/src/main/java/cwms/cda/helpers/DatabaseHelpers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/helpers/DatabaseHelpers.java
@@ -1,20 +1,43 @@
 package cwms.cda.helpers;
 
-import java.sql.CallableStatement;
-import java.sql.Connection;
-import java.sql.SQLException;
-
-import javax.servlet.http.HttpServletRequest;
 
 public class DatabaseHelpers {
-    public static Connection setSession(Connection conn, HttpServletRequest request) throws SQLException{
-        String sessionKey = (String)request.getSession(false).getAttribute("SESSION_KEY");
-        try (
-            CallableStatement setSession = conn.prepareCall("call cwms_env.set_session_id(?)");
-        ){
-            setSession.setString(1,sessionKey);
-            setSession.execute();
-            return conn;
+
+    
+    public static enum SCHEMA_VERSION {
+        V2025_07_02(20250702, "2025.07.02"),        
+        LATEST_DEV(999999, "99.99.99"),
+        BYPASS(-1, "Bypass")
+        ;
+
+        private final int numeric;
+        private final String text;
+
+        SCHEMA_VERSION(int numeric, String text)
+        {
+            this.numeric = numeric;
+            this.text = text;
+        }
+
+        public int numeric() {
+            return this.numeric;
+        }
+
+        public String text() {
+            return this.text;
+        }
+
+        public static SCHEMA_VERSION fromNumeric(int value)
+        {
+            for(var tmp: SCHEMA_VERSION.values())
+            {
+                if (tmp.numeric == value)
+                {
+                    return tmp;
+                }
+            }
+            throw new IllegalArgumentException(
+                "Numeric Value " + value + " does not match an available version enumeration.");
         }
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/helpers/DatabaseHelpers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/helpers/DatabaseHelpers.java
@@ -5,7 +5,7 @@ public class DatabaseHelpers {
 
     
     public static enum SCHEMA_VERSION {
-        V2025_07_01(250702, "25.07.02"),        
+        V2025_07_01(250701, "25.07.01"),
         LATEST_DEV(999999, "99.99.99"),
         BYPASS(-1, "Bypass")
         ;

--- a/cwms-data-api/src/test/java/cwms/cda/api/BinaryTimeSeriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/BinaryTimeSeriesControllerTestIT.java
@@ -6,9 +6,12 @@ import cwms.cda.data.dto.binarytimeseries.BinaryTimeSeries;
 import cwms.cda.data.dto.binarytimeseries.BinaryTimeSeriesRow;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV2;
+import fixtures.CwmsDataApiSetupCallback;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.response.ResponseBody;
+import mil.army.usace.hec.test.database.CwmsDatabaseContainer;
+
 import org.apache.commons.io.IOUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
@@ -398,7 +401,7 @@ final class BinaryTimeSeriesControllerTestIT extends DataApiTestIT {
 
         // Step 1)
         // Try to create the binary time series without LRTS header set
-
+        
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
             .accept(format)
@@ -413,7 +416,7 @@ final class BinaryTimeSeriesControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
         .assertThat()
-            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
 
         // Step 2)
         // Create the binary time series

--- a/cwms-data-api/src/test/java/cwms/cda/api/BinaryTimeSeriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/BinaryTimeSeriesControllerTestIT.java
@@ -6,6 +6,8 @@ import cwms.cda.data.dto.binarytimeseries.BinaryTimeSeries;
 import cwms.cda.data.dto.binarytimeseries.BinaryTimeSeriesRow;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV2;
+import cwms.cda.helpers.DatabaseHelpers;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import fixtures.CwmsDataApiSetupCallback;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
@@ -402,21 +404,27 @@ final class BinaryTimeSeriesControllerTestIT extends DataApiTestIT {
         // Step 1)
         // Try to create the binary time series without LRTS header set
         
-        given()
-            .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(format)
-            .contentType(Formats.JSONV2)
-            .body(tsData)
-            .header("Authorization", user.toHeaderValue())
-            .header(ApiServlet.IS_NEW_LRTS, false)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .post("/timeseries/binary/")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL,true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        var assertThat = 
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(format)
+                .contentType(Formats.JSONV2)
+                .body(tsData)
+                .header("Authorization", user.toHeaderValue())
+                .header(ApiServlet.IS_NEW_LRTS, false)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/binary/")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat();
+
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+            assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        } else {
+            assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+        }
 
         // Step 2)
         // Create the binary time series

--- a/cwms-data-api/src/test/java/cwms/cda/api/BinaryTimeSeriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/BinaryTimeSeriesControllerTestIT.java
@@ -420,10 +420,10 @@ final class BinaryTimeSeriesControllerTestIT extends DataApiTestIT {
                 .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat();
 
-        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
             assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
         } else {
-            assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND))
+            assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND));
         }
 
         // Step 2)

--- a/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
@@ -98,7 +98,7 @@ public class DataApiTestIT {
     protected static String createLocationQuery = null;
     protected static String createTimeseriesQuery = null;
     protected static String createTimeseriesOffsetQuery = null;
-    protected static final String registerApiKey = "insert into at_api_keys(userid,key_name,apikey) values(UPPER(?),?,?)";
+    protected static final String registerApiKey = "insert into at_api_keys(userid,key_name,apikey,expires) values(UPPER(?),?,?, null)";
     protected static final String removeApiKeys = "delete from at_api_keys where UPPER(userid) = UPPER(?) and apikey = ?";
 
     protected static final Configuration freemarkerConfig = new Configuration(Configuration.VERSION_2_3_32);

--- a/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
@@ -112,11 +112,12 @@ public class DataApiTestIT {
         freemarkerConfig.setClassForTemplateLoading(DataApiTestIT.class, "/");
     }
 
-    public static final String OPEN_API_SPEC_URL = String.format("%s:%s%s/swagger-docs", CwmsDataApiSetupCallback.httpUrl(), CwmsDataApiSetupCallback.httpPort(), System.getProperty("warContext"));
-    private static OpenApiValidationFilter validationFilter;
+    private static String OPEN_API_SPEC_URL = null;
+    private static OpenApiValidationFilter validationFilter = null;
 
     public static OpenApiValidationFilter getOpenApiValidationFilter() {
         if (validationFilter == null) {
+            OPEN_API_SPEC_URL = String.format("%s:%s%s/swagger-docs", CwmsDataApiSetupCallback.httpUrl(), CwmsDataApiSetupCallback.httpPort(), System.getProperty("warContext"));
             validationFilter = new OpenApiValidationFilter(OPEN_API_SPEC_URL);
         }
         return validationFilter;

--- a/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
@@ -29,6 +29,8 @@ import static cwms.cda.data.dao.JooqDao.SESSION_USE_LRTS_ID_FORMAT;
 
 import com.atlassian.oai.validator.restassured.OpenApiValidationFilter;
 import com.google.common.flogger.FluentLogger;
+
+import cwms.cda.data.dao.Dao;
 import cwms.cda.data.dao.DeleteRule;
 import cwms.cda.data.dao.StreamDao;
 import cwms.cda.data.dao.basin.BasinDao;
@@ -504,6 +506,10 @@ public class DataApiTestIT {
     protected static DSLContext dslContext(Connection connection) {
         DSLContext dsl = DSL.using(connection, SQLDialect.ORACLE18C);
         return dsl;
+    }
+
+    protected static int getSchemaVersion() {
+        return CwmsDataApiSetupCallback.getSchemaVersion();
     }
 
     protected static String readResourceFile(String resourcePath) throws IOException {

--- a/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
@@ -279,7 +279,9 @@ public class DataApiTestIT {
                 stmt.setString(2, "CWMS_20");       // CREATEDBY
                 stmt.executeUpdate();
             } catch (SQLException ex) {
-                throw new RuntimeException("Unable to insert user: " + username, ex);
+                if (!ex.getMessage().contains("unique constraint")) {
+                    throw new RuntimeException("Unable to insert user: " + username, ex);
+                }
             }
         }, "cwms_20");
     }

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationCategoryControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationCategoryControllerTestIT.java
@@ -44,7 +44,7 @@ import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 @Tag("integration")
 class LocationCategoryControllerTestIT extends DataApiTestIT {

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -49,7 +49,7 @@ import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV1;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import javax.servlet.http.HttpServletResponse;
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationKindControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationKindControllerIT.java
@@ -42,7 +42,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.shaded.org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 @Tag("integration")
 final class LocationKindControllerIT extends DataApiTestIT {

--- a/cwms-data-api/src/test/java/cwms/cda/api/TextTimeSeriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TextTimeSeriesControllerTestIT.java
@@ -315,22 +315,26 @@ public class TextTimeSeriesControllerTestIT extends DataApiTestIT {
             .body("standard-text-values", nullValue())
             .body("regular-text-values.size()", equalTo(0))
             .statusCode(is(HttpServletResponse.SC_OK));
-
-        given()
-            .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(format)
-            .contentType(Formats.JSONV2)
-            .body(tsData)
-            .header(AUTHORIZATION, user.toHeaderValue())
-            .header(ApiServlet.IS_NEW_LRTS, false)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .post("/timeseries/text")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL,true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        assertThat =
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(format)
+                .contentType(Formats.JSONV2)
+                .body(tsData)
+                .header(AUTHORIZATION, user.toHeaderValue())
+                .header(ApiServlet.IS_NEW_LRTS, false)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/text")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat();
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
+            assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        } else {
+            assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+        }
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/TextTimeSeriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TextTimeSeriesControllerTestIT.java
@@ -39,6 +39,7 @@ import cwms.cda.data.dto.texttimeseries.TextTimeSeries;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV2;
 import cwms.cda.helpers.DateUtils;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import fixtures.CwmsDataApiSetupCallback;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
@@ -212,21 +213,27 @@ public class TextTimeSeriesControllerTestIT extends DataApiTestIT {
         String startStr = "2005-02-01T08:00:00Z";
         String endStr = "2005-02-01T14:00:00Z";
         String tsIdentifier = "TsTextTestLoc.Flow.Inst.1DayLocal.0.lrts-test";
-        given()
-            .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(format)
-            .queryParam(Controllers.OFFICE, OFFICE)
-            .queryParam(Controllers.NAME, tsIdentifier)
-            .queryParam(Controllers.BEGIN,startStr)
-            .queryParam(Controllers.END,endStr)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .get("/timeseries/text")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL,true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        var assertThat =
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(format)
+                .queryParam(Controllers.OFFICE, OFFICE)
+                .queryParam(Controllers.NAME, tsIdentifier)
+                .queryParam(Controllers.BEGIN,startStr)
+                .queryParam(Controllers.END,endStr)
+                .header(ApiServlet.IS_NEW_LRTS, false)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .get("/timeseries/text")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat();
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
+            assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        } else {
+            assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+        }
 
         // create
         InputStream resource = this.getClass().getResourceAsStream("/cwms/cda/api/spk/local_regular_text_ts.json");

--- a/cwms-data-api/src/test/java/cwms/cda/api/TextTimeSeriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TextTimeSeriesControllerTestIT.java
@@ -226,7 +226,7 @@ public class TextTimeSeriesControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
         .assertThat()
-            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
 
         // create
         InputStream resource = this.getClass().getResourceAsStream("/cwms/cda/api/spk/local_regular_text_ts.json");
@@ -323,7 +323,7 @@ public class TextTimeSeriesControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
         .assertThat()
-            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
@@ -416,7 +416,7 @@ final class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
             .then()
                 .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat();
-        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
             assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
         } else {
             assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND));

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
@@ -38,6 +38,7 @@ import cwms.cda.data.dto.TimeSeriesCategory;
 import cwms.cda.data.dto.TimeSeriesGroup;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import fixtures.CwmsDataApiSetupCallback;
 import fixtures.FunctionalSchemas;
 import fixtures.TestAccounts;
@@ -399,22 +400,27 @@ final class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
         createTimeseriesWithNewLRTSInterval(officeId, timeSeriesId, 0);
 
         // try to create a group without setting the LRTS header
-        given()
-            .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(format)
-            .contentType(Formats.JSON)
-            .body(groupXml)
-            .header("Authorization", user.toHeaderValue())
-            .header(ApiServlet.IS_NEW_LRTS, false)
-            .queryParam(FAIL_IF_EXISTS, false)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .post("/timeseries/group")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL,true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        var assertThat =
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(format)
+                .contentType(Formats.JSON)
+                .body(groupXml)
+                .header("Authorization", user.toHeaderValue())
+                .header(ApiServlet.IS_NEW_LRTS, false)
+                .queryParam(FAIL_IF_EXISTS, false)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/group")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat();
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+            assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        } else {
+            assertThat.statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+        }
         //Create Group
         given()
             .log().ifValidationFails(LogDetail.ALL,true)

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
@@ -414,7 +414,7 @@ final class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
         .assertThat()
-            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
         //Create Group
         given()
             .log().ifValidationFails(LogDetail.ALL,true)

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesIdentifierDescriptorControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesIdentifierDescriptorControllerTestIT.java
@@ -195,16 +195,15 @@ final class TimeSeriesIdentifierDescriptorControllerTestIT extends DataApiTestIT
         .assertThat()
             .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
             .body("details.message",
-                is("Invalid time series description: "
-                    + "12HoursLocal is not a valid interval"));
+                is(String.format("Invalid time series description: ORA-20998: ERROR: INVALID Time Series Identifier \"%s\": No such interval", tsId)));
     }
 
     @Test
-    void testInvalidItem() throws Exception {
+    void test_invalid_ts_id() throws Exception {
         createLocation("BadLocationTSTest",true,"SPK");
         TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
         String tsId = "BadLocationTSTest" +
-            ".Precip-Cumulative.Avg.12HoursLocal.12HoursLocal.DescriptorTEST_LRTS25";
+            ".Precip-Cumulative.Ave.~12Hours.12HoursLocal.DescriptorTEST_LRTS25";
         TimeSeriesIdentifierDescriptor ts = buildTimeSeriesIdentifierDescriptor(OFFICE, tsId);
 
         ObjectMapper om = JsonV2.buildObjectMapper();
@@ -228,7 +227,7 @@ final class TimeSeriesIdentifierDescriptorControllerTestIT extends DataApiTestIT
             .body("message", equalTo("Bad Request."))
             .body("source", equalTo("User Input"))
             .body("details.message",
-                is("Invalid time series description: 12HoursLocal is not a valid duration"));
+                is(String.format("Invalid time series description: ORA-20998: ERROR: INVALID Time Series Identifier \"%s\": No such duration", tsId)));
     }
 
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesIdentifierDescriptorControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesIdentifierDescriptorControllerTestIT.java
@@ -13,6 +13,7 @@ import cwms.cda.data.dao.JooqDao;
 import cwms.cda.data.dto.TimeSeriesIdentifierDescriptor;
 import cwms.cda.formatters.Formats;
 import cwms.cda.formatters.json.JsonV2;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import fixtures.TestAccounts;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.path.json.JsonPath;
@@ -178,24 +179,35 @@ final class TimeSeriesIdentifierDescriptorControllerTestIT extends DataApiTestIT
         Assertions.assertTrue(names.isEmpty());
 
         // Try to store it again, but this time with the new LRTS flag set to false.
-        given()
-            .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(format)
-            .contentType(Formats.JSONV2)
-            .body(serializedTs)
-            .header("Authorization", user.toHeaderValue())
-            .header(ApiServlet.IS_NEW_LRTS, false)
-            .queryParam("office",OFFICE)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .post("/timeseries/identifier-descriptor/")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL,true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
-            .body("details.message",
-                is(String.format("Invalid time series description: ORA-20998: ERROR: INVALID Time Series Identifier \"%s\": No such interval", tsId)));
+        var assertThat =
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(format)
+                .contentType(Formats.JSONV2)
+                .body(serializedTs)
+                .header("Authorization", user.toHeaderValue())
+                .header(ApiServlet.IS_NEW_LRTS, false)
+                .queryParam("office",OFFICE)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/identifier-descriptor/")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat();
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+            assertThat
+                .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
+                .body("details.message",
+                    is(String.format("Invalid time series description: ORA-20998: ERROR: " +
+                                     "INVALID Time Series Identifier \"%s\": No such interval", tsId)));
+        } else {
+            assertThat
+                .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
+                .body("details.message",
+                    is("Invalid time series description: "
+                    + "12HoursLocal is not a valid interval"));
+        }
     }
 
     @Test
@@ -208,26 +220,33 @@ final class TimeSeriesIdentifierDescriptorControllerTestIT extends DataApiTestIT
 
         ObjectMapper om = JsonV2.buildObjectMapper();
         String serializedTs = om.writeValueAsString(ts);
-        given()
-            .log().ifValidationFails(LogDetail.ALL,true)
-            .accept(Formats.DEFAULT)
-            .contentType(Formats.JSONV2)
-            .body(serializedTs)
-            .header("Authorization", user.toHeaderValue())
-            .header(ApiServlet.IS_NEW_LRTS, false)
-            .queryParam("office",OFFICE)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .post("/timeseries/identifier-descriptor/")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL,true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
-            .body("message", equalTo("Bad Request."))
-            .body("source", equalTo("User Input"))
-            .body("details.message",
+        var assertThat =
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(Formats.DEFAULT)
+                .contentType(Formats.JSONV2)
+                .body(serializedTs)
+                .header("Authorization", user.toHeaderValue())
+                .header(ApiServlet.IS_NEW_LRTS, false)
+                .queryParam("office",OFFICE)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/identifier-descriptor/")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat()
+                .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
+                .body("message", equalTo("Bad Request."))
+                .body("source", equalTo("User Input"))
+            ;
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+            assertThat.body("details.message",
                 is(String.format("Invalid time series description: ORA-20998: ERROR: INVALID Time Series Identifier \"%s\": No such duration", tsId)));
+        } else {
+            assertThat.body("details.message",
+                is("Invalid time series description: 12HoursLocal is not a valid duration"));
+        }
     }
 
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesIdentifierDescriptorControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesIdentifierDescriptorControllerTestIT.java
@@ -195,7 +195,7 @@ final class TimeSeriesIdentifierDescriptorControllerTestIT extends DataApiTestIT
             .then()
                 .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat();
-        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
             assertThat
                 .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
                 .body("details.message",
@@ -240,7 +240,7 @@ final class TimeSeriesIdentifierDescriptorControllerTestIT extends DataApiTestIT
                 .body("message", equalTo("Bad Request."))
                 .body("source", equalTo("User Input"))
             ;
-        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
             assertThat.body("details.message",
                 is(String.format("Invalid time series description: ORA-20998: ERROR: INVALID Time Series Identifier \"%s\": No such duration", tsId)));
         } else {

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -210,7 +210,7 @@ final class TimeseriesControllerTestIT extends DataApiTestIT {
             .then()
                 .log().ifValidationFails(LogDetail.ALL, true)
             .assertThat();
-        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_01.numeric()) {
             assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
         } else {
             assertThat.statusCode(is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -208,7 +208,7 @@ final class TimeseriesControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL, true)
         .assertThat()
-            .statusCode(is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import cwms.cda.ApiServlet;
 import cwms.cda.data.dto.Location;
 import cwms.cda.formatters.Formats;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import cwms.cda.helpers.ZoneIdHelper;
 import fixtures.CwmsDataApiSetupCallback;
 import fixtures.MinimumSchema;
@@ -192,23 +193,28 @@ final class TimeseriesControllerTestIT extends DataApiTestIT {
             .statusCode(is(HttpServletResponse.SC_OK));
 
         // inserting the time series with new LRTS ID turned off
-        given()
-            .log().ifValidationFails(LogDetail.ALL, true)
-            .accept(Formats.JSONV2)
-            .contentType(Formats.JSONV2)
-            .header("Authorization", user.toHeaderValue())
-            .header(ApiServlet.IS_NEW_LRTS, false)
-            .queryParam(OFFICE, officeId)
-            .queryParam(CREATE_AS_LRTS, true)
-            .body(tsData)
-        .when()
-            .redirects().follow(true)
-            .redirects().max(3)
-            .post("/timeseries/")
-        .then()
-            .log().ifValidationFails(LogDetail.ALL, true)
-        .assertThat()
-            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        var assertThat =
+            given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.JSONV2)
+                .contentType(Formats.JSONV2)
+                .header("Authorization", user.toHeaderValue())
+                .header(ApiServlet.IS_NEW_LRTS, false)
+                .queryParam(OFFICE, officeId)
+                .queryParam(CREATE_AS_LRTS, true)
+                .body(tsData)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .post("/timeseries/")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL, true)
+            .assertThat();
+        if (getSchemaVersion() > SCHEMA_VERSION.V2025_07_02.numeric()) {
+            assertThat.statusCode(is(HttpServletResponse.SC_BAD_REQUEST));
+        } else {
+            assertThat.statusCode(is(HttpServletResponse.SC_INTERNAL_SERVER_ERROR));
+        }
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/WaterSupplyAccountingControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/WaterSupplyAccountingControllerIT.java
@@ -54,7 +54,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;

--- a/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
@@ -219,6 +219,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
     @Test
     @Order(5)
     public void test_key_usage() throws Exception {
+        
         createLocation("ApiKey-Test Location",true,"SPK");
         String json = loadResourceAsString("cwms/cda/api/location_create_spk.json");
         Location location = new Location.Builder(Formats.parseContent(Formats.parseHeader(Formats.JSON, Location.class),
@@ -234,6 +235,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL,true)
             .accept(Formats.JSON)
             .contentType(Formats.JSON)
+            .queryParam("fail-if-exists", false)
             .body(serializedLocation)
             .header("Authorization", user.toHeaderValue())
         .when()
@@ -248,7 +250,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
         final ApiKey expiredKey = realKeys.stream()
                                           .filter(k -> k.getKeyName().equals(EXPIRED_KEY_NAME))
                                           .findFirst()
-                                          .orElseThrow(() -> new Exception("expired key not in real keys list."));
+                                          .orElseGet(() -> fail("expired key not in real keys list."));
         final Location updateLocation = new Location.Builder(location)
                         .withCountyName("Sacramento")
                         .build();

--- a/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
@@ -1,9 +1,9 @@
 package cwms.cda.api.auth;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Test;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
@@ -220,7 +220,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
     @Order(5)
     public void test_key_usage() throws Exception {
         createLocation("ApiKey-Test Location",true,"SPK");
-        String json = loadResourceAsString("cwms/cda/api/location_create.json");
+        String json = loadResourceAsString("cwms/cda/api/location_create_spk.json");
         Location location = new Location.Builder(Formats.parseContent(Formats.parseHeader(Formats.JSON, Location.class),
             json, Location.class))
                 .withOfficeId("SPK")
@@ -243,7 +243,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
-            .statusCode(is(HttpCode.ACCEPTED.getStatus()));
+            .statusCode(is(HttpCode.CREATED.getStatus()));
 
         final ApiKey expiredKey = realKeys.stream()
                                           .filter(k -> k.getKeyName().equals(EXPIRED_KEY_NAME))

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/StreamLocationNodeTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/StreamLocationNodeTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 
 final class StreamLocationNodeTest {
 

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/watersupply/PumpAccountingTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/watersupply/PumpAccountingTest.java
@@ -33,7 +33,7 @@ import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
 import cwms.cda.helpers.DTOMatch;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/watersupply/WaterSupplyAccountingTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/watersupply/WaterSupplyAccountingTest.java
@@ -33,7 +33,7 @@ import cwms.cda.api.errors.FieldException;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.formatters.Formats;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.org.apache.commons.io.IOUtils;
+import org.apache.commons.io.IOUtils;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -100,7 +100,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
         if (tmp.equalsIgnoreCase("latest-dev")) {
             ret = 999999;
         } else if (tmp.equalsIgnoreCase("Bypass")) {
-            ret = -1;
+            ret = getSchemaVersion();
         } else if(tmp.toLowerCase().endsWith("staging")) {
             ret = 1009999;
         } else {

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -113,9 +113,9 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
         CwmsDatabaseContainer<?> db = CwmsDataApiSetupCallback.getDatabaseLink();
         try {
             return db.connection((c) -> {
-                var ctx = JooqDao.getDslContext(c, null);
+                var ctx = JooqDao.getDslContext(c, db.getOfficeId());
                 return Dao.versionAsInteger(Dao.getVersion(ctx));
-            }, "cwms_20");
+            }, webUser);
         } catch (SQLException ex) {
             throw new RuntimeException(ex);
         }

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import com.google.common.flogger.FluentLogger;
 
 import cwms.cda.data.dao.Dao;
+import cwms.cda.data.dao.JooqDao;
+import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import cwms.cda.security.OpenIdConnectIdentitityProvider;
 import fixtures.tomcat.SingleSignOnWrapper;
 import helpers.TsRandomSampler;
@@ -95,17 +97,28 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
     {
         int ret;
         String tmp = schemaVersion();
-        if (tmp.equalsIgnoreCase("latest-dev") || tmp.equalsIgnoreCase("Bypass")) {
+        if (tmp.equalsIgnoreCase("latest-dev")) {
             ret = 999999;
-        }
-        else if(tmp.toLowerCase().endsWith("staging")) {
+        } else if (tmp.equalsIgnoreCase("Bypass")) {
+            ret = getSchemaVersion();
+        } else if(tmp.toLowerCase().endsWith("staging")) {
             ret = 1009999;
-        }
-        else
-        {
+        } else {
             ret = Dao.versionAsInteger(tmp.replaceAll("-RC.*", "").replace("-","."));
         }
         return ret;
+    }
+
+    public static int getSchemaVersion() {
+        CwmsDatabaseContainer<?> db = CwmsDataApiSetupCallback.getDatabaseLink();
+        try {
+            return db.connection((c) -> {
+                var ctx = JooqDao.getDslContext(c, null);
+                return Dao.versionAsInteger(Dao.getVersion(ctx));
+            }, "cwms_20");
+        } catch (SQLException ex) {
+            throw new RuntimeException(ex);
+        }
     }
 
     @Override
@@ -116,7 +129,6 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public void beforeAll(ExtensionContext context) throws Exception {
         if (cdaInstance == null ) {
             cwmsDb = CwmsDatabaseContainers.createDatabaseContainer(ORACLE_IMAGE)

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -26,7 +26,6 @@ import com.google.common.flogger.FluentLogger;
 
 import cwms.cda.data.dao.Dao;
 import cwms.cda.data.dao.JooqDao;
-import cwms.cda.helpers.DatabaseHelpers.SCHEMA_VERSION;
 import cwms.cda.security.OpenIdConnectIdentitityProvider;
 import fixtures.tomcat.SingleSignOnWrapper;
 import helpers.TsRandomSampler;
@@ -80,7 +79,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
         String ret;
         if (!System.getProperty(CwmsDatabaseContainers.BYPASS_URL,"").isEmpty())
         {
-            ret = "Bypass";
+            ret = System.getProperty("testcontainer.cwms.bypass.version","Bypass");
         }
         else if (ORACLE_IMAGE.contains("database-ready"))
         {
@@ -100,7 +99,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
         if (tmp.equalsIgnoreCase("latest-dev")) {
             ret = 999999;
         } else if (tmp.equalsIgnoreCase("Bypass")) {
-            ret = getSchemaVersion();
+            ret = -1;
         } else if(tmp.toLowerCase().endsWith("staging")) {
             ret = 1009999;
         } else {

--- a/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
+++ b/cwms-data-api/src/test/java/fixtures/CwmsDataApiSetupCallback.java
@@ -100,7 +100,7 @@ public class CwmsDataApiSetupCallback implements BeforeAllCallback,AfterAllCallb
         if (tmp.equalsIgnoreCase("latest-dev")) {
             ret = 999999;
         } else if (tmp.equalsIgnoreCase("Bypass")) {
-            ret = getSchemaVersion();
+            ret = -1;
         } else if(tmp.toLowerCase().endsWith("staging")) {
             ret = 1009999;
         } else {

--- a/cwms-data-api/src/test/java/fixtures/SchemaVersionCondition.java
+++ b/cwms-data-api/src/test/java/fixtures/SchemaVersionCondition.java
@@ -44,7 +44,7 @@ public class SchemaVersionCondition implements ExecutionCondition {
             .filter(Objects::nonNull)
             .map(annotation -> {
                 int version = annotation.value();
-                int currentVersion = getCurrentSchemaVersion();
+                int currentVersion = CwmsDataApiSetupCallback.getSchemaVersion();
                 if (currentVersion < version) {
                     return ConditionEvaluationResult.disabled("Test disabled because schema version "
                         + currentVersion + " is less than " + version);
@@ -53,15 +53,5 @@ public class SchemaVersionCondition implements ExecutionCondition {
                     + currentVersion + " is at least " + version);
             })
             .orElse(ENABLED);
-    }
-
-    private int getCurrentSchemaVersion() {
-        try {
-            return CwmsDataApiSetupCallback.getDatabaseLink().connection(c->{
-                return AuthDao.getInstance(DSL.using(c)).getDbVersion();
-            }, CwmsDataApiSetupCallback.getWebUser());
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/cwms-data-api/src/test/resources/tomcat/conf/context.xml
+++ b/cwms-data-api/src/test/resources/tomcat/conf/context.xml
@@ -9,7 +9,7 @@
               minIdle="${CDA_POOL_MIN_IDLE}"
               validationQuery="select 1 from dual"
               validationQueryTimeout="1"              
-              removeAbandoned="true"
+              removeAbandoned="false"
               removeAbandonedTimeout="10"
               testOnBorrow="true"
               testOnConnect="true"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ jjwt = "0.11.5"
 jstl = "1.2"
 junit = "5.11.1"
 junit-launcher = "1.11.2"
-testcontainers = { strictly = "1.20.4" }
+testcontainers = { strictly = "2.0.2" }
 cwms-testcontainers = "2.0.0"
 oracle-jdbc = "19.3.0.0"
 mockito = "4.6.1"
@@ -101,9 +101,9 @@ openapi-spec-validation = { module = "com.atlassian.oai:swagger-request-validato
 
 
 testcontainers-base = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers"}
-testcontainers-database-commons = { module = "org.testcontainers:database-commons", version.ref = "testcontainers" }
-testcontainers-jdbc = { module = "org.testcontainers:jdbc", version.ref = "testcontainers"}
-testcontainers-junit-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainers"}
+testcontainers-database-commons = { module = "org.testcontainers:testcontainers-database-commons", version.ref = "testcontainers" }
+testcontainers-jdbc = { module = "org.testcontainers:testcontainers-jdbc", version.ref = "testcontainers"}
+testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter", version.ref = "testcontainers"}
 testcontainers-cwms = { module = "mil.army.usace.hec:testcontainers-cwms", version.ref = "cwms-testcontainers"}
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
 oracle-jdbc-driver = { module ="com.oracle.database.jdbc:ojdbc8", version.ref = "oracle-jdbc" }


### PR DESCRIPTION
NOTE: bit hot mess still. Additional cleanup to happen with #1480 

Update and error messaging to handle to output from https://github.com/HydrologicEngineeringCenter/cwms-database/pull/72 for LRTS time series validation.

Additionally had to update testcontainers as I had updated docker and only the latest version of test containers properly accounted for some altered behavior. And then discovered some incorrectly imported dependencies and corrected that.

Modifications were made to how the Schema version was acquired. There is some minor duplication of schema versions. Will update in further PR. This has waited long enough and is causing confusion on other work.