### PR TITLE
fix paging for rating spec getAll endpoint

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/rating/RatingSpecController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/rating/RatingSpecController.java
@@ -65,7 +65,7 @@ public class RatingSpecController implements CrudHandler {
 
     private final MetricRegistry metrics;
 
-    private static final int DEFAULT_PAGE_SIZE = 100;
+    static final int DEFAULT_PAGE_SIZE = 100;
 
     private final Histogram requestResultSize;
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -251,7 +251,7 @@ public abstract class JooqDao<T> extends Dao<T> {
      * an easy to read manner without having to worry about the syntax.
      */
     public static Condition caseInsensitiveLikeRegex(Field<String> field, String regex) {
-        if("*".equals(regex)) {
+        if("*".equals(regex) || ".*".equals(regex)) {
             return DSL.noCondition();
         }
         return new CustomCondition() {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/JooqDao.java
@@ -251,6 +251,9 @@ public abstract class JooqDao<T> extends Dao<T> {
      * an easy to read manner without having to worry about the syntax.
      */
     public static Condition caseInsensitiveLikeRegex(Field<String> field, String regex) {
+        if("*".equals(regex)) {
+            return DSL.noCondition();
+        }
         return new CustomCondition() {
             @Override
             public void accept(org.jooq.Context<?> ctx) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingAdapter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingAdapter.java
@@ -104,10 +104,14 @@ public class RatingAdapter {
             withAbstractFields(builder, rating);
 
             String[] evaluationStrings = rating.getEvaluationStrings();
-            builder.withEvaluations(Arrays.asList(evaluationStrings));
+            if(evaluationStrings != null) {
+                builder.withEvaluations(Arrays.asList(evaluationStrings));
+            }
 
             String[] conditionStrings = rating.getConditionStrings();
-            builder.withConditions(Arrays.asList(conditionStrings));
+            if(conditionStrings != null) {
+                builder.withConditions(Arrays.asList(conditionStrings));
+            }
 
             List<String> ratingSpecIds = new ArrayList<>();
             SourceRating[] sourceRatings = rating.getSourceRatings();

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
@@ -55,8 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -130,8 +130,8 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
                     } catch (NumberFormatException e) {
                         logger.atInfo().log("Could not parse %s", parts[1]);
                     }
-                    pageSize = Integer.parseInt(parts[2]);
                 }
+                pageSize = Integer.parseInt(parts[2]);
             }
         }
 
@@ -152,14 +152,20 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
             specCondition = specCondition.and(maskRegex);
         }
 
-        // Total number of specs (not joined rows)
         if (total == null) {
             total = dsl.fetchCount(specView, specCondition);
         }
 
-        // Page the specs first in a derived table (avoids IN(...) limits entirely)
         var specPage = dsl
-            .select(specView.RATING_SPEC_CODE)
+            .select(
+                specView.RATING_SPEC_CODE,
+                specView.OFFICE_ID, specView.RATING_ID, specView.DATE_METHODS,
+                specView.TEMPLATE_ID, specView.LOCATION_ID, specView.VERSION,
+                specView.SOURCE_AGENCY, specView.ACTIVE_FLAG, specView.AUTO_UPDATE_FLAG,
+                specView.AUTO_ACTIVATE_FLAG, specView.AUTO_MIGRATE_EXT_FLAG,
+                specView.IND_ROUNDING_SPECS, specView.DEP_ROUNDING_SPEC,
+                specView.DESCRIPTION, specView.ALIASED_ITEM
+            )
             .from(specView)
             .where(specCondition)
             .orderBy(specView.OFFICE_ID, specView.RATING_ID)
@@ -167,53 +173,64 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
             .offset(offset)
             .asTable("spec_page");
 
-        Field<Long> pageSpecCode = DSL.field(DSL.name("spec_page", "RATING_SPEC_CODE"), Long.class);
+        Field<Long> spSpecCode = specPage.field(specView.RATING_SPEC_CODE);
+        Field<String> spOfficeId = specPage.field(specView.OFFICE_ID);
+        Field<String> spRatingId = specPage.field(specView.RATING_ID);
+
+        Field<List<ZonedDateTime>> effectiveDates =
+            DSL.multiset(
+                    dsl.select(ratView.EFFECTIVE_DATE)
+                       .from(ratView)
+                       .where(ratView.RATING_SPEC_CODE.eq(spSpecCode))
+                       .and(ratView.ALIASED_ITEM.isNull())
+                       .and(ratView.EFFECTIVE_DATE.isNotNull())
+                       .orderBy(ratView.EFFECTIVE_DATE)
+                )
+               .convertFrom(r ->
+                   r.getValues(ratView.EFFECTIVE_DATE).stream()
+                    .map(RatingSpecDao::toZdt)
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList())
+               )
+               .as("effective_dates");
 
         ResultQuery<? extends Record> query = dsl.select(
-                specView.RATING_SPEC_CODE,
-                specView.OFFICE_ID, specView.RATING_ID, specView.DATE_METHODS,
-                specView.TEMPLATE_ID, specView.LOCATION_ID, specView.VERSION,
-                specView.SOURCE_AGENCY, specView.ACTIVE_FLAG, specView.AUTO_UPDATE_FLAG,
-                specView.AUTO_ACTIVATE_FLAG, specView.AUTO_MIGRATE_EXT_FLAG,
-                specView.IND_ROUNDING_SPECS, specView.DEP_ROUNDING_SPEC,
-                specView.DESCRIPTION, specView.ALIASED_ITEM,
-                ratView.RATING_SPEC_CODE, ratView.EFFECTIVE_DATE)
-            .from(specView)
-            .join(specPage)
-            .on(specView.RATING_SPEC_CODE.eq(pageSpecCode))
-            .leftOuterJoin(ratView)
-            .on(specView.RATING_SPEC_CODE.eq(ratView.RATING_SPEC_CODE))
-            .where(specView.ALIASED_ITEM.isNull())
+                spSpecCode,
+                spOfficeId,
+                spRatingId,
+                specPage.field(specView.DATE_METHODS),
+                specPage.field(specView.TEMPLATE_ID),
+                specPage.field(specView.LOCATION_ID),
+                specPage.field(specView.VERSION),
+                specPage.field(specView.SOURCE_AGENCY),
+                specPage.field(specView.ACTIVE_FLAG),
+                specPage.field(specView.AUTO_UPDATE_FLAG),
+                specPage.field(specView.AUTO_ACTIVATE_FLAG),
+                specPage.field(specView.AUTO_MIGRATE_EXT_FLAG),
+                specPage.field(specView.IND_ROUNDING_SPECS),
+                specPage.field(specView.DEP_ROUNDING_SPEC),
+                specPage.field(specView.DESCRIPTION),
+                specPage.field(specView.ALIASED_ITEM),
+                effectiveDates
+            )
+            .from(specPage)
+            .orderBy(spOfficeId, spRatingId)
             .fetchSize(DEFAULT_FETCH_SIZE);
 
         logger.atFine().log("%s", lazy(() -> query.getSQL(ParamType.INLINED)));
 
-        Map<Long, RatingSpec.Builder> specBuilders = new HashMap<>();
-        Map<Long, List<ZonedDateTime>> effectiveDatesBySpec = new HashMap<>();
-
-        query.fetch()
-            .forEach(rec -> {
-                Long specCode = rec.get(specView.RATING_SPEC_CODE);
-                // create builder only once per specCode
-                specBuilders.computeIfAbsent(specCode, sc -> {
-                    RatingSpec template = buildRatingSpec(rec); // still uses the row, but only once per spec
-                    return new RatingSpec.Builder().fromRatingSpec(template);
-                });
-                ZonedDateTime effective = toZdt(rec.get(ratView.EFFECTIVE_DATE));
-                if (effective != null) {
-                    effectiveDatesBySpec.computeIfAbsent(specCode, k -> new ArrayList<>())
-                        .add(effective);
-                }
-            });
-        List<RatingSpec> specs = specBuilders.entrySet().stream()
-            .map(e -> {
-                List<ZonedDateTime> dates = effectiveDatesBySpec.get(e.getKey());
-                return e.getValue()
+        List<RatingSpec> specs = query.fetch()
+            .stream()
+            .map(rec -> {
+                RatingSpec template = buildRatingSpec(rec);
+                List<ZonedDateTime> dates = rec.get(effectiveDates);
+                return new RatingSpec.Builder()
+                    .fromRatingSpec(template)
                     .withEffectiveDates(dates == null ? List.of() : dates)
                     .build();
             })
-            .sorted(comparing(RatingSpec::getOfficeId).thenComparing(RatingSpec::getRatingId))
-            .collect(Collectors.toList());
+            .collect(toList());
+
         RatingSpecs.Builder builder = new RatingSpecs.Builder(offset, pageSize, total);
         builder.withSpecs(specs);
         return builder.build();

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
@@ -183,7 +183,6 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
                        .from(ratView)
                        .where(ratView.RATING_SPEC_CODE.eq(spSpecCode))
                        .and(ratView.ALIASED_ITEM.isNull())
-                       .and(ratView.EFFECTIVE_DATE.isNotNull())
                        .orderBy(ratView.EFFECTIVE_DATE)
                 )
                .convertFrom(r ->

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
@@ -188,7 +188,6 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
 
         logger.atFine().log("%s", lazy(() -> query.getSQL(ParamType.INLINED)));
 
-        // Preserve stable ordering
         Map<Long, RatingSpec.Builder> specBuilders = new HashMap<>();
         Map<Long, List<ZonedDateTime>> effectiveDatesBySpec = new HashMap<>();
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/RatingSpecDao.java
@@ -27,6 +27,7 @@ package cwms.cda.data.dao;
 import static com.google.common.flogger.LazyArgs.lazy;
 
 import static cwms.cda.data.dto.rating.RatingSpec.Builder.buildIndependentRoundingSpecs;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -48,9 +49,8 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -114,69 +114,8 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
         super(dsl);
     }
 
-    public Collection<RatingSpec> retrieveRatingSpecs(String office, String specIdMask) {
-
-        AV_RATING_SPEC specView = AV_RATING_SPEC.AV_RATING_SPEC;
-        AV_RATING ratView = AV_RATING.AV_RATING;
-
-        // We don't want to also check AV_RATING_SPEC.ALIASED_ITEM b/c we
-        // don't care whether the specs returned are an alias or not.
-        // We do want to exclude the aliased ratings b/c we only want one
-        // copy of each matching rating.
-
-        Condition condition = ratView.ALIASED_ITEM.isNull();
-
-        if (office != null) {
-            condition = condition.and(specView.OFFICE_ID.eq(office));
-        }
-
-        if (specIdMask != null) {
-            Condition likeRegex = JooqDao.caseInsensitiveLikeRegex(specView.RATING_ID, specIdMask);
-            condition = condition.and(likeRegex);
-        }
-
-        ResultQuery<? extends Record> query = dsl.select(specView.RATING_SPEC_CODE,
-                        specView.OFFICE_ID, specView.RATING_ID, specView.TEMPLATE_ID,
-                        specView.LOCATION_ID, specView.VERSION, specView.SOURCE_AGENCY,
-                        specView.ACTIVE_FLAG, specView.AUTO_UPDATE_FLAG,
-                        specView.AUTO_ACTIVATE_FLAG,
-                        specView.AUTO_MIGRATE_EXT_FLAG, specView.IND_ROUNDING_SPECS,
-                        specView.DEP_ROUNDING_SPEC, specView.DATE_METHODS, specView.DESCRIPTION,
-                        ratView.RATING_SPEC_CODE, ratView.EFFECTIVE_DATE)
-                .from(specView)
-                .leftOuterJoin(ratView)
-                .on(specView.RATING_SPEC_CODE.eq(ratView.RATING_SPEC_CODE))
-                .where(condition)
-                .fetchSize(DEFAULT_FETCH_SIZE);
-
-        logger.atFine().log("%s", lazy(() -> query.getSQL(ParamType.INLINED)));
-
-        Map<RatingSpec, List<ZonedDateTime>> map = new LinkedHashMap<>();
-        try (Stream<? extends Record> stream = query.fetchStream()) {
-            stream.forEach(rec -> {
-                RatingSpec template = buildRatingSpec(rec);
-
-                Timestamp effectiveDate = rec.get(ratView.EFFECTIVE_DATE);
-                ZonedDateTime effective = toZdt(effectiveDate);
-
-                List<ZonedDateTime> list = map.computeIfAbsent(template, k -> new ArrayList<>());
-                if (effective != null) {
-                    list.add(effective);
-                }
-            });
-        }
-
-        return map.entrySet().stream()
-                .map(entry -> new RatingSpec.Builder()
-                        .fromRatingSpec(entry.getKey())
-                        .withEffectiveDates(entry.getValue())
-                        .build())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-    }
-
-
-    public RatingSpecs retrieveRatingSpecs(String cursor, int pageSize, String office,
-                                           String specIdMask) {
+    @NotNull
+    public RatingSpecs retrieveRatingSpecs(String cursor, int pageSize, String office, String specIdMask) {
         Integer total = null;
         int offset = 0;
 
@@ -191,149 +130,108 @@ public class RatingSpecDao extends JooqDao<RatingSpec> {
                     } catch (NumberFormatException e) {
                         logger.atInfo().log("Could not parse %s", parts[1]);
                     }
+                    pageSize = Integer.parseInt(parts[2]);
                 }
-                pageSize = Integer.parseInt(parts[2]);
             }
         }
-
-        Set<RatingSpec> retval = getRatingSpecs(office, specIdMask, offset, pageSize);
-
-        RatingSpecs.Builder builder = new RatingSpecs.Builder(offset, pageSize, total);
-        builder.withSpecs(new ArrayList<>(retval));
-        return builder.build();
-    }
-
-    @NotNull
-    public Set<RatingSpec> getRatingSpecs(String office, String specIdMask, int firstRow,
-                                          int pageSize) {
-        Set<RatingSpec> retVal;
 
         AV_RATING_SPEC specView = AV_RATING_SPEC.AV_RATING_SPEC;
         AV_RATING ratView = AV_RATING.AV_RATING;
 
-        // We don't want to also check AV_RATING_SPEC.ALIASED_ITEM b/c we
-        // don't care whether the specs returned are an alias or not.
-        // We do want to exclude the aliased ratings b/c we only want one
-        // copy of each matching rating.
-        Condition condition = ratView.ALIASED_ITEM.isNull();
+        // Conditions that define WHICH SPECS match
+        Condition specCondition = specView.TEMPLATE_ID.notLike("%Stage-Offset%")
+            .and(specView.TEMPLATE_ID.notLike("%Stage-Shift%"))
+            .and(specView.ALIASED_ITEM.isNull());
 
         if (office != null) {
-            condition = condition.and(specView.OFFICE_ID.eq(office));
+            specCondition = specCondition.and(specView.OFFICE_ID.eq(office.toUpperCase()));
         }
 
         if (specIdMask != null) {
             Condition maskRegex = JooqDao.caseInsensitiveLikeRegex(specView.RATING_ID, specIdMask);
-            condition = condition.and(maskRegex);
+            specCondition = specCondition.and(maskRegex);
         }
 
-        ResultQuery<? extends Record> query = dsl.select(specView.RATING_SPEC_CODE,
-                        specView.OFFICE_ID, specView.RATING_ID, specView.DATE_METHODS,
-                        specView.TEMPLATE_ID, specView.LOCATION_ID, specView.VERSION,
-                        specView.SOURCE_AGENCY, specView.ACTIVE_FLAG, specView.AUTO_UPDATE_FLAG,
-                        specView.AUTO_ACTIVATE_FLAG, specView.AUTO_MIGRATE_EXT_FLAG,
-                        specView.IND_ROUNDING_SPECS, specView.DEP_ROUNDING_SPEC,
-                        specView.DESCRIPTION, specView.ALIASED_ITEM,
-                        ratView.RATING_SPEC_CODE, ratView.EFFECTIVE_DATE)
-                .from(specView)
-                .leftOuterJoin(ratView)
-                .on(specView.RATING_SPEC_CODE.eq(ratView.RATING_SPEC_CODE))
-                .where(condition)
-                .orderBy(specView.OFFICE_ID, specView.TEMPLATE_ID, ratView.RATING_ID,
-                        ratView.EFFECTIVE_DATE)
-                .limit(pageSize)
-                .offset(firstRow);
-
-        logger.atFine().log("%s", lazy(() -> query.getSQL(ParamType.INLINED)));
-
-        Map<RatingSpec, List<ZonedDateTime>> map = new LinkedHashMap<>();
-        try (Stream<? extends Record> stream = query.fetchStream()) {
-            stream.forEach(rec -> {
-                RatingSpec template = buildRatingSpec(rec);
-
-                Timestamp effectiveDate = rec.get(ratView.EFFECTIVE_DATE);
-                ZonedDateTime effective = toZdt(effectiveDate);
-
-                List<ZonedDateTime> list = map.computeIfAbsent(template, k -> new ArrayList<>());
-                if (effective != null) {
-                    list.add(effective);
-                }
-            });
+        // Total number of specs (not joined rows)
+        if (total == null) {
+            total = dsl.fetchCount(specView, specCondition);
         }
 
-        retVal = map.entrySet().stream()
-                .map(entry -> new RatingSpec.Builder()
-                        .fromRatingSpec(entry.getKey())
-                        .withEffectiveDates(entry.getValue())
-                        .build())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        return retVal;
-    }
+        // Page the specs first in a derived table (avoids IN(...) limits entirely)
+        var specPage = dsl
+            .select(specView.RATING_SPEC_CODE)
+            .from(specView)
+            .where(specCondition)
+            .orderBy(specView.OFFICE_ID, specView.RATING_ID)
+            .limit(pageSize)
+            .offset(offset)
+            .asTable("spec_page");
 
-
-    public Optional<RatingSpec> retrieveRatingSpec(String office, String specId) {
-        Set<RatingSpec> retVal;
-
-        AV_RATING_SPEC specView = AV_RATING_SPEC.AV_RATING_SPEC;
-        AV_RATING ratView = AV_RATING.AV_RATING;
-
-        Condition condition = ratView.ALIASED_ITEM.isNull();
-
-        if (specId != null) {
-            condition = condition.and(specView.RATING_ID.eq(specId));
-        }
-
-        if (office != null) {
-            condition = condition.and(specView.OFFICE_ID.eq(office));
-        }
+        Field<Long> pageSpecCode = DSL.field(DSL.name("spec_page", "RATING_SPEC_CODE"), Long.class);
 
         ResultQuery<? extends Record> query = dsl.select(
-                        specView.RATING_SPEC_CODE,
-                        specView.OFFICE_ID, specView.RATING_ID, specView.TEMPLATE_ID,
-                        specView.LOCATION_ID, specView.VERSION, specView.SOURCE_AGENCY,
-                        specView.ACTIVE_FLAG, specView.AUTO_UPDATE_FLAG,
-                        specView.AUTO_ACTIVATE_FLAG, specView.AUTO_MIGRATE_EXT_FLAG,
-                        specView.IND_ROUNDING_SPECS, specView.DEP_ROUNDING_SPEC,
-                        specView.DATE_METHODS, specView.DESCRIPTION,
-                        ratView.RATING_SPEC_CODE, ratView.EFFECTIVE_DATE
-                )
-                .from(specView)
-                .leftOuterJoin(ratView)
-                .on(specView.RATING_SPEC_CODE.eq(ratView.RATING_SPEC_CODE))
-                .where(condition)
-                .orderBy(specView.OFFICE_ID, specView.RATING_ID, ratView.EFFECTIVE_DATE)
-                .fetchSize(DEFAULT_FETCH_SIZE);
+                specView.RATING_SPEC_CODE,
+                specView.OFFICE_ID, specView.RATING_ID, specView.DATE_METHODS,
+                specView.TEMPLATE_ID, specView.LOCATION_ID, specView.VERSION,
+                specView.SOURCE_AGENCY, specView.ACTIVE_FLAG, specView.AUTO_UPDATE_FLAG,
+                specView.AUTO_ACTIVATE_FLAG, specView.AUTO_MIGRATE_EXT_FLAG,
+                specView.IND_ROUNDING_SPECS, specView.DEP_ROUNDING_SPEC,
+                specView.DESCRIPTION, specView.ALIASED_ITEM,
+                ratView.RATING_SPEC_CODE, ratView.EFFECTIVE_DATE)
+            .from(specView)
+            .join(specPage)
+            .on(specView.RATING_SPEC_CODE.eq(pageSpecCode))
+            .leftOuterJoin(ratView)
+            .on(specView.RATING_SPEC_CODE.eq(ratView.RATING_SPEC_CODE))
+            .where(specView.ALIASED_ITEM.isNull())
+            .fetchSize(DEFAULT_FETCH_SIZE);
 
         logger.atFine().log("%s", lazy(() -> query.getSQL(ParamType.INLINED)));
 
-        Map<RatingSpec, List<ZonedDateTime>> map = new LinkedHashMap<>();
-        try (Stream<? extends Record> stream = query.fetchStream()) {
-            stream.forEach(rec -> {
-                RatingSpec template = buildRatingSpec(rec);
+        // Preserve stable ordering
+        Map<Long, RatingSpec.Builder> specBuilders = new HashMap<>();
+        Map<Long, List<ZonedDateTime>> effectiveDatesBySpec = new HashMap<>();
 
-                Timestamp effectiveDate = rec.get(ratView.EFFECTIVE_DATE);
-                ZonedDateTime effective = toZdt(effectiveDate);
-
-                List<ZonedDateTime> list = map.computeIfAbsent(template, k -> new ArrayList<>());
+        query.fetch()
+            .forEach(rec -> {
+                Long specCode = rec.get(specView.RATING_SPEC_CODE);
+                // create builder only once per specCode
+                specBuilders.computeIfAbsent(specCode, sc -> {
+                    RatingSpec template = buildRatingSpec(rec); // still uses the row, but only once per spec
+                    return new RatingSpec.Builder().fromRatingSpec(template);
+                });
+                ZonedDateTime effective = toZdt(rec.get(ratView.EFFECTIVE_DATE));
                 if (effective != null) {
-                    list.add(effective);
+                    effectiveDatesBySpec.computeIfAbsent(specCode, k -> new ArrayList<>())
+                        .add(effective);
                 }
             });
-        }
-
-        retVal = map.entrySet().stream()
-                .map(entry -> new RatingSpec.Builder()
-                        .fromRatingSpec(entry.getKey())
-                        .withEffectiveDates(entry.getValue())
-                        .build())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-
-        // There should only be one key in the map
-        if (retVal.size() > 1) {
-            throw new IllegalStateException("More than one rating spec found for id: " + specId);
-        }
-
-        return retVal.stream().findFirst();
+        List<RatingSpec> specs = specBuilders.entrySet().stream()
+            .map(e -> {
+                List<ZonedDateTime> dates = effectiveDatesBySpec.get(e.getKey());
+                return e.getValue()
+                    .withEffectiveDates(dates == null ? List.of() : dates)
+                    .build();
+            })
+            .sorted(comparing(RatingSpec::getOfficeId).thenComparing(RatingSpec::getRatingId))
+            .collect(Collectors.toList());
+        RatingSpecs.Builder builder = new RatingSpecs.Builder(offset, pageSize, total);
+        builder.withSpecs(specs);
+        return builder.build();
     }
+
+
+        public Optional<RatingSpec> retrieveRatingSpec(String office, String specId) {
+            RatingSpecs ratingSpecs = retrieveRatingSpecs(null, 1, office, specId);
+            List<RatingSpec> specs = ratingSpecs.getSpecs();
+            if(specs.size() > 1) {
+                throw new IllegalStateException("More than one rating spec found for specId: " + specId);
+            } else if(specs.isEmpty()) {
+                return Optional.empty();
+            } else {
+                return Optional.of(specs.get(0));
+            }
+        }
 
     public static ZonedDateTime toZdt(final Timestamp time) {
         if (time != null) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingSpecs.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/rating/RatingSpecs.java
@@ -73,7 +73,7 @@ public class RatingSpecs extends CwmsDTOPaginated {
         private int offset;
         private int pageSize;
         private Integer total;
-        private List<RatingSpec> specs;
+        private List<RatingSpec> specs = new ArrayList<>();
 
         public Builder() {
         }

--- a/cwms-data-api/src/test/java/cwms/cda/api/rating/RatingSpecControllerPagingIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/rating/RatingSpecControllerPagingIT.java
@@ -1,0 +1,108 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package cwms.cda.api.rating;
+
+import static cwms.cda.api.Controllers.OFFICE;
+import static cwms.cda.api.Controllers.PAGE;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import cwms.cda.api.DataApiTestIT;
+import cwms.cda.formatters.Formats;
+import fixtures.TestAccounts;
+import hec.data.RatingException;
+import hec.data.cwmsRating.RatingSet;
+import io.restassured.filter.log.LogDetail;
+import javax.servlet.http.HttpServletResponse;
+import mil.army.usace.hec.cwms.rating.io.jdbc.RatingJdbcFactory;
+import mil.army.usace.hec.cwms.rating.io.xml.RatingXmlFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import usace.cwms.db.jooq.codegen.packages.CWMS_ENV_PACKAGE;
+
+@Tag("integration")
+class RatingSpecControllerPagingIT extends DataApiTestIT {
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        String locationId = "RatingSpecGetAllPaged";
+        String ratingXml = readResourceFile("cwms/cda/api/RatingSpecGetAllPaged_Stage_Flow_COE_Production.xml");
+        String officeId = "SPK";
+        createLocation(locationId, true, officeId);
+        connectionAsWebUser(c ->{
+            CWMS_ENV_PACKAGE.call_SET_SESSION_OFFICE_ID(dslContext(c).configuration(), "SPK");
+            for(int i = 0; i < RatingSpecController.DEFAULT_PAGE_SIZE * 2; i++) {
+                try {
+                    String xml = ratingXml.replace("{location-id}", locationId)
+                        .replace("{version-template}", "Test" + i);
+                    RatingSet ratingSet = RatingXmlFactory.ratingSet(xml);
+                    RatingJdbcFactory.store(ratingSet, c, true, true);
+                } catch (RatingException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+
+    @Test
+    void test_getAll_paged() {
+        var response = given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .queryParam(OFFICE, "SPK")
+            .queryParam("rating-id-mask", ".*")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/ratings/spec")
+        .then()
+            .assertThat()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("page-size", equalTo(RatingSpecController.DEFAULT_PAGE_SIZE))
+            .body("total", greaterThan(RatingSpecController.DEFAULT_PAGE_SIZE))
+            .body("next-page", notNullValue())
+            .extract();
+        String nextPage = response.path("next-page");
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .queryParam(OFFICE, "SPK")
+            .queryParam(PAGE, nextPage)
+            .queryParam("rating-id-mask", ".*")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/ratings/spec")
+        .then()
+            .assertThat()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .statusCode(is(HttpServletResponse.SC_OK));
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/api/rating/RatingSpecControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/rating/RatingSpecControllerTestIT.java
@@ -45,6 +45,7 @@ import java.util.stream.IntStream;
 
 import static cwms.cda.api.Controllers.METHOD;
 import static cwms.cda.api.Controllers.OFFICE;
+import static cwms.cda.api.Controllers.RATING_ID_MASK;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -106,7 +107,8 @@ class RatingSpecControllerTestIT extends DataApiTestIT {
                 .log().ifValidationFails(LogDetail.ALL,true)
                 .accept(Formats.JSONV2)
                 .contentType(Formats.JSONV2)
-                .queryParam("office", officeId)
+                .queryParam(OFFICE, officeId)
+                .queryParam(RATING_ID_MASK, specContainer.specId)
             .when()
                 .redirects().follow(true)
                 .redirects().max(3)

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/RatingSpecDaoTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/RatingSpecDaoTest.java
@@ -32,7 +32,8 @@ class RatingSpecDaoTest {
         DSLContext lrl = getDslContext(getConnection(), OFFICE_ID);
 
         RatingSpecDao dao = new RatingSpecDao(lrl);
-        Collection<RatingSpec> ratingSpecs = dao.retrieveRatingSpecs(OFFICE_ID, "^ARTH");
+        Collection<RatingSpec> ratingSpecs = dao.retrieveRatingSpecs(null, 1000, OFFICE_ID, "^ARTH")
+            .getSpecs();
         assertNotNull(ratingSpecs);
         assertFalse(ratingSpecs.isEmpty());
 

--- a/cwms-data-api/src/test/resources/cwms/cda/api/RatingSpecGetAllPaged_Stage_Flow_COE_Production.xml
+++ b/cwms-data-api/src/test/resources/cwms/cda/api/RatingSpecGetAllPaged_Stage_Flow_COE_Production.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ratings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.hec.usace.army.mil/xmlSchema/cwms/Ratings.xsd">
+  <rating-template office-id="SPK">
+    <parameters-id>Stage;Flow</parameters-id>
+    <version>COE</version>
+    <ind-parameter-specs>
+      <ind-parameter-spec position="1">
+        <parameter>Stage</parameter>
+        <in-range-method>LINEAR</in-range-method>
+        <out-range-low-method>ERROR</out-range-low-method>
+        <out-range-high-method>ERROR</out-range-high-method>
+      </ind-parameter-spec>
+    </ind-parameter-specs>
+    <dep-parameter>Flow</dep-parameter>
+    <description></description>
+  </rating-template>
+  <rating-spec office-id="SPK">
+    <rating-spec-id>{location-id}.Stage;Flow.COE.{version-template}</rating-spec-id>
+    <template-id>Stage;Flow.COE</template-id>
+    <location-id>{location-id}</location-id>
+    <version>{version-template}</version>
+    <source-agency></source-agency>
+    <in-range-method>LINEAR</in-range-method>
+    <out-range-low-method>NULL</out-range-low-method>
+    <out-range-high-method>NEAREST</out-range-high-method>
+    <active>true</active>
+    <auto-update>false</auto-update>
+    <auto-activate>false</auto-activate>
+    <auto-migrate-extension>false</auto-migrate-extension>
+    <ind-rounding-specs>
+      <ind-rounding-spec position="1">4444444444</ind-rounding-spec>
+    </ind-rounding-specs>
+    <dep-rounding-spec>4444444444</dep-rounding-spec>
+    <description></description>
+  </rating-spec>
+  <simple-rating office-id="SPK">
+    <rating-spec-id>{location-id}.Stage;Flow.COE.{version-template}</rating-spec-id>
+    <units-id>ft;cfs</units-id>
+    <effective-date>2002-04-09T13:53:01Z</effective-date>
+    <create-date>2014-06-11T14:46:00Z</create-date>
+    <active>true</active>
+    <description/>
+    <rating-points>
+      <point>
+        <ind>2.37744006</ind>
+        <dep>14.1584233</dep>
+      </point>
+    </rating-points>
+  </simple-rating>
+</ratings>


### PR DESCRIPTION
- the total size of rating specs was not queries, so next-page was never generated
- optimize the query by paging and filtering just on the rating specs, not the rating specs + effective dates
- optimize `caseInsensitiveLikeRegex` condition for `"*"` and `".*"` by setting it to `noCondition()`. This is especially helpful when columns are concatenations like TSIDs, Rating Ids, etc