### PR TITLE
CDA-44 - Adds location vertical-datum endpoint. Implements vertical-datum conversion for location retreival.

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -81,6 +81,7 @@ import cwms.cda.api.StateController;
 import cwms.cda.api.StreamController;
 import cwms.cda.api.StreamLocationController;
 import cwms.cda.api.StreamReachController;
+import cwms.cda.api.VerticalDatumController;
 import cwms.cda.api.TextTimeSeriesController;
 import cwms.cda.api.TextTimeSeriesValueController;
 import cwms.cda.api.TimeSeriesCategoryController;
@@ -448,6 +449,14 @@ public class ApiServlet extends HttpServlet {
         get("/locations/with-kinds/", new LocationKindController(metrics));
         cdaCrudCache("/locations/{location-id}",
                 new LocationController(metrics), requiredRoles, 5, TimeUnit.MINUTES);
+
+        VerticalDatumController vdiController = new VerticalDatumController(metrics);
+        String vdiPath = format("/location/{%s}/vertical-datum", Controllers.LOCATION_ID);
+        get(vdiPath, ctx -> vdiController.getOne(ctx, ctx.pathParam(Controllers.LOCATION_ID)));
+        addCacheControl(vdiPath, 5, TimeUnit.MINUTES);
+        post(vdiPath, vdiController::create, requiredRoles);
+        patch(vdiPath, ctx -> vdiController.update(ctx, ctx.pathParam(Controllers.LOCATION_ID)), requiredRoles);
+        delete(vdiPath, ctx -> vdiController.delete(ctx, ctx.pathParam(Controllers.LOCATION_ID)), requiredRoles);
         cdaCrudCache("/entity/{entity-id}",
                 new EntityController(metrics), requiredRoles, 5, TimeUnit.MINUTES);
         cdaCrudCache("/states/{state}",

--- a/cwms-data-api/src/main/java/cwms/cda/api/LocationController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LocationController.java
@@ -155,7 +155,7 @@ public class LocationController implements CrudHandler {
             LocationsDao locationsDao = getLocationsDao(dsl);
 
             String names = ctx.queryParam(NAMES);
-            String units = ctx.queryParam(UNIT);
+            String units = ctx.queryParamAsClass(UNIT, String.class).getOrDefault(UnitSystem.SI.value());
             String datum = ctx.queryParam(DATUM);
             String office = ctx.queryParam(OFFICE);
 
@@ -221,6 +221,8 @@ public class LocationController implements CrudHandler {
                         + "default SI units for their parameters."),
                 @OpenApiParam(name = INCLUDE_ALIASES, type = Boolean.class, description = "Specifies whether to "
                         + "include location aliases in the response. Default: false"),
+                @OpenApiParam(name = DATUM, description = "Specifies the elevation datum of"
+                        + " the response. This field affects only vertical datum. Valid values: NAVD88, NGVD29."),
             },
             responses = {
                 @OpenApiResponse(status = STATUS_200,
@@ -241,15 +243,16 @@ public class LocationController implements CrudHandler {
             DSLContext dsl = getDslContext(ctx);
 
             String units =
-                    ctx.queryParamAsClass(UNIT, String.class).getOrDefault(UnitSystem.EN.value());
+                    ctx.queryParamAsClass(UNIT, String.class).getOrDefault(UnitSystem.SI.value());
             String office = requiredParam(ctx, OFFICE);
             boolean includeAliases =
                     ctx.queryParamAsClass(INCLUDE_ALIASES, Boolean.class).getOrDefault(false);
+            String datum = ctx.queryParam(DATUM);
             String formatHeader = ctx.header(Header.ACCEPT);
             ContentType contentType = Formats.parseHeader(formatHeader, Location.class);
             ctx.contentType(contentType.toString());
             LocationsDao locationDao = getLocationsDao(dsl);
-            Location location = locationDao.getLocation(locationId, units, office, includeAliases);
+            Location location = locationDao.getLocation(locationId, units, office, includeAliases, datum);
             String serializedLocation = Formats.format(contentType, location);
             ctx.result(serializedLocation);
             addDeprecatedContentTypeWarning(ctx, contentType);
@@ -335,7 +338,7 @@ public class LocationController implements CrudHandler {
             Location locationFromBody = Formats.parseContent(contentType, ctx.body(), Location.class);
             //getLocation will throw an error if location does not exist
             Location existingLocation = locationsDao.getLocation(locationId,
-                    UnitSystem.EN.getValue(), locationFromBody.getOfficeId(), false);
+                    UnitSystem.EN.getValue(), locationFromBody.getOfficeId(), false, null);
             existingLocation = updatedClearedFields(ctx.body(), contentType.getType(),
                     existingLocation);
             //only store (update) if location does exist

--- a/cwms-data-api/src/main/java/cwms/cda/api/VerticalDatumController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/VerticalDatumController.java
@@ -1,0 +1,228 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package cwms.cda.api;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
+import com.google.common.flogger.FluentLogger;
+import static com.codahale.metrics.MetricRegistry.name;
+import static cwms.cda.api.Controllers.CREATE;
+import static cwms.cda.api.Controllers.DELETE;
+import static cwms.cda.api.Controllers.GET_ONE;
+import static cwms.cda.api.Controllers.LOCATION_ID;
+import static cwms.cda.api.Controllers.OFFICE;
+import static cwms.cda.api.Controllers.RESULTS;
+import static cwms.cda.api.Controllers.SIZE;
+import static cwms.cda.api.Controllers.UNIT;
+import static cwms.cda.api.Controllers.UPDATE;
+import static cwms.cda.api.Controllers.requiredParam;
+import static cwms.cda.data.dao.JooqDao.getDslContext;
+
+import cwms.cda.data.dao.VerticalDatumDao;
+import cwms.cda.data.dto.StatusResponse;
+import cwms.cda.data.dto.VerticalDatumInfo;
+import cwms.cda.formatters.ContentType;
+import cwms.cda.formatters.Formats;
+import io.javalin.apibuilder.CrudHandler;
+import io.javalin.core.util.Header;
+import io.javalin.http.BadRequestResponse;
+import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.HttpMethod;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiContent;
+import io.javalin.plugin.openapi.annotations.OpenApiParam;
+import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+import javax.servlet.http.HttpServletResponse;
+import org.jetbrains.annotations.NotNull;
+import org.jooq.DSLContext;
+
+public final class VerticalDatumController implements CrudHandler {
+
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+    private final MetricRegistry metrics;
+    private final Histogram requestResultSize;
+
+    public VerticalDatumController(MetricRegistry metrics) {
+        this.metrics = metrics;
+        String className = this.getClass().getName();
+        requestResultSize = this.metrics.histogram((name(className, RESULTS, SIZE)));
+    }
+
+    private Timer.Context markAndTime(String subject) {
+        return Controllers.markAndTime(metrics, getClass().getName(), subject);
+    }
+
+    @Override
+    public void getAll(@NotNull Context ctx) {
+        throw new BadRequestResponse("location-id is required in path");
+    }
+
+    @OpenApi(
+            pathParams = {
+                    @OpenApiParam(name = LOCATION_ID, description = "Specifies the location-id.")
+            },
+            queryParams = {
+                    @OpenApiParam(name = OFFICE, required = true, description = "Specifies the owning office."),
+                    @OpenApiParam(name = UNIT, description = "Specifies the unit of measure for elevation/offsets (e.g., m or ft). Default is m.")
+            },
+            responses = {
+                    @OpenApiResponse(status = Controllers.STATUS_200,
+                            content = {@OpenApiContent(type = Formats.JSONV1, from = VerticalDatumInfo.class),
+                                       @OpenApiContent(type = Formats.JSON, from = VerticalDatumInfo.class),
+                                       @OpenApiContent(type = Formats.XMLV1, from = VerticalDatumInfo.class),
+                                       @OpenApiContent(type = Formats.XML, from = VerticalDatumInfo.class)})
+            },
+            description = "Returns Vertical Datum Info for the specified location.",
+            tags = {"Locations"}
+    )
+    @Override
+    public void getOne(@NotNull Context ctx, @NotNull String locationId) {
+        String office = requiredParam(ctx, OFFICE);
+        String units = ctx.queryParamAsClass(UNIT, String.class).getOrDefault("m");
+        try (Timer.Context ignored = markAndTime(GET_ONE)) {
+            DSLContext dsl = getDslContext(ctx);
+            VerticalDatumDao dao = new VerticalDatumDao(dsl);
+            VerticalDatumInfo info = dao.retrieveVerticalDatumInfo(office, locationId, units);
+            String formatHeader = ctx.header(Header.ACCEPT);
+            ContentType contentType = Formats.parseHeader(formatHeader, VerticalDatumInfo.class);
+            ctx.contentType(contentType.toString());
+            String serialized = Formats.format(contentType, info);
+            ctx.result(serialized);
+            ctx.status(HttpServletResponse.SC_OK);
+            requestResultSize.update(serialized.length());
+        }
+    }
+
+    @OpenApi(
+            requestBody = @OpenApiRequestBody(
+                    content = {
+                            @OpenApiContent(from = VerticalDatumInfo.class, type = Formats.JSONV1),
+                            @OpenApiContent(from = VerticalDatumInfo.class, type = Formats.XMLV1)
+                    },
+                    required = true),
+            queryParams = {
+                    @OpenApiParam(name = LOCATION_ID, required = true, description = "Specifies the location id for this vertical-datum-info."),
+                    @OpenApiParam(name = OFFICE, required = true, description = "Specifies the owning office.")
+            },
+            description = "Create Vertical Datum Info for a Location",
+            method = HttpMethod.POST,
+            tags = {"Locations"},
+            responses = {
+                    @OpenApiResponse(status = Controllers.STATUS_201, description = "Vertical Datum Info successfully stored to CWMS.")
+            }
+    )
+    @Override
+    public void create(@NotNull Context ctx) {
+        try (Timer.Context ignored = markAndTime(CREATE)) {
+            String formatHeader = ctx.req.getContentType();
+            ContentType contentType = Formats.parseHeader(formatHeader, VerticalDatumInfo.class);
+            VerticalDatumInfo info = Formats.parseContent(contentType, ctx.body(), VerticalDatumInfo.class);
+            //allow locationId and office to be specified in either the body or as query params, but require them to be present in one of those places
+            String locationId = info.getLocation();
+            String office = info.getOffice();
+            if(locationId == null || locationId.isBlank()) {
+                locationId = requiredParam(ctx, LOCATION_ID);
+            }
+            if(office == null || office.isBlank()) {
+                office = requiredParam(ctx, OFFICE);
+            }
+            DSLContext dsl = getDslContext(ctx);
+            VerticalDatumDao dao = new VerticalDatumDao(dsl);
+            dao.createVerticalDatumInfo(office, locationId, info);
+            StatusResponse re = new StatusResponse(office,
+                    "Vertical Datum Info successfully stored to CWMS.", locationId);
+            ctx.status(HttpServletResponse.SC_CREATED).json(re);
+        }
+    }
+
+    @OpenApi(
+            requestBody = @OpenApiRequestBody(
+                    content = {
+                            @OpenApiContent(from = VerticalDatumInfo.class, type = Formats.JSONV1),
+                            @OpenApiContent(from = VerticalDatumInfo.class, type = Formats.XMLV1)
+                    },
+                    required = true),
+            pathParams = {
+                    @OpenApiParam(name = LOCATION_ID, description = "The ID of the location to update")
+            },
+            queryParams = {
+                    @OpenApiParam(name = OFFICE, required = true, description = "Specifies the owning office.")
+            },
+            description = "Update Vertical Datum Info for a Location",
+            method = HttpMethod.PATCH,
+            tags = {"Locations"},
+            responses = {
+                    @OpenApiResponse(status = Controllers.STATUS_200, description = "Updated Vertical Datum Info")
+            }
+    )
+    @Override
+    public void update(@NotNull Context ctx, @NotNull String locationId) {
+        try (Timer.Context ignored = markAndTime(UPDATE)) {
+            String formatHeader = ctx.req.getContentType();
+            ContentType contentType = Formats.parseHeader(formatHeader, VerticalDatumInfo.class);
+            VerticalDatumInfo info = Formats.parseContent(contentType, ctx.body(), VerticalDatumInfo.class);
+            //allow locationId and office to be specified in either the body or as query params, but require them to be present in one of those places
+            String office = info.getOffice();
+            if(office == null || office.isBlank()) {
+                office = requiredParam(ctx, OFFICE);
+            }
+            DSLContext dsl = getDslContext(ctx);
+            VerticalDatumDao dao = new VerticalDatumDao(dsl);
+            dao.updateVerticalDatumInfo(office, locationId, info);
+            StatusResponse re = new StatusResponse(office,
+                    "Updated Vertical Datum Info", locationId);
+            ctx.status(HttpServletResponse.SC_OK).json(re);
+        }
+    }
+
+    @OpenApi(
+            pathParams = {
+                    @OpenApiParam(name = LOCATION_ID, required = true, description = "Specifies the location-id for the vertical-datum being deleted.")
+            },
+            queryParams = {
+                    @OpenApiParam(name = OFFICE, required = true, description = "Specifies the owning office.")
+            },
+            description = "Delete Vertical Datum Info for a Location",
+            method = HttpMethod.DELETE,
+            tags = {"Locations"},
+            responses = {
+                    @OpenApiResponse(status = Controllers.STATUS_200, description = "Vertical Datum Info successfully deleted from CWMS."),
+                    @OpenApiResponse(status = Controllers.STATUS_404, description = "Vertical Datum Info not found.")
+            }
+    )
+    @Override
+    public void delete(@NotNull Context ctx, @NotNull String locationId) {
+        String office = requiredParam(ctx, OFFICE);
+        try (Timer.Context ignored = markAndTime(DELETE)) {
+            DSLContext dsl = getDslContext(ctx);
+            VerticalDatumDao dao = new VerticalDatumDao(dsl);
+            dao.deleteVerticalDatumInfo(office, locationId);
+            StatusResponse re = new StatusResponse(office,
+                    "Vertical Datum Info successfully deleted from CWMS.", locationId);
+            ctx.status(HttpServletResponse.SC_OK).json(re);
+        }
+    }
+}

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationVerticalDatumConverter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationVerticalDatumConverter.java
@@ -1,0 +1,49 @@
+package cwms.cda.data.dao;
+
+import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.VerticalDatumInfo;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class LocationVerticalDatumConverter {
+
+    private LocationVerticalDatumConverter() {
+        throw new AssertionError("Utility class, don't instantiate");
+    }
+
+    public static Location convertToVerticalDatum(Location originalLocation, VerticalDatum convertTo, VerticalDatumInfo vdi) {
+        if (originalLocation == null || convertTo == null) {
+            return originalLocation;
+        }
+        if (vdi == null) {
+            return originalLocation;
+        }
+        VerticalDatum current = getVerticalDatum(originalLocation).orElse(convertTo);
+        if (Objects.equals(convertTo, current)) {
+            return originalLocation;
+        }
+        VerticalDatumInfo.Offset offset = vdi.getOffsetForDatum(convertTo);
+        if (offset == null) {
+            return originalLocation;
+        }
+        VerticalDatumInfo newVdi = vdi.convertedTo(offset);
+        return new Location.Builder(originalLocation)
+                .withElevation(newVdi.getElevation())
+                .withElevationUnits(newVdi.getUnit())
+                .withVerticalDatum(newVdi.getNativeDatum())
+                .build();
+    }
+
+    public static Optional<VerticalDatum> getVerticalDatum(Location location) {
+        return Optional.ofNullable(location)
+                .map(Location::getVerticalDatum) // unwrap Optional<VerticalDatumInfo>
+                .filter(s -> !s.isBlank())
+                .map(s -> {
+                    if (s.equalsIgnoreCase(VerticalDatum.OTHER.toString())) {
+                        throw new IllegalArgumentException("Vertical Datum of OTHER is not currently supported.");
+                    }
+                    return VerticalDatum.getVerticalDatum(s);
+                });
+    }
+}

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDao.java
@@ -38,7 +38,7 @@ public interface LocationsDao {
 
     List<CwmsIdLocationKind> getLocationKinds(String idRegexMask, String kindRegexMask, String officeId);
 
-    Location getLocation(String locationName, String unitSystem, String officeId, boolean includeAliases) throws IOException;
+    Location getLocation(String locationName, String unitSystem, String officeId, boolean includeAliases, String datum) throws IOException;
 
     Location getLocation(String locationName, String unitSystem, String officeId) throws IOException;
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
@@ -53,6 +53,7 @@ import cwms.cda.data.dto.Catalog;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.data.dto.CwmsIdLocationKind;
 import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.VerticalDatumInfo;
 import cwms.cda.data.dto.catalog.CatalogEntry;
 import cwms.cda.data.dto.catalog.LocationAlias;
 import cwms.cda.data.dto.catalog.LocationCatalogEntry;
@@ -114,26 +115,46 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
     }
 
     public List<Location> getLocations(String nameRegex, String unitSystem, String datum, String officeId) {
+        return connectionResult(dsl, c -> {
+            Configuration configuration = getDslContext(c, officeId).configuration();
+            setOffice(c, officeId);
+            Condition whereCondition = JooqDao.caseInsensitiveLikeRegexNullTrue(AV_LOC.LOCATION_ID, nameRegex);
 
-        Condition whereCondition = JooqDao.caseInsensitiveLikeRegexNullTrue(AV_LOC.LOCATION_ID, nameRegex);
+            if (officeId != null) {
+                whereCondition = whereCondition.and(AV_LOC.DB_OFFICE_ID.equalIgnoreCase(officeId));
+            }
 
-        if (officeId != null) {
-            whereCondition = whereCondition.and(AV_LOC.DB_OFFICE_ID.equalIgnoreCase(officeId));
-        }
+            if (unitSystem != null) {
+                whereCondition = whereCondition.and(AV_LOC.UNIT_SYSTEM.equalIgnoreCase(unitSystem));
+            }
 
-        if (unitSystem != null) {
-            whereCondition = whereCondition.and(AV_LOC.UNIT_SYSTEM.equalIgnoreCase(unitSystem));
-        }
-
-        if (datum != null) {
-            whereCondition = whereCondition.and(AV_LOC.VERTICAL_DATUM.equalIgnoreCase(datum));
-        }
-
-        return dsl.select(AV_LOC.asterisk())
+            List<Location> results = dsl.select(AV_LOC.asterisk())
                     .from(AV_LOC)
                     .where(whereCondition)
                     .fetchSize(DEFAULT_SMALL_FETCH_SIZE)
                     .fetch(this::buildLocation);
+
+            List<Location> finalizedResults = new ArrayList<>();
+            if (datum != null && !datum.isBlank()) {
+                for(Location loc : results) {
+                    loc = convertLocationToVerticalDatum(configuration, loc, datum, officeId);
+                    finalizedResults.add(loc);
+                }
+            }
+            return finalizedResults;
+        });
+    }
+
+    public static Location convertLocationToVerticalDatum(Configuration configuration, Location loc, String datum, String officeId) {
+        String dbVdiXml = CWMS_LOC_PACKAGE.call_GET_VERTICAL_DATUM_INFO_F__2(configuration, loc.getName(), loc.getElevationUnits(), officeId);
+        if (dbVdiXml != null && !dbVdiXml.isBlank()) {
+            VerticalDatumInfo dbVdi = TimeSeriesDaoImpl.parseVerticalDatumInfo(dbVdiXml);
+            VerticalDatum target = VerticalDatum.getVerticalDatum(datum);
+            if (target != null) {
+                loc = LocationVerticalDatumConverter.convertToVerticalDatum(loc, target, dbVdi);
+            }
+        }
+        return loc;
     }
 
     @Override
@@ -156,39 +177,48 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
 
     @Override
     public Location getLocation(String locationName, String unitSystem, String officeId) {
-        return getLocation(locationName, unitSystem, officeId, false);
+        return getLocation(locationName, unitSystem, officeId, false, null);
     }
 
     @Override
-    public Location getLocation(String locationName, String unitSystem, String officeId, boolean includeAliases) {
-        if (includeAliases) {
-            List<Record> locs = dsl.select(asterisk())
-                .from(AV_LOC2.AV_LOC2)
-                .leftJoin(AV_LOC_ALIAS)
-                .on(AV_LOC2.AV_LOC2.BASE_LOCATION_ID.eq(AV_LOC_ALIAS.BASE_LOCATION_ID).and(
-                    AV_LOC2.AV_LOC2.LOCATION_CODE.eq(AV_LOC_ALIAS.LOCATION_CODE.cast(Long.class))))
-                .where(AV_LOC2.AV_LOC2.DB_OFFICE_ID.equalIgnoreCase(officeId)
-                    .and(AV_LOC2.AV_LOC2.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
-                        .and(AV_LOC2.AV_LOC2.LOCATION_ID.equalIgnoreCase(locationName))))
-                .fetch();
-            if (locs.isEmpty()) {
-                throw new NotFoundException("Location not found for office:" + officeId + " and unit "
-                    + "system:" + unitSystem + " and id:" + locationName);
+    public Location getLocation(String locationName, String unitSystem, String officeId, boolean includeAliases, String datum) {
+        return connectionResult(dsl, c -> {
+            Configuration configuration = getDslContext(c, officeId).configuration();
+            setOffice(c, officeId);
+            Location retVal;
+            if (includeAliases) {
+                List<Record> locs = dsl.select(asterisk())
+                        .from(AV_LOC2.AV_LOC2)
+                        .leftJoin(AV_LOC_ALIAS)
+                        .on(AV_LOC2.AV_LOC2.BASE_LOCATION_ID.eq(AV_LOC_ALIAS.BASE_LOCATION_ID).and(
+                                AV_LOC2.AV_LOC2.LOCATION_CODE.eq(AV_LOC_ALIAS.LOCATION_CODE.cast(Long.class))))
+                        .where(AV_LOC2.AV_LOC2.DB_OFFICE_ID.equalIgnoreCase(officeId)
+                                .and(AV_LOC2.AV_LOC2.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
+                                        .and(AV_LOC2.AV_LOC2.LOCATION_ID.equalIgnoreCase(locationName))))
+                        .fetch();
+                if (locs.isEmpty()) {
+                    throw new NotFoundException("Location not found for office:" + officeId + " and unit "
+                            + "system:" + unitSystem + " and id:" + locationName);
+                }
+                retVal = buildLocation(null, locs, true);
+            } else {
+                Record loc = dsl.select(AV_LOC.asterisk())
+                        .from(AV_LOC)
+                        .where(AV_LOC.DB_OFFICE_ID.equalIgnoreCase(officeId)
+                                .and(AV_LOC.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
+                                        .and(AV_LOC.LOCATION_ID.equalIgnoreCase(locationName))))
+                        .fetchOne();
+                if (loc == null) {
+                    throw new NotFoundException("Location not found for office:" + officeId + " and unit "
+                            + "system:" + unitSystem + " and id:" + locationName);
+                }
+                retVal = buildLocation(loc);
             }
-            return buildLocation(null, locs, true);
-        } else {
-            Record loc = dsl.select(AV_LOC.asterisk())
-                .from(AV_LOC)
-                .where(AV_LOC.DB_OFFICE_ID.equalIgnoreCase(officeId)
-                    .and(AV_LOC.UNIT_SYSTEM.equalIgnoreCase(unitSystem)
-                        .and(AV_LOC.LOCATION_ID.equalIgnoreCase(locationName))))
-                .fetchOne();
-            if (loc == null) {
-                throw new NotFoundException("Location not found for office:" + officeId + " and unit "
-                    + "system:" + unitSystem + " and id:" + locationName);
+            if(retVal != null && datum != null && !datum.isBlank()) {
+                retVal = convertLocationToVerticalDatum(configuration, retVal, datum, officeId);
             }
-            return buildLocation(loc);
-        }
+            return retVal;
+        });
     }
 
     private CwmsIdLocationKind buildLocationKind(Record loc) {
@@ -301,9 +331,6 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
         });
     }
 
-    /**
-     * @deprecated Use {@link #storeLocation(Location, boolean)} instead.
-     */
     @Deprecated
     @Override
     public void storeLocation(Location location) throws IOException {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/VerticalDatumDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/VerticalDatumDao.java
@@ -1,0 +1,114 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package cwms.cda.data.dao;
+
+import cwms.cda.api.errors.AlreadyExists;
+import cwms.cda.api.errors.NotFoundException;
+import cwms.cda.data.dto.VerticalDatumInfo;
+import cwms.cda.formatters.xml.XMLv1;
+import org.jooq.DSLContext;
+import org.jooq.Record1;
+import usace.cwms.db.jooq.codegen.packages.CWMS_LOC_PACKAGE;
+import usace.cwms.db.jooq.codegen.tables.AV_VERT_DATUM_OFFSET;
+
+/**
+ * DAO responsible for CRUD operations on Vertical Datum Info for a Location.
+ */
+public final class VerticalDatumDao extends JooqDao<VerticalDatumInfo> {
+
+    public VerticalDatumDao(DSLContext dsl) {
+        super(dsl);
+    }
+
+    public VerticalDatumInfo retrieveVerticalDatumInfo(String officeId, String locationId, String unit) {
+        return connectionResult(dsl, conn -> {
+            DSLContext ctx = getDslContext(conn, officeId);
+            //using jooq to check if exists, because the package get was adding to view if it didn't exist
+            verifyVerticalDatumInfoExists(officeId, locationId);
+            String xml = CWMS_LOC_PACKAGE.call_GET_VERTICAL_DATUM_INFO_F__2(ctx.configuration(), locationId, unit, officeId);
+            return TimeSeriesDaoImpl.parseVerticalDatumInfo(xml);
+        });
+    }
+
+    public void createVerticalDatumInfo(String officeId, String locationId, VerticalDatumInfo vdi) {
+        connection(dsl, conn -> {
+            DSLContext ctx = getDslContext(conn, officeId);
+            verifyVerticalDatumInfoDoesNotExist(officeId, locationId);
+            store(ctx, officeId, locationId, vdi);
+        });
+    }
+
+    public void updateVerticalDatumInfo(String officeId, String locationId, VerticalDatumInfo vdi) {
+        connection(dsl, conn -> {
+            DSLContext ctx = getDslContext(conn, officeId);
+            verifyVerticalDatumInfoExists(officeId, locationId);
+            store(ctx, officeId, locationId, vdi);
+        });
+    }
+
+    private void store(DSLContext ctx, String officeId, String locationId, VerticalDatumInfo vdi) {
+        //we pass in the location and office, and including them in the xml causes store issues in the db so, removing since they aren't necessary
+        VerticalDatumInfo vdiWithoutLocAndOffice = new VerticalDatumInfo.Builder().from(vdi)
+                .withOffice(null)
+                .withLocation(null)
+                .build();
+        String xml = new XMLv1().format(vdiWithoutLocAndOffice);
+        CWMS_LOC_PACKAGE.call_SET_VERTICAL_DATUM_INFO__3(ctx.configuration(), locationId, xml, formatBool(false), officeId);
+    }
+
+
+    public void deleteVerticalDatumInfo(String officeId, String locationId) {
+        connection(dsl, conn -> {
+            DSLContext ctx = getDslContext(conn, officeId);
+            verifyVerticalDatumInfoExists(officeId, locationId);
+            VerticalDatumInfo emptyVdi = new VerticalDatumInfo.Builder()
+                    .withLocation(locationId)
+                    .withOffice(officeId)
+                    .withUnit("m")
+                    .build();
+            String emptyXml = new XMLv1().format(emptyVdi);
+            CWMS_LOC_PACKAGE.call_SET_VERTICAL_DATUM_INFO(ctx.configuration(), emptyXml, formatBool(false));
+            CWMS_LOC_PACKAGE.call_DELETE_LOCAL_VERT_DATUM_NAME__2(ctx.configuration(), locationId, officeId);
+        });
+    }
+
+    private void verifyVerticalDatumInfoExists(String officeId, String locationId) {
+        Record1<usace.cwms.db.jooq.codegen.tables.records.AV_VERT_DATUM_OFFSET> result = dsl.select(AV_VERT_DATUM_OFFSET.AV_VERT_DATUM_OFFSET).from(AV_VERT_DATUM_OFFSET.AV_VERT_DATUM_OFFSET)
+                .where(AV_VERT_DATUM_OFFSET.AV_VERT_DATUM_OFFSET.LOCATION_ID.eq(locationId))
+                .and(AV_VERT_DATUM_OFFSET.AV_VERT_DATUM_OFFSET.OFFICE_ID.eq(officeId))
+                .fetchOne();
+        if(result == null) {
+            throw new NotFoundException("No vertical datum info found for location " + locationId + " in office " + officeId);
+        }
+    }
+
+    private void verifyVerticalDatumInfoDoesNotExist(String officeId, String locationId) {
+        try {
+            verifyVerticalDatumInfoExists(officeId, locationId);
+        } catch (NotFoundException e) {
+            return;
+        }
+        throw new AlreadyExists("Vertical datum info already exists for location " + locationId + " in office " + officeId, null);
+    }
+}

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/VerticalDatumInfo.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/VerticalDatumInfo.java
@@ -10,6 +10,12 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import cwms.cda.data.dao.VerticalDatum;
+import cwms.cda.formatters.Formats;
+import cwms.cda.formatters.annotations.FormattableWith;
+import cwms.cda.formatters.json.JsonV1;
+import cwms.cda.formatters.json.JsonV2;
+import cwms.cda.formatters.xml.XMLv1;
+import cwms.cda.formatters.xml.XMLv2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,11 +27,16 @@ import java.util.stream.Collectors;
 @JsonDeserialize(builder = VerticalDatumInfo.Builder.class)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
+@FormattableWith(contentType = Formats.XMLV1, formatter = XMLv1.class)
+@FormattableWith(contentType = Formats.XMLV2, formatter = XMLv2.class, aliases = {Formats.XML})
+@FormattableWith(contentType = Formats.JSONV2, formatter = JsonV2.class, aliases = {Formats.DEFAULT, Formats.JSON})
+@FormattableWith(contentType = Formats.JSONV1, formatter = JsonV1.class)
 public class VerticalDatumInfo extends CwmsDTOBase {
 
-
+    @JacksonXmlProperty(isAttribute = true)
     String office;
 
+    @JacksonXmlProperty(isAttribute = true)
     String unit;
     String location;
 
@@ -132,6 +143,7 @@ public class VerticalDatumInfo extends CwmsDTOBase {
 
     @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
     public static class Offset {
+        @JacksonXmlProperty(isAttribute = true)
         boolean estimate;
 
         String toDatum;
@@ -268,13 +280,15 @@ public class VerticalDatumInfo extends CwmsDTOBase {
 
         @JsonIgnore
         public Builder from(VerticalDatumInfo vdi) {
-            this.office = vdi.getOffice();
-            this.unit = vdi.getUnit();
-            this.location = vdi.getLocation();
-            this.nativeDatum = vdi.getNativeDatum();
-            this.elevation = vdi.getElevation();
-            this.offsets = vdi.getOffsets();
-            this.localDatumName = vdi.getLocalDatumName();
+            if(vdi != null) {
+                this.office = vdi.getOffice();
+                this.unit = vdi.getUnit();
+                this.location = vdi.getLocation();
+                this.nativeDatum = vdi.getNativeDatum();
+                this.elevation = vdi.getElevation();
+                this.offsets = vdi.getOffsets();
+                this.localDatumName = vdi.getLocalDatumName();
+            }
             return this;
         }
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -363,61 +363,55 @@ class LocationControllerTestIT extends DataApiTestIT {
             // 200.0 native NAVD-88 + (1.2) offset to NGVD-29 = 201.2
             .body("elevation.doubleValue()", closeTo(12.2, 1e-6));
 
-        // Cleanup created VDIs and locations
-        try {
-            given()
-                .log().ifValidationFails(LogDetail.ALL,true)
-                .accept(Formats.JSON)
-                .header("Authorization", user.toHeaderValue())
-                .queryParam(OFFICE, officeId)
-            .when()
-                .redirects().follow(true)
-                .redirects().max(3)
-                .delete("/location/" + locNgvd + "/vertical-datum")
-            .then()
-                .log().ifValidationFails(LogDetail.ALL,true);
-        } catch (Exception ignore) {}
-        try {
-            given()
-                .log().ifValidationFails(LogDetail.ALL,true)
-                .accept(Formats.JSON)
-                .header("Authorization", user.toHeaderValue())
-                .queryParam(OFFICE, officeId)
-            .when()
-                .redirects().follow(true)
-                .redirects().max(3)
-                .delete("/location/" + locNavd + "/vertical-datum")
-            .then()
-                .log().ifValidationFails(LogDetail.ALL,true);
-        } catch (Exception ignore) {}
-        try {
-            given()
-                .log().ifValidationFails(LogDetail.ALL,true)
-                .accept(Formats.JSON)
-                .header("Authorization", user.toHeaderValue())
-                .queryParam(OFFICE, officeId)
-                .queryParam(CASCADE_DELETE, true)
-            .when()
-                .redirects().follow(true)
-                .redirects().max(3)
-                .delete("/locations/" + locNgvd)
-            .then()
-                .log().ifValidationFails(LogDetail.ALL,true);
-        } catch (Exception ignore) {}
-        try {
-            given()
-                .log().ifValidationFails(LogDetail.ALL,true)
-                .accept(Formats.JSON)
-                .header("Authorization", user.toHeaderValue())
-                .queryParam(OFFICE, officeId)
-                .queryParam(CASCADE_DELETE, true)
-            .when()
-                .redirects().follow(true)
-                .redirects().max(3)
-                .delete("/locations/" + locNavd)
-            .then()
-                .log().ifValidationFails(LogDetail.ALL,true);
-        } catch (Exception ignore) {}
+        // clean up VDI and locations
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSON)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(OFFICE, officeId)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/location/" + locNgvd + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true);
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSON)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(OFFICE, officeId)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/location/" + locNavd + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true);
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSON)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(OFFICE, officeId)
+            .queryParam(CASCADE_DELETE, true)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/locations/" + locNgvd)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true);
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSON)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(OFFICE, officeId)
+            .queryParam(CASCADE_DELETE, true)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/locations/" + locNavd)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true);
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -27,6 +27,7 @@ package cwms.cda.api;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import cwms.cda.data.dao.LocationCategoryDao;
 import cwms.cda.data.dao.LocationGroupDao;
+import cwms.cda.data.dao.VerticalDatum;
 import fixtures.CwmsDataApiSetupCallback;
 import java.time.ZoneId;
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ import cwms.cda.data.dto.AssignedLocation;
 import cwms.cda.data.dto.LocationCategory;
 import cwms.cda.data.dto.LocationGroup;
 import cwms.cda.formatters.ContentType;
+import cwms.cda.data.dto.VerticalDatumInfo;
 import fixtures.TestAccounts.KeyUser;
 import io.restassured.filter.log.LogDetail;
 import org.jooq.DSLContext;
@@ -58,6 +60,7 @@ import static cwms.cda.data.dao.JsonRatingUtilsTest.loadResourceAsString;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
@@ -123,6 +126,29 @@ class LocationControllerTestIT extends DataApiTestIT {
                 // ignore
             }
         }
+
+        try {
+            String officeId = "SPK";
+            String json = loadResourceAsString("cwms/cda/api/location_create_spk.json");
+            Location location = new Location.Builder(Formats.parseContent(Formats.parseHeader(Formats.JSON, Location.class), json, Location.class))
+                    .withOfficeId(officeId)
+                    .build();
+            given()
+                    .log().ifValidationFails(LogDetail.ALL,true)
+                    .accept(Formats.JSON)
+                    .header("Authorization", user.toHeaderValue())
+                    .queryParam(OFFICE, officeId)
+                    .queryParam(CASCADE_DELETE, "true")
+            .when()
+                    .redirects().follow(true)
+                    .redirects().max(3)
+                    .delete("/locations/" + location.getName())
+            .then()
+                    .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception e) {
+            //ignore
+        }
+
     }
 
     @Test
@@ -225,6 +251,173 @@ class LocationControllerTestIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
             .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+    }
+
+    @Test
+    void test_get_one_with_datum_param() throws Exception {
+        // Create two locations with explicit native datums
+        String officeId = "SPK";
+        String locNavd = "LocDatumITNAVD88";
+        String locNgvd = "LocDatumITNGVD29";
+
+        // Helpers create and set vertical datum in DB
+        createLocationWithVerticalDatum(locNavd, true, officeId, VerticalDatum.NAVD88);
+        createLocationWithVerticalDatum(locNgvd, true, officeId, VerticalDatum.NGVD29);
+
+        // Create explicit Vertical Datum Info (VDI) with known elevations and offsets
+        // so we can verify the elevation conversion when requesting an alternate datum.
+        KeyUser user = KeyUser.SPK_NORMAL;
+
+        // For NGVD-29 native location, set elevation 100.0 m and an offset to NAVD-88 of -0.5 m
+        VerticalDatumInfo vdiNgvd = new VerticalDatumInfo.Builder()
+            .withOffice(officeId)
+            .withLocation(locNgvd)
+            .withUnit("m")
+            .withNativeDatum("NGVD-29")
+            .withElevation(11.0)
+            .withOffsets(new VerticalDatumInfo.Offset[]{
+                new VerticalDatumInfo.Offset(true, "NAVD-88", -0.5)
+            })
+            .build();
+        ContentType vdiCt = Formats.parseHeader(Formats.JSONV1, VerticalDatumInfo.class);
+        String vdiNgvdBody = Formats.format(vdiCt, vdiNgvd);
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSON)
+            .contentType(Formats.JSONV1)
+            .body(vdiNgvdBody)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(OFFICE, officeId)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/location/" + locNgvd + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED));
+
+        // For NAVD-88 native location, set elevation 200.0 m and an offset to NGVD-29 of +1.2 m
+        VerticalDatumInfo vdiNavd = new VerticalDatumInfo.Builder()
+            .withOffice(officeId)
+            .withLocation(locNavd)
+            .withUnit("m")
+            .withNativeDatum("NAVD-88")
+            .withElevation(11.0)
+            .withOffsets(new VerticalDatumInfo.Offset[]{
+                new VerticalDatumInfo.Offset(true, "NGVD-29", 1.2)
+            })
+            .build();
+        String vdiNavdBody = Formats.format(vdiCt, vdiNavd);
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSON)
+            .contentType(Formats.JSONV1)
+            .body(vdiNavdBody)
+            .header("Authorization", user.toHeaderValue())
+            .queryParam(OFFICE, officeId)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/location/" + locNavd + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED));
+
+        // Request NAVD88 for NGVD29 location
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
+            .queryParam(DATUM, VerticalDatum.NAVD88.toString())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/" + locNgvd)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("vertical-datum", equalTo("NAVD-88"))
+            // 100.0 native NGVD-29 + (-0.5) offset to NAVD-88 = 99.5
+            .body("elevation.doubleValue()", closeTo(10.5, 1e-6));
+
+        // Request NGVD29 for NAVD88 location
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
+            .queryParam(DATUM, VerticalDatum.NGVD29.toString())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/" + locNavd)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("vertical-datum", equalTo("NGVD-29"))
+            // 200.0 native NAVD-88 + (1.2) offset to NGVD-29 = 201.2
+            .body("elevation.doubleValue()", closeTo(12.2, 1e-6));
+
+        // Cleanup created VDIs and locations
+        try {
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(Formats.JSON)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(OFFICE, officeId)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .delete("/location/" + locNgvd + "/vertical-datum")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception ignore) {}
+        try {
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(Formats.JSON)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(OFFICE, officeId)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .delete("/location/" + locNavd + "/vertical-datum")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception ignore) {}
+        try {
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(Formats.JSON)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(OFFICE, officeId)
+                .queryParam(CASCADE_DELETE, true)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .delete("/locations/" + locNgvd)
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception ignore) {}
+        try {
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .accept(Formats.JSON)
+                .header("Authorization", user.toHeaderValue())
+                .queryParam(OFFICE, officeId)
+                .queryParam(CASCADE_DELETE, true)
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .delete("/locations/" + locNavd)
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception ignore) {}
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/api/VerticalDatumControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/VerticalDatumControllerTestIT.java
@@ -1,0 +1,348 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to do so, subject to the
+ * following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package cwms.cda.api;
+
+import static cwms.cda.api.Controllers.OFFICE;
+import static cwms.cda.security.ApiKeyIdentityProvider.AUTH_HEADER;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import cwms.cda.data.dto.VerticalDatumInfo;
+import cwms.cda.formatters.ContentType;
+import cwms.cda.formatters.Formats;
+import fixtures.TestAccounts;
+import fixtures.TestAccounts.KeyUser;
+import io.restassured.filter.log.LogDetail;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import java.util.stream.Stream;
+
+@Tag("integration")
+final class VerticalDatumControllerTestIT extends DataApiTestIT {
+
+    private static final String OFFICE_ID = TestAccounts.KeyUser.SPK_NORMAL.getOperatingOffice();
+
+    private static final String TEST_LOCATION = "VDI_LOC_TEST";
+
+    @BeforeAll
+    static void setup() throws Exception {
+        createLocation(TEST_LOCATION, true, OFFICE_ID);
+    }
+
+
+    @AfterAll
+    static void cleanup() {
+        try {
+            KeyUser user = KeyUser.SPK_NORMAL;
+            given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.XML)
+                .queryParam(OFFICE, OFFICE_ID)
+                .queryParam(Controllers.CASCADE_DELETE, true)
+                .header(AUTH_HEADER, user.toHeaderValue())
+            .when()
+                .delete("/locations/" + TEST_LOCATION)
+            .then()
+                .log().ifValidationFails(LogDetail.ALL, true);
+        } catch (Exception ignore) {
+        }
+
+        try {
+            // DELETE
+            given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.XML)
+                .queryParam(OFFICE, OFFICE_ID)
+                .header(AUTH_HEADER, KeyUser.SPK_NORMAL.toHeaderValue())
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .delete("/location/" + TEST_LOCATION + "/vertical-datum")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL, true);
+        } catch (Exception ignore) {
+        }
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        try {
+            // DELETE
+            given()
+                .log().ifValidationFails(LogDetail.ALL, true)
+                .accept(Formats.XML)
+                .queryParam(OFFICE, OFFICE_ID)
+                .header(AUTH_HEADER, KeyUser.SPK_NORMAL.toHeaderValue())
+            .when()
+                .redirects().follow(true)
+                .redirects().max(3)
+                .delete("/location/" + TEST_LOCATION + "/vertical-datum")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL, true);
+        } catch (Exception ignore) {
+        }
+    }
+
+    @MethodSource("provideFormats")
+    @ParameterizedTest
+    void test_vertical_datum_crud(ContentType contentType) {
+        // Build a VerticalDatumInfo payload
+        VerticalDatumInfo.Offset[] offsets = new VerticalDatumInfo.Offset[] {
+            new VerticalDatumInfo.Offset(true, "NAVD-88", -0.5)
+        };
+        VerticalDatumInfo vdi = new VerticalDatumInfo.Builder()
+            .withOffice(OFFICE_ID)
+            .withLocation(TEST_LOCATION)
+            .withUnit("m")
+            .withNativeDatum("NGVD-29")
+            .withElevation(100.0)
+            .withOffsets(offsets)
+            .build();
+
+        String vdiPayload = Formats.format(contentType, vdi);
+
+        KeyUser user = KeyUser.SPK_NORMAL;
+
+        // CREATE
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .contentType(contentType.toString())
+            .body(vdiPayload)
+            .queryParam(OFFICE, OFFICE_ID)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED));
+
+        // GET
+        String getBody =
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .queryParam(OFFICE, OFFICE_ID)
+            .queryParam(Controllers.UNIT, "m")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .extract()
+            .asString();
+
+        VerticalDatumInfo got = Formats.parseContent(contentType, getBody, VerticalDatumInfo.class);
+        assertEquals(100.0, got.getElevation(), 0.001);
+        assertEquals("NGVD-29", got.getNativeDatum());
+
+        // UPDATE
+        VerticalDatumInfo vdiUpdated = new VerticalDatumInfo.Builder()
+            .from(vdi)
+            .withElevation(101.25)
+            .build();
+        String vdiUpdatedPayload = Formats.format(contentType, vdiUpdated);
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .contentType(contentType.toString())
+            .body(vdiUpdatedPayload)
+            .queryParam(OFFICE, OFFICE_ID)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .patch("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK));
+
+        //VERIFY UPDATE
+        String verifyUpdateBody =
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .queryParam(OFFICE, OFFICE_ID)
+            .queryParam(Controllers.UNIT, "m")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .extract()
+            .asString();
+
+        VerticalDatumInfo gotUpdated = Formats.parseContent(contentType, verifyUpdateBody, VerticalDatumInfo.class);
+        assertEquals(101.25, gotUpdated.getElevation(), 0.001);
+        assertEquals("NGVD-29", gotUpdated.getNativeDatum());
+
+        // DELETE
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .queryParam(OFFICE, OFFICE_ID)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .delete("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK));
+
+        //VERIFY DELETE
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .queryParam(OFFICE, OFFICE_ID)
+            .queryParam(Controllers.UNIT, "m")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+    }
+
+    @MethodSource("provideFormats")
+    @ParameterizedTest
+    void test_create_vertical_datum_already_exists_fails(ContentType contentType) {
+        // Build a VerticalDatumInfo payload
+        VerticalDatumInfo.Offset[] offsets = new VerticalDatumInfo.Offset[] {
+                new VerticalDatumInfo.Offset(true, "NAVD-88", -0.5)
+        };
+        VerticalDatumInfo vdi = new VerticalDatumInfo.Builder()
+                .withOffice(OFFICE_ID)
+                .withLocation(TEST_LOCATION)
+                .withUnit("m")
+                .withNativeDatum("NGVD-29")
+                .withElevation(100.0)
+                .withOffsets(offsets)
+                .build();
+
+        String vdiPayload = Formats.format(contentType, vdi);
+
+        KeyUser user = KeyUser.SPK_NORMAL;
+
+        // First CREATE should succeed
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .contentType(contentType.toString())
+            .body(vdiPayload)
+            .queryParam(OFFICE, OFFICE_ID)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CREATED));
+
+        // Second CREATE with same payload should fail
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .contentType(contentType.toString())
+            .body(vdiPayload)
+            .queryParam(OFFICE, OFFICE_ID)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .post("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_CONFLICT));
+    }
+
+    @MethodSource("provideFormats")
+    @ParameterizedTest
+    void test_update_vertical_datum_not_found_returns_404(ContentType contentType) {
+        // Build a VerticalDatumInfo payload
+        VerticalDatumInfo.Offset[] offsets = new VerticalDatumInfo.Offset[] {
+                new VerticalDatumInfo.Offset(true, "NAVD-88", -0.5)
+        };
+        VerticalDatumInfo vdi = new VerticalDatumInfo.Builder()
+                .withOffice(OFFICE_ID)
+                .withLocation(TEST_LOCATION)
+                .withUnit("m")
+                .withNativeDatum("NGVD-29")
+                .withElevation(100.0)
+                .withOffsets(offsets)
+                .build();
+
+        String vdiPayload = Formats.format(contentType, vdi);
+
+        KeyUser user = KeyUser.SPK_NORMAL;
+        // Attempt UPDATE should return 404 Not Found since no VDI exists yet
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(contentType.toString())
+            .contentType(contentType.toString())
+            .body(vdiPayload)
+            .queryParam(OFFICE, OFFICE_ID)
+            .header(AUTH_HEADER, user.toHeaderValue())
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .patch("/location/" + TEST_LOCATION + "/vertical-datum")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+    }
+
+    static Stream<Arguments> provideFormats() {
+        return Stream.of(
+                Arguments.of(Formats.parseHeader(Formats.XMLV1, VerticalDatumInfo.class)),
+                Arguments.of(Formats.parseHeader(Formats.JSONV1, VerticalDatumInfo.class))
+        );
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/LocationVerticalDatumConverterTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/LocationVerticalDatumConverterTest.java
@@ -1,0 +1,45 @@
+package cwms.cda.data.dao;
+
+import cwms.cda.data.dto.Location;
+import cwms.cda.data.dto.VerticalDatumInfo;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LocationVerticalDatumConverterTest {
+
+    @Test
+    void testConvertVerticalDatumOnLocation() {
+        VerticalDatumInfo.Offset[] offsets = new VerticalDatumInfo.Offset[] {
+                new VerticalDatumInfo.Offset(false, "NGVD-29", 0.0),
+                new VerticalDatumInfo.Offset(false, "NAVD-88", -0.5)
+        };
+        VerticalDatumInfo vdi = new VerticalDatumInfo.Builder()
+                .withOffice("LRL")
+                .withLocation("TEST_LOCATION")
+                .withUnit("m")
+                .withNativeDatum("NGVD-29")
+                .withElevation(100.0)
+                .withOffsets(offsets)
+                .build();
+
+        Location loc = new Location.Builder("TEST_LOCATION", "SITE", ZoneId.of("UTC"),
+                50.0, 50.0, "NGVD29", "LRL")
+                .withElevationUnits("m")
+                .withVerticalDatum("NGVD-29")
+                .withElevation(100.0)
+                .build();
+
+        Location converted = LocationVerticalDatumConverter.convertToVerticalDatum(loc, VerticalDatum.NAVD88, vdi);
+
+        assertEquals("NAVD-88", converted.getVerticalDatum());
+        assertEquals(99.5, converted.getElevation(), 1e-6);
+
+        // round-trip back to NGVD29
+        Location back = LocationVerticalDatumConverter.convertToVerticalDatum(converted, VerticalDatum.NGVD29, vdi);
+        assertEquals("NGVD-29", back.getVerticalDatum());
+        assertEquals(100.0, back.getElevation(), 1e-6);
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/VerticalDatumInfoTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/VerticalDatumInfoTest.java
@@ -122,6 +122,21 @@ class VerticalDatumInfoTest
 		assertVDIEquals(expected, actual);
 	}
 
+    @Test
+    void test_xml_serialize_attributes() {
+        VerticalDatumInfo vdi = new VerticalDatumInfo.Builder()
+                .withOffice("LRL")
+                .withUnit("m")
+                .withLocation("Buckhorn")
+                .withNativeDatum("NGVD-29")
+                .withLocalDatumName("Local Datum Name")
+                .withElevation(230.7)
+                .build();
+        String serialized = new XMLv1().format(vdi);
+        //verify unit and office are attributes not elements since the db expects them as attributes
+        assertTrue(serialized.contains("<vertical-datum-info office=\"LRL\" unit=\"m\""));
+    }
+
 	@Test
 	void testVertDatum1() throws IOException
 	{


### PR DESCRIPTION
Fixes: https://github.com/USACE/cwms-data-api/issues/1577
Part of fix for: https://github.com/USACE/cwms-data-api/issues/1101

CDA-44 - Adds test for both xml and json content-types for vertical datum info

CDA-44 - Improved error handling of create, update, delete. Added workarounds to some db behavior. Adds tests for vertical datum endpoint.

Implements vertical datum endpoint. Failing test needs to be resolved.

Fixed failing tests. Leaving in this state until decision on Location DTO is made to handle VerticalDatumInfo, as we need a means of storing to the datum offset table.

Defaulted units for storing vertical datum location

Reverts much of the DTO with internal json ignored Vertical Datum Info. Updated tests, Updated dao and controller to handle vertical datum info conversions with DTO changes. Assumption that we can only convert if we have a vdi entry in table for location.

adds back store with fail-if-exists param

adds updated json that uses vertical datum info

Fixes broken build. Achieves passing retrieval test.

adds vertical datum info to retrieved location data. Adds conversion logic. Adds integration tests.

CDA-44 - DTO updates and converter added on update and update to table on create