### PR TITLE
Devops/update keycloak

### DIFF
--- a/compose_files/keycloak/healthcheck.sh
+++ b/compose_files/keycloak/healthcheck.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+{ printf 'HEAD /auth/health/ready HTTP/1.0\r\n\r\n' >&0; grep 'HTTP/1.0 200'; } 0<>/dev/tcp/localhost/9000

--- a/cwms-data-api/logging.properties
+++ b/cwms-data-api/logging.properties
@@ -67,7 +67,8 @@ org.apache.catalina.core.ContainerBase.[Catalina].[localhost].[/cwms-data].handl
 
 fixtures.level=FINE
 cwms.cda.datasource.level=FINE
-org.apache.level=FINE
+org.apache.level=ERROR
+org.apache.tomcat.jdbc.pool.level=INFO
 org.apache.catalina.realm.level=INFO
 org.apache.catalina.realm.useParentHandlers=true
 org.apache.catalina.authenticator.level=INFO

--- a/cwms-data-api/src/test/resources/tomcat/conf/context.xml
+++ b/cwms-data-api/src/test/resources/tomcat/conf/context.xml
@@ -16,7 +16,7 @@
               testWhileIdle="true"
               timeBetweenEvictionRunsMillis="5000"
               logValidationErrors="true"
-              suspectTimeout="15"
+              suspectTimeout="8"
               jdbcInterceptors="QueryTimeoutInterceptor(queryTimeout=600);StatementFinalizer(trace=true);StatementCache(callable=true);SlowQueryReport(threshold=5000);ResetAbandonedTimer"
               logAbandoned="true"
               maxAge="3600000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,9 +109,9 @@ services:
 
   auth:
     image: quay.io/keycloak/keycloak:26.5
-    command: ["start-dev","--import-realm"]
+    command: ["start-dev", "--import-realm"]
     healthcheck:
-      test: "/usr/bin/curl -If localhost:${APP_PORT:-8081}/auth/health/ready || exit 1"
+      test: "/healthcheck.sh"
       interval: 5s
       timeout: 1s
       retries: 100


### PR DESCRIPTION
Updates keycloak to a version that continuous to run in gh actions (weird, but not gonna worry about it as we *should* keep that up to date.

Also partially reverts a change made in #1586 that incorrectly sets the user session to the provided office id, which is intended purely as a search constraint.