### PR TITLE
CDA-82: Resolved failing location level tests

### DIFF
--- a/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
@@ -1725,7 +1725,7 @@ public class LevelsControllerTestIT extends DataApiTestIT {
         ZonedDateTime levelDate = ZonedDateTime.ofInstant(Instant.parse("2024-01-01T00:00:00Z"), ZoneId.of("UTC"));
         List<SeasonalValueBean> values = new ArrayList<>();
         int numValues = 12;
-        for (int i = 1; i <= numValues; i++) {
+        for (int i = 0; i < numValues; i++) {
             values.add(new SeasonalValueBean.Builder()
                 .withValue(i + 1.0)
                 .withOffsetMonths(i)
@@ -1790,7 +1790,7 @@ public class LevelsControllerTestIT extends DataApiTestIT {
         ZonedDateTime levelDate = ZonedDateTime.ofInstant(Instant.parse("2024-01-01T00:00:00Z"), ZoneId.of("UTC"));
         List<SeasonalValueBean> values = new ArrayList<>();
         int numValues = 12;
-        for (int i = 1; i <= numValues; i++) {
+        for (int i = 0; i < numValues; i++) {
             values.add(new SeasonalValueBean.Builder()
                 .withValue(i + 1.0)
                 .withOffsetMonths(i)


### PR DESCRIPTION
Adjusted integration test data time offsets to fit within interval.

New error message in DB procedure caused tests to fail.