### PR TITLE
Fix broken relative swagger doc link

### DIFF
--- a/cda-gui/src/links/header-links.js
+++ b/cda-gui/src/links/header-links.js
@@ -17,7 +17,7 @@ export default [
       {
         id: "swagger-schema",
         text: "Swagger Docs Schema",
-        href: "swagger-docs",
+        href: "/cwms-data/swagger-docs",
       },
     ],
   },


### PR DESCRIPTION
Confirmed the following does work

https://cwms-data.usace.army.mil/cwms-data/swagger-docs

Without the absolute path to /cwms-data it was assuming `/cwms-data/swagger-ui/swagger-docs`