### PR TITLE
Force specific revision for now.

### DIFF
--- a/.github/actions/database-migration-image/Dockerfile
+++ b/.github/actions/database-migration-image/Dockerfile
@@ -10,6 +10,8 @@ COPY cda-user.sql /after.install.d/
 ENV RDS_MODE="true"
 ENV BUILDUSER=DBAdmin
 
+# Due to the way we originally set this up it needs to always be 99.99.99-SNAPSHOT for now.
+RUN sed -i "s/<revision>.*<\/revision>/<revision>99.99.99-SNAPSHOT<\/revision>/" ../pom.xml
 
 ENTRYPOINT [ "/entry.sh" ]
 CMD ["/cwmsdb/schema/docker/install.sh"]


### PR DESCRIPTION
The "corrections" to the database project caused the embedded revision of the installer container to be main instead of the 99-99-99-SNAPSHOT marker.

There's more work to do on the database project for that, but I think we will go in a slightly different direction of using the current data so for here we're just going to fork it to the above marker.