### PR TITLE
CDA-105: Updated authentication error message for expired API keys

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -43,7 +43,6 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpServletResponse;
 import javax.sql.DataSource;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
@@ -56,6 +55,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
     public static final String SCHEMA_TOO_OLD = "The CWMS-Data-API requires schema version "
                                              + "23.03.16 or later to handle authorization operations.";
     public static final String DATA_API_PRINCIPAL = "DataApiPrincipal";
+    public static final String AUTH_ERROR_MSG = "Authentication failed. The API Key may be invalid or no longer active.";
     // At this level we just care that the user has permissions in *any* office
     private static final String RETRIEVE_GROUPS_OF_USER =
             ResourceHelper.getResourceAsString("/cwms/data/sql/user_groups.sql", AuthDao.class);
@@ -204,8 +204,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                         if (rs.next()) {
                             return rs.getString(1);
                         } else {
-                            throw new CwmsAuthException("Authentication failed. "
-                                + "The API Key may be invalid or no longer active.");
+                            throw new CwmsAuthException(AUTH_ERROR_MSG);
                         }
                     }
                 } catch (SQLException ex) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -204,7 +204,8 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                         if (rs.next()) {
                             return rs.getString(1);
                         } else {
-                            throw new CwmsAuthException("No user for key");
+                            throw new CwmsAuthException("Authentication failed. "
+                                + "The API Key may be invalid or no longer active.");
                         }
                     }
                 } catch (SQLException ex) {

--- a/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
@@ -26,6 +26,7 @@ import io.javalin.http.HttpCode;
 import io.restassured.filter.log.LogDetail;
 import io.restassured.specification.RequestSpecification;
 
+import static cwms.cda.data.dao.AuthDao.AUTH_ERROR_MSG;
 import static cwms.cda.data.dao.JsonRatingUtilsTest.loadResourceAsString;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -270,8 +271,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
             .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()))
-            .body("message", is("Authentication failed. "
-                + "The API Key may be invalid or no longer active."));
+            .body("message", is(AUTH_ERROR_MSG));
         // fail to use no existent key
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
@@ -287,8 +287,7 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
             .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()))
-            .body("message", is("Authentication failed. "
-                + "The API Key may be invalid or no longer active."));
+            .body("message", is(AUTH_ERROR_MSG));
     }
 
     @Order(6)

--- a/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
@@ -269,7 +269,9 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
-            .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()));
+            .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()))
+            .body("message", is("Authentication failed. "
+                + "The API Key may be invalid or no longer active."));
         // fail to use no existent key
         given()
             .log().ifValidationFails(LogDetail.ALL,true)
@@ -284,7 +286,9 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
         .then()
             .log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
-            .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()));
+            .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()))
+            .body("message", is("Authentication failed. "
+                + "The API Key may be invalid or no longer active."));
     }
 
     @Order(6)


### PR DESCRIPTION
Resolves #1554 

Updates API key error message from `no user for key` to `Authentication failed. The API Key may be invalid or no longer active.` 