### PR TITLE
Duplicate root replaced

### DIFF
--- a/cda-gui/src/links/header-links.js
+++ b/cda-gui/src/links/header-links.js
@@ -17,7 +17,7 @@ export default [
       {
         id: "swagger-schema",
         text: "Swagger Docs Schema",
-        href: "/cwms-data/swagger-docs",
+        href: "/swagger-docs",
       },
     ],
   },


### PR DESCRIPTION
Testing this on dev I realized it is adding the /cwms-data root again. 

Forgot we are using a different router on CDA. 