### PR TITLE
1622 data query tool should have a refresh button

### DIFF
--- a/cda-gui/.env.development
+++ b/cda-gui/.env.development
@@ -1,1 +1,1 @@
-CDA_API_ROOT=https://water.dev.cwbi.us/cwms-data
+VITE_CDA_API_ROOT=https://water.dev.cwbi.us/cwms-data

--- a/cda-gui/.env.production
+++ b/cda-gui/.env.production
@@ -1,1 +1,1 @@
-CDA_API_ROOT=https://cwms-data.usace.army.mil/cwms-data
+VITE_CDA_API_ROOT=https://cwms-data.usace.army.mil/cwms-data

--- a/cda-gui/.env.test
+++ b/cda-gui/.env.test
@@ -1,1 +1,1 @@
-CDA_API_ROOT=https://cwms-data-test.cwbi.us/cwms-data
+VITE_CDA_API_ROOT=https://cwms-data-test.cwbi.us/cwms-data

--- a/cda-gui/src/pages/data-query/components/DataTabs.jsx
+++ b/cda-gui/src/pages/data-query/components/DataTabs.jsx
@@ -13,6 +13,7 @@ export default function DataTabs({
   timeseriesParams,
   begin,
   end,
+  sortAscending,
 }) {
   if (!tsids || !tsids.length) return null;
   if (isLoading) return <Skeleton type="card" className="w-full h-[500px]" />;
@@ -38,7 +39,7 @@ export default function DataTabs({
                   dateFormat="YYYY-MM-DD HH:mm:ss"
                   interval="5"
                   missingString="---"
-                  sortAscending
+                  sortAscending={sortAscending}
                   trim
                   pageSize={1000000}
                   tableOptions={{
@@ -116,4 +117,5 @@ DataTabs.propTypes = {
   timeseriesParams: PropTypes.array,
   begin: PropTypes.object.isRequired,
   end: PropTypes.object.isRequired,
+  sortAscending: PropTypes.bool.isRequired,
 };

--- a/cda-gui/src/pages/data-query/components/SettingsGearButton.jsx
+++ b/cda-gui/src/pages/data-query/components/SettingsGearButton.jsx
@@ -1,0 +1,32 @@
+import { forwardRef } from "react";
+import PropTypes from "prop-types";
+import { FiSettings } from "react-icons/fi";
+
+const SettingsGearButton = forwardRef(function SettingsGearButton(
+  { active = false, className = "", ...props },
+  ref,
+) {
+  const activeClassName = active
+    ? "border-red-200 bg-red-50 text-red-600 hover:bg-red-100"
+    : "border-slate-300 bg-white text-slate-700 hover:bg-slate-50";
+
+  return (
+    <button
+      {...props}
+      ref={ref}
+      type="button"
+      className={`inline-flex items-center justify-center gap-2 rounded border px-3 py-2 shadow-sm transition ${activeClassName} ${className}`.trim()}
+    >
+      <span className="text-sm font-medium">Query Settings</span>
+      <FiSettings className="h-5 w-5" aria-hidden="true" />
+      <span className="sr-only">Open query settings</span>
+    </button>
+  );
+});
+
+SettingsGearButton.propTypes = {
+  active: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default SettingsGearButton;

--- a/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
+++ b/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
@@ -3,7 +3,13 @@ import PropTypes from "prop-types";
 import Toggle from "./Toggle";
 import SettingsGearButton from "./SettingsGearButton";
 
-export default function SettingsMenu({ cacheEnabled, setCacheEnabled, active }) {
+export default function SettingsMenu({
+  cacheEnabled,
+  setCacheEnabled,
+  sortAscending,
+  setSortAscending,
+  active,
+}) {
   return (
     <Menu as="div" className="relative inline-block text-left">
       <MenuButton as={SettingsGearButton} active={active} />
@@ -24,6 +30,24 @@ export default function SettingsMenu({ cacheEnabled, setCacheEnabled, active }) 
             />
           </div>
         </MenuItem>
+        <MenuItem>
+          <div className="mt-4 flex items-start justify-between gap-4">
+            <div>
+              <div className="text-sm font-semibold text-slate-900">
+                Ascending table order
+              </div>
+              <p className="text-xs text-slate-600">
+                Show the oldest timestamps first. Disable to show newest rows first.
+              </p>
+            </div>
+            <Toggle
+              checked={sortAscending}
+              onChange={setSortAscending}
+              label=""
+              className="ml-0"
+            />
+          </div>
+        </MenuItem>
       </MenuItems>
     </Menu>
   );
@@ -33,4 +57,6 @@ SettingsMenu.propTypes = {
   active: PropTypes.bool,
   cacheEnabled: PropTypes.bool.isRequired,
   setCacheEnabled: PropTypes.func.isRequired,
+  setSortAscending: PropTypes.func.isRequired,
+  sortAscending: PropTypes.bool.isRequired,
 };

--- a/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
+++ b/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
@@ -1,0 +1,36 @@
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import PropTypes from "prop-types";
+import Toggle from "./Toggle";
+import SettingsGearButton from "./SettingsGearButton";
+
+export default function SettingsMenu({ cacheEnabled, setCacheEnabled, active }) {
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      <MenuButton as={SettingsGearButton} active={active} />
+      <MenuItems className="absolute right-0 z-10 mt-2 w-72 rounded-md border border-slate-200 bg-white p-4 shadow-lg focus:outline-none">
+        <MenuItem>
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="text-sm font-semibold text-slate-900">Enable cache</div>
+              <p className="text-xs text-slate-600">
+                Use browser cache for repeated requests. Disable to force fresh fetches.
+              </p>
+            </div>
+            <Toggle
+              checked={cacheEnabled}
+              onChange={setCacheEnabled}
+              label=""
+              className="ml-0"
+            />
+          </div>
+        </MenuItem>
+      </MenuItems>
+    </Menu>
+  );
+}
+
+SettingsMenu.propTypes = {
+  active: PropTypes.bool,
+  cacheEnabled: PropTypes.bool.isRequired,
+  setCacheEnabled: PropTypes.func.isRequired,
+};

--- a/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
+++ b/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
@@ -34,15 +34,15 @@ export default function SettingsMenu({
           <div className="mt-4 flex items-start justify-between gap-4">
             <div>
               <div className="text-sm font-semibold text-slate-900">
-                Ascending table order
+                Descending table order
               </div>
               <p className="text-xs text-slate-600">
-                Show the oldest timestamps first. Disable to show newest rows first.
+                Keep newest timestamps first. Disable to switch to oldest rows first.
               </p>
             </div>
             <Toggle
-              checked={sortAscending}
-              onChange={setSortAscending}
+              checked={!sortAscending}
+              onChange={(checked) => setSortAscending(!checked)}
               label=""
               className="ml-0"
             />

--- a/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
+++ b/cda-gui/src/pages/data-query/components/SettingsMenu.jsx
@@ -25,7 +25,6 @@ export default function SettingsMenu({
             <Toggle
               checked={cacheEnabled}
               onChange={setCacheEnabled}
-              label=""
               className="ml-0"
             />
           </div>
@@ -43,7 +42,6 @@ export default function SettingsMenu({
             <Toggle
               checked={!sortAscending}
               onChange={(checked) => setSortAscending(!checked)}
-              label=""
               className="ml-0"
             />
           </div>

--- a/cda-gui/src/pages/data-query/components/TimeSeriesDropdown.jsx
+++ b/cda-gui/src/pages/data-query/components/TimeSeriesDropdown.jsx
@@ -76,6 +76,11 @@ export default function TimeSeriesDropdown({ office, tsids, setTsids }) {
             onChange={(event) => setSearchTerm(event.target.value)}
             className="px-3 py-2 border rounded w-full"
             placeholder="Search TSID (e.g. Location.Elev.Inst.1Hour.0.Version)"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            name="tsid-search"
           />
           <ComboboxOptions className="bg-white border mt-1 max-h-60 overflow-auto">
             {loading ? (

--- a/cda-gui/src/pages/data-query/components/TimeSeriesDropdown.jsx
+++ b/cda-gui/src/pages/data-query/components/TimeSeriesDropdown.jsx
@@ -14,7 +14,7 @@ import { useDebounce } from "use-debounce";
 // Catalog client
 const catalogApi = new CatalogApi(
   new Configuration({
-    basePath: import.meta.env.CDA_URL,
+    basePath: import.meta.env.VITE_CDA_API_ROOT,
     headers: { accept: "application/json;version=2" },
   }),
 );

--- a/cda-gui/src/pages/data-query/hooks/useAliases.js
+++ b/cda-gui/src/pages/data-query/hooks/useAliases.js
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { CatalogApi, Configuration } from "cwmsjs";
 
-const CDA_URL = import.meta.env.CDA_URL;
+const CDA_URL = import.meta.env.VITE_CDA_API_ROOT;
 const config = new Configuration({
   basePath: CDA_URL,
 });

--- a/cda-gui/src/pages/data-query/hooks/useConfigList.js
+++ b/cda-gui/src/pages/data-query/hooks/useConfigList.js
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { BlobApi, Configuration } from "cwmsjs";
 
-const CDA_URL = import.meta.env.CDA_URL;
+const CDA_URL = import.meta.env.VITE_CDA_API_ROOT;
 const config = new Configuration({
   basePath: CDA_URL,
 });

--- a/cda-gui/src/pages/data-query/hooks/useDescriptors.js
+++ b/cda-gui/src/pages/data-query/hooks/useDescriptors.js
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Configuration, CatalogApi } from "cwmsjs";
 
 const config = new Configuration({
-  basePath: import.meta.env.CDA_URL,
+  basePath: import.meta.env.VITE_CDA_API_ROOT,
 });
 const cataApi = new CatalogApi(config);
 

--- a/cda-gui/src/pages/data-query/hooks/useOffices.js
+++ b/cda-gui/src/pages/data-query/hooks/useOffices.js
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Configuration, OfficesApi } from "cwmsjs";
 
-const CDA_URL = import.meta.env.CDA_URL;
+const CDA_URL = import.meta.env.VITE_CDA_API_ROOT;
 const config = new Configuration({
   basePath: CDA_URL,
 });

--- a/cda-gui/src/pages/data-query/hooks/useParams.js
+++ b/cda-gui/src/pages/data-query/hooks/useParams.js
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Configuration, ParametersApi } from "cwmsjs";
 
-const CDA_URL = import.meta.env.CDA_URL;
+const CDA_URL = import.meta.env.VITE_CDA_API_ROOT;
 const config = new Configuration({
   basePath: CDA_URL,
 });

--- a/cda-gui/src/pages/data-query/index.jsx
+++ b/cda-gui/src/pages/data-query/index.jsx
@@ -23,7 +23,9 @@ const v2_config = new Configuration({
 const ts_api = new TimeSeriesApi(v2_config);
 const offices_api = new OfficesApi();
 const DATA_QUERY_CACHE_KEY = "data-query-cache-enabled";
+const DATA_QUERY_SORT_ASC_KEY = "data-query-sort-ascending";
 const DEFAULT_CACHE_ENABLED = true;
+const DEFAULT_SORT_ASCENDING = true;
 
 // const config = cwmsConfigs["SWF"];
 // async function fetchConfig(configUrl) {
@@ -41,6 +43,11 @@ export default function DataQuery() {
     const storedValue = window.localStorage.getItem(DATA_QUERY_CACHE_KEY);
     return storedValue === null ? DEFAULT_CACHE_ENABLED : storedValue === "true";
   });
+  const [sortAscending, setSortAscending] = useState(() => {
+    if (typeof window === "undefined") return DEFAULT_SORT_ASCENDING;
+    const storedValue = window.localStorage.getItem(DATA_QUERY_SORT_ASC_KEY);
+    return storedValue === null ? DEFAULT_SORT_ASCENDING : storedValue === "true";
+  });
   //   const [location, setLocation] = useState(null);
   //   const [parameter, setParameter] = useState(null);
   //   const [interval, setInterval] = useState(null);
@@ -55,6 +62,14 @@ export default function DataQuery() {
       window.localStorage.setItem(DATA_QUERY_CACHE_KEY, String(cacheEnabled));
     }
   }, [cacheEnabled]);
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        DATA_QUERY_SORT_ASC_KEY,
+        String(sortAscending),
+      );
+    }
+  }, [sortAscending]);
 
   const toggleTSID = (tsid) =>
     setVisibleTSIDs((prev) =>
@@ -267,7 +282,9 @@ export default function DataQuery() {
       setIsRefreshing(false);
     }
   };
-  const hasActiveSettings = cacheEnabled !== DEFAULT_CACHE_ENABLED;
+  const hasActiveSettings =
+    cacheEnabled !== DEFAULT_CACHE_ENABLED ||
+    sortAscending !== DEFAULT_SORT_ASCENDING;
 
   if (error)
     return (
@@ -287,6 +304,8 @@ export default function DataQuery() {
           <SettingsMenu
             cacheEnabled={cacheEnabled}
             setCacheEnabled={setCacheEnabled}
+            sortAscending={sortAscending}
+            setSortAscending={setSortAscending}
             active={hasActiveSettings}
           />
         </div>
@@ -420,6 +439,7 @@ export default function DataQuery() {
               isLoading={timeseriesLoading}
               cdaParams={cdaParams}
               timeseriesParams={timeseriesParams}
+              sortAscending={sortAscending}
             />
           )}
         </div>

--- a/cda-gui/src/pages/data-query/index.jsx
+++ b/cda-gui/src/pages/data-query/index.jsx
@@ -12,6 +12,7 @@ import DataTabs from "./components/DataTabs";
 import Toggle from "./components/Toggle";
 import TimeSeriesBuilder from "./components/TimeSeriesBuilder";
 import TimeSeriesManager from "./components/TimeSeriesManager";
+import SettingsMenu from "./components/SettingsMenu";
 const CDA_DATE_FORMAT = "YYYY-MM-DDTHH:mm:ssZ";
 
 const v2_config = new Configuration({
@@ -21,6 +22,8 @@ const v2_config = new Configuration({
 });
 const ts_api = new TimeSeriesApi(v2_config);
 const offices_api = new OfficesApi();
+const DATA_QUERY_CACHE_KEY = "data-query-cache-enabled";
+const DEFAULT_CACHE_ENABLED = true;
 
 // const config = cwmsConfigs["SWF"];
 // async function fetchConfig(configUrl) {
@@ -32,6 +35,12 @@ const offices_api = new OfficesApi();
 export default function DataQuery() {
   const [tsids, setTsids] = useState([]);
   const [visibleTSIDs, setVisibleTSIDs] = useState(tsids);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [cacheEnabled, setCacheEnabled] = useState(() => {
+    if (typeof window === "undefined") return DEFAULT_CACHE_ENABLED;
+    const storedValue = window.localStorage.getItem(DATA_QUERY_CACHE_KEY);
+    return storedValue === null ? DEFAULT_CACHE_ENABLED : storedValue === "true";
+  });
   //   const [location, setLocation] = useState(null);
   //   const [parameter, setParameter] = useState(null);
   //   const [interval, setInterval] = useState(null);
@@ -41,6 +50,11 @@ export default function DataQuery() {
     // Reset visible list when tsids change
     setVisibleTSIDs(tsids);
   }, [tsids]);
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(DATA_QUERY_CACHE_KEY, String(cacheEnabled));
+    }
+  }, [cacheEnabled]);
 
   const toggleTSID = (tsid) =>
     setVisibleTSIDs((prev) =>
@@ -61,7 +75,7 @@ export default function DataQuery() {
   const [beginDateTime, setBeginDateTime] = useState(dayjs().subtract(1, "day"));
   const [endDateTime, setEndDateTime] = useState(dayjs());
 
-  async function fetchAllTSData(data) {
+  async function fetchAllTSData(data, requestOverrides) {
     let startDate = data?.begin;
     let endDate = data?.end;
     let values = data?.values;
@@ -69,16 +83,19 @@ export default function DataQuery() {
     const maxPages = 200;
     let pageCount = 0;
     while (nextPage) {
-      let _result = await ts_api.getTimeSeries({
-        begin: startDate,
-        end: endDate,
-        name,
-        office,
-        page: nextPage,
-        pageSize: 25000,
-        // begin: beginDateTime.format(CDA_DATE_FORMAT),
-        // end: endDateTime.format(CDA_DATE_FORMAT),
-      });
+      let _result = await ts_api.getTimeSeries(
+        {
+          begin: startDate,
+          end: endDate,
+          name,
+          office,
+          page: nextPage,
+          pageSize: 25000,
+          // begin: beginDateTime.format(CDA_DATE_FORMAT),
+          // end: endDateTime.format(CDA_DATE_FORMAT),
+        },
+        requestOverrides,
+      );
       // if (!_result?.page) page = false
       nextPage = _result?.nextPage;
       endDate = _result?.end;
@@ -102,24 +119,40 @@ export default function DataQuery() {
   const {
     data: timeseriesData,
     isLoading: timeseriesLoading,
+    refetch: refetchTimeseries,
     error,
   } = useQuery({
-    queryKey: ["cdaTimeSeries", tsids, office, beginDateTime, endDateTime],
+    queryKey: [
+      "cdaTimeSeries",
+      tsids,
+      office,
+      beginDateTime,
+      endDateTime,
+      cacheEnabled,
+    ],
 
     queryFn: async () => {
+      const requestOverrides = cacheEnabled
+        ? undefined
+        : {
+            cache: "no-store",
+          };
       const promises = tsids.map((tsid) => {
         return ts_api
-          .getTimeSeriesRaw({
-            name: tsid,
-            office: office,
-            begin: beginDateTime.format(CDA_DATE_FORMAT),
-            end: endDateTime.format(CDA_DATE_FORMAT),
-            pageSize: 25000,
-          })
+          .getTimeSeriesRaw(
+            {
+              name: tsid,
+              office: office,
+              begin: beginDateTime.format(CDA_DATE_FORMAT),
+              end: endDateTime.format(CDA_DATE_FORMAT),
+              pageSize: 25000,
+            },
+            requestOverrides,
+          )
           .then(async (r) => {
             if (r.raw.ok) {
               let _data = await r.raw.json();
-              return await fetchAllTSData(_data);
+              return await fetchAllTSData(_data, requestOverrides);
             } else return { name: tsid, values: [], message: r.raw.text };
           })
           .catch((e) => {
@@ -141,6 +174,8 @@ export default function DataQuery() {
           tsid.split(".").every((part) => part.trim() !== ""),
       ) &&
       office !== undefined,
+    staleTime: cacheEnabled ? 1000 * 60 * 5 : 0,
+    gcTime: cacheEnabled ? 1000 * 60 * 30 : 0,
   });
 
   const timeseriesParams = useMemo(() => {
@@ -224,6 +259,15 @@ export default function DataQuery() {
     link.click();
     document.body.removeChild(link);
   };
+  const handleRefreshTimeseries = async () => {
+    setIsRefreshing(true);
+    try {
+      await refetchTimeseries();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+  const hasActiveSettings = cacheEnabled !== DEFAULT_CACHE_ENABLED;
 
   if (error)
     return (
@@ -239,6 +283,13 @@ export default function DataQuery() {
   return (
     <div className="px-5">
       <UsaceBox title="Hydrologic Query">
+        <div className="mb-4 flex justify-end">
+          <SettingsMenu
+            cacheEnabled={cacheEnabled}
+            setCacheEnabled={setCacheEnabled}
+            active={hasActiveSettings}
+          />
+        </div>
         <div className="flex flex-col lg:flex-row gap-4">
           <div className="flex flex-col gap-4 w-4/5 md:w-3/5">
             <div className={!office ? "text-lg m-auto" : "flex gap-4"}>
@@ -334,6 +385,15 @@ export default function DataQuery() {
               }`}
             >
               Download JSON
+            </Button>
+            <Button
+              onClick={handleRefreshTimeseries}
+              disabled={!tsids.length || !office || isRefreshing}
+              className={`mb-4 bg-slate-700 text-white px-4 py-2 rounded ms-2 ${
+                !tsids.length || !office ? "hidden" : ""
+              }`}
+            >
+              {isRefreshing ? "Refreshing..." : "Refresh Data"}
             </Button>
           </div>
 

--- a/cda-gui/src/pages/data-query/index.jsx
+++ b/cda-gui/src/pages/data-query/index.jsx
@@ -25,7 +25,7 @@ const offices_api = new OfficesApi();
 const DATA_QUERY_CACHE_KEY = "data-query-cache-enabled";
 const DATA_QUERY_SORT_ASC_KEY = "data-query-sort-ascending";
 const DEFAULT_CACHE_ENABLED = true;
-const DEFAULT_SORT_ASCENDING = true;
+const DEFAULT_SORT_ASCENDING = false;
 
 // const config = cwmsConfigs["SWF"];
 // async function fetchConfig(configUrl) {

--- a/cda-gui/vite.config.js
+++ b/cda-gui/vite.config.js
@@ -5,12 +5,10 @@ import react from "@vitejs/plugin-react";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   // const BASE_PATH = env?.BASE_PATH ?? "/cwms-data";
+  console.log({ CDA_API_ROOT: env.VITE_CDA_API_ROOT });
   return {
     base: "/cwms-data",
     plugins: [react()],
-    define: {
-      "import.meta.env.CDA_URL": JSON.stringify("/cwms-data"),
-    },
     server: {
       proxy: {
         "^/cwms-data/timeseries/.*": {

--- a/cda-gui/vite.config.js
+++ b/cda-gui/vite.config.js
@@ -5,7 +5,6 @@ import react from "@vitejs/plugin-react";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   // const BASE_PATH = env?.BASE_PATH ?? "/cwms-data";
-  console.log({ CDA_API_ROOT: env.VITE_CDA_API_ROOT });
   return {
     base: "/cwms-data",
     plugins: [react()],


### PR DESCRIPTION
- Fixes env var naming
- Adds a refresh button
- adds new menu icon
  - Enable / Disable Cache (state / browser)
  - Set asc/desc order
  - make settings menu icon red when something is disabled (cache)
- Change table to desc by default
- Disable the auto complete default input box features to ensure they do not get in the way of the smart input items (combobox items)

Various snippets:
<img width="1419" height="1055" alt="image" src="https://github.com/user-attachments/assets/3dfe6a13-42c7-4ed4-a620-19293437783f" />
<img width="879" height="262" alt="image" src="https://github.com/user-attachments/assets/d030e616-eb33-46c3-886b-b30b898802d7" />
