### PR TITLE
Devops/build updates

### DIFF
--- a/.github/actions/badge/action.yml
+++ b/.github/actions/badge/action.yml
@@ -1,0 +1,58 @@
+name: 'Create badge'
+description: Create and upload a custom badge
+inputs:
+  label:
+    type: string
+    description: Badge name
+    required: true
+  status:
+    type: string
+    description: Status. Pass/Fail, or numeric, Pass will set color to green, Fail to red, anything else is blue.
+    required: true
+  file:
+    type: string
+    description: Name of file to create, can include folders
+    required: true
+  run_id:
+    type: number
+    description: The value of github.run_id, or another appropriate tracker for downstream use.
+    required: true
+outputs: {}
+runs:
+  using: "composite"
+  steps:
+    - name: Badge directory
+      shell: bash
+      run: mkdir -p "badges/$(dirname '${{inputs.file}}')" || true
+    - name: Prepare variables
+      id: vars
+      shell: bash
+      env:
+        UNSAFE: ${{ inputs.file }}
+      run: |
+        # Act, which we use for testing, doesn't yet support case in expression
+        # However we may keep this to handle some more complex cases anyways.
+        case "${{ inputs.status}}" in
+          "Pass")
+            echo "color=green" >> $GITHUB_OUTPUT
+            ;;
+          "Fail")
+            echo "color=red" >> $GITHUB_OUTPUT
+            ;;
+          *)
+            echo "color=blue" >> $GITHUB_OUTPUT
+        esac
+        echo "safe_file=${UNSAFE//\//_}" >> $GITHUB_OUTPUT
+    - name: Build Badge
+      uses: emibcn/badge-action@v2.0.2
+      with:
+        label: ${{inputs.label}}
+        status: ${{inputs.status}}
+        color: ${{ steps.vars.outputs.color }}
+        path: badges/${{inputs.file}}
+    - name: Upload badge
+      uses: actions/upload-artifact@v4
+      with:
+        name: badges_${{ inputs.run_id }}_${{ steps.vars.outputs.safe_file }}
+        path: badges/**/*.svg
+        overwrite: true

--- a/.github/actions/database-migration-image/action.yml
+++ b/.github/actions/database-migration-image/action.yml
@@ -1,4 +1,5 @@
 name: 'Database Migration Container'
+description: Setup database migration container.
 inputs:
   base-image:
     type: string

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,13 @@ jobs:
           annotate_only: true
           include_passed: true
           report_paths: '**/TEST-*.xml'
+      - name: Build Badge
+        uses: emibcn/badge-action@v2.0.2
+        with:
+          label: 'Build'
+          status: 'Ok'
+          color: 'blue,555,daf'
+          path: '.github/badges/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg'
   open-api-static-analysis:
     name: OpenApi Static Analysis Tests
     runs-on: ubuntu-latest
@@ -101,3 +108,23 @@ jobs:
           tag: latest-dev
 
       # No uploads, we're just verifying that nothing broke the docker image.
+  badges:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Badge Branch
+        uses: actions/checkout@v5.0.0
+        with:
+          ref: badges
+          fetch-depth: 1
+          path: badge-workingdir
+      - name: Apply Badge
+        working-directory: badge-workingdir
+        run: |
+          mkdir build
+          cp ../.github/badges/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg build/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add build/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg
+          git commit -m "Update Badge for build ${{ github.event.ref }}"
+          git push origin badges

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,12 @@ jobs:
           label: 'Build'
           status: 'Ok'
           color: 'blue,555,daf'
-          path: '.github/badges/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg'
+          path: 'badges/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg'
+      - name: Upload badge
+        uses: actions/upload-artifact@v4
+        with:
+          name: badges_${{ github.run_id }}_${{ matrix.jdk}}_${{ matrix.schema.env }}
+          path: badges/**/*.svg
   open-api-static-analysis:
     name: OpenApi Static Analysis Tests
     runs-on: ubuntu-latest
@@ -118,11 +123,16 @@ jobs:
           ref: badges
           fetch-depth: 1
           path: badge-workingdir
+      - name: Download badges
+        uses: actions/download-artifact@v4
+        with:
+          pattern: badges_${{ github.run_id }}_*
+          path: ./ # directory to download artifacts into
+          merge-multiple: true  # downloaded artifacts will be in the same directory specified by path
       - name: Apply Badge
         working-directory: badge-workingdir
         run: |
           mkdir build
-          cp ../.github/badges/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg build/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add build/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,11 @@ jobs:
             image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25.07.01"
           - env: next-release
             image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:26.02.17-RC01"
+# place holder for now and leaving commented but in place. General scheme target tests again the current release, the next release, the previous release, and latest development.
+# at this time every possible instance of concern is on 25.07.01, once 26.02.17 is finalized it becomes release and 25.07.01 becomes previous.
+# next-release will be comment out until such time as a RC gets made
+#          - env: previous
+#           image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25.07.01"
     name: build and test (jdk ${{matrix.jdk}}, schema ${{matrix.schema.env}})
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         jdk: [11]
+        # place holder for now and leaving commented but in place. General scheme target tests again the current release, the next release, the previous release, and latest development.
+        # at this time every possible instance of concern is on 25.07.01, once 26.02.17 is finalized it becomes release and 25.07.01 becomes previous.
+        # next-release will be comment out until such time as a RC gets made
         schema:
           - env: latest
             image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:latest-dev"
@@ -21,11 +24,8 @@ jobs:
             image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25.07.01"
           - env: next-release
             image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:26.02.17-RC01"
-# place holder for now and leaving commented but in place. General scheme target tests again the current release, the next release, the previous release, and latest development.
-# at this time every possible instance of concern is on 25.07.01, once 26.02.17 is finalized it becomes release and 25.07.01 becomes previous.
-# next-release will be comment out until such time as a RC gets made
-#          - env: previous
-#           image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25.07.01"
+          # - env: previous
+          #   image: "ghcr.io/hydrologicengineeringcenter/cwms-database/cwms/database-ready-ora-23.5:25.07.01"
     name: build and test (jdk ${{matrix.jdk}}, schema ${{matrix.schema.env}})
     runs-on: ubuntu-latest
     outputs:
@@ -49,25 +49,21 @@ jobs:
         run: ./gradlew clean build --info --init-script init.gradle
       - name: integration tests
         run: ./gradlew integrationtest --info --init-script init.gradle -PCDA.oracle.database.image=${{matrix.schema.image}}
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+      - name: Create matrix job badge
         if: success() || failure() # always run even if the previous step fails
-        with:
-          annotate_only: true
-          include_passed: true
-          report_paths: '**/TEST-*.xml'
-      - name: Build Badge
-        uses: emibcn/badge-action@v2.0.2
+        uses: ./.github/actions/badge
         with:
           label: 'Build'
-          status: 'Ok'
-          color: 'blue,555,daf'
-          path: 'badges/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg'
-      - name: Upload badge
-        uses: actions/upload-artifact@v4
-        with:
-          name: badges_${{ github.run_id }}_${{ matrix.jdk}}_${{ matrix.schema.env }}
-          path: badges/**/*.svg
+          status: ${{ job.status == 'success' && 'Pass' || 'Fail' }}
+          file: ${{ matrix.jdk }}/${{ matrix.schema.env }}.svg
+          run_id: ${{ github.run_id }}
+      # - name: Publish Test Report
+      #   uses: mikepenz/action-junit-report@v5
+      #   if: success() || failure() # always run even if the previous step fails
+      #   with:
+      #     annotate_only: true
+      #     include_passed: true
+      #     report_paths: '**/TEST-*.xml'
   open-api-static-analysis:
     name: OpenApi Static Analysis Tests
     runs-on: ubuntu-latest
@@ -105,6 +101,7 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v5.0.0
+      # No uploads, we're just verifying that nothing broke the docker image.
       - name: Build Migration image
         uses: ./.github/actions/database-migration-image
         with:
@@ -112,29 +109,31 @@ jobs:
           # TODO get current target image from build information
           tag: latest-dev
 
-      # No uploads, we're just verifying that nothing broke the docker image.
+
+
   badges:
     needs: build
     runs-on: ubuntu-latest
+    # we are reporing build state so always run
+    if: always()
     steps:
       - name: Badge Branch
         uses: actions/checkout@v5.0.0
         with:
           ref: badges
           fetch-depth: 1
-          path: badge-workingdir
       - name: Download badges
         uses: actions/download-artifact@v4
         with:
           pattern: badges_${{ github.run_id }}_*
-          path: ./ # directory to download artifacts into
+          path: ./build  # directory to download artifacts into
           merge-multiple: true  # downloaded artifacts will be in the same directory specified by path
       - name: Apply Badge
-        working-directory: badge-workingdir
         run: |
-          mkdir build
+          find . -type f
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add build/${{ matrix.jdk }}/${{ matrix.schema.env }}.svg
-          git commit -m "Update Badge for build ${{ github.event.ref }}"
-          git push origin badges
+          git add build/**/*.svg
+          git status
+          git commit --allow-empty -m "Update Badge for build ${{ github.event.ref }}"
+          git push origin badges -f

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,8 @@ jobs:
   badges:
     needs: build
     runs-on: ubuntu-latest
-    # we are reporing build state so always run
-    if: always()
+    # we are reporing build state so always run, but only on builds on the main branch
+    if: always() && (github.ref_name == 'develop')
     steps:
       - name: Badge Branch
         uses: actions/checkout@v5.0.0
@@ -135,5 +135,5 @@ jobs:
           git config --local user.name "GitHub Action"
           git add build/**/*.svg
           git status
-          git commit --allow-empty -m "Update Badge for build ${{ github.event.ref }}"
+          git commit --allow-empty -m "Update Badge for build of ${{ github.sha }}"
           git push origin badges -f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         env:
           NIGHTLY: ${{inputs.nightly}}
         run:
-          if [[ "${NIGHTLY}" == true]]; then
+          if [[ "${NIGHTLY}" == true ]]; then
             echo "version=${{inputs.branch}}-nightly" >> $GITHUB_OUTPUT
           else
             echo "version=${{inputs.branch}}" >> $GITHUB_OUTPUT
@@ -138,6 +138,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
       - name: Set Output Image
         id: set_image
+        env:
+            REPO: ${{ steps.repo.outputs.name }}
+            VERSION: ${{ steps.version.outputs.version }}
         run: |
           echo "api_image=ghcr.io/${REPO}:$VERSION" >> $GITHUB_OUTPUT
       - name: Setup Database Migration Image
@@ -150,6 +153,7 @@ jobs:
         id: migration-publish
         env:
           REPO: ${{ steps.repo.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           IMAGE=ghcr.io/${REPO}-schema-migration:$VERSION
           docker tag ${{steps.migration.outputs.image}} $IMAGE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,17 +67,22 @@ jobs:
           java-version: '11'
           cache: 'gradle'
       - name: Set version
-        if: inputs.nightly == true
-        run: echo "VERSION=${{inputs.branch}}-nightly" >> $GITHUB_ENV
-      - name: Set version
-        if: inputs.nightly == false
-        run: echo "VERSION=${{inputs.branch}}" >> $GITHUB_ENV
+        id: version
+        env:
+          NIGHTLY: ${{inputs.nightly}}
+        run:
+          if [[ "${NIGHTLY}" == true]]; then
+            echo "version=${{inputs.branch}}-nightly" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{inputs.branch}}" >> $GITHUB_OUTPUT
+          fi
       - name: Sanitize repo for container image names
+        id: repo
         run: |
           REPO=`echo "${{github.repository}}" | tr  '[:upper:]' '[:lower:]'`
-          echo "REPO=$REPO" >> $GITHUB_ENV
+          echo "name=$REPO" >> $GITHUB_OUTPUT
       - name: show version
-        run: echo ${VERSION}
+        run: echo ${{ steps.version.outputs.version }}
       - name: build war
         run: ./gradlew build --info --init-script init.gradle -PversionOverride=$VERSION
       - name: Create GitHub Release
@@ -86,8 +91,8 @@ jobs:
         if: github.event_name != 'pull_request' && (github.event.ref == 'refs/heads/develop' || startsWith(github.event.ref, 'refs/tags'))
         uses: softprops/action-gh-release@v2.6.1
         with:
-          files: cwms-data-api/build/libs/cwms-data-api-${{env.VERSION}}.war
-          tag_name: ${{env.VERSION}}
+          files: cwms-data-api/build/libs/cwms-data-api-${{steps.version.outputs.version}}.war
+          tag_name: ${{steps.version.outputs.version}}
           generate_release_notes: true
           token: ${{ secrets.token != null && secrets.token || secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
@@ -101,11 +106,11 @@ jobs:
           context: git
           images: |
             ${{secrets.registry != null && secrets.registry ||secrets.HEC_PUB_REGISTRY}}/cwms/data-api
-            ghcr.io/${{env.REPO}}
+            ghcr.io/${{steps.repo.outputs.name}}
           tags: |
             type=sha
             type=ref,event=tag
-            type=raw,value=${{env.VERSION}}
+            type=raw,value=${{steps.version.outputs.version}}
             type=schedule,pattern=${{inputs.branch}}-{{date 'YYYY.MM.DD'}}
             type=schedule,pattern=${{inputs.branch}}-{{date 'YYYY.MM.DD-hhmmss'}}
       - name: Log in to the Container registry
@@ -143,6 +148,8 @@ jobs:
           tag: latest-dev
       - name: Publish migration container
         id: migration-publish
+        env:
+          REPO: ${{ steps.repo.outputs.name }}
         run: |
           IMAGE=ghcr.io/${REPO}-schema-migration:$VERSION
           docker tag ${{steps.migration.outputs.image}} $IMAGE

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pki/certs
 compose.env
 .vscode
 **/node_modules/
+cwms-data-api/features.properties

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <h2>Build Status</h2>
+  <h2>Detailed Build Status</h2>
   <table>
     <thead>
       <tr>
@@ -36,15 +36,15 @@
       </tr>
       <tr>
         <td>Current Release</td>
-        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/release.svg">
+        <td><img alt="Current Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/release.svg">
       </tr>
       <tr>
         <td>Next Release</td>
-        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/next-release.svg">
+        <td><img alt="Next Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/next-release.svg">
       </tr>
       <tr>
         <td>Previous Release - NOTE: Not applicable yet</td>
-        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/previous.svg">
+        <td><img alt="Previous Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/previous.svg">
       </tr>
     </tbody>
   </table>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
   </a>
 </p>
 
-<p align="center">
+<div align="center">
   <h2>Detailed Build Status</h2>
   <table>
     <thead>
@@ -48,7 +48,7 @@
       </tr>
     </tbody>
   </table>
-</p>
+</div>
 
 <p align="center">
   <strong>

--- a/README.md
+++ b/README.md
@@ -12,15 +12,42 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/usace/cwms-data-api/actions/workflows/build.yml">
-    <img alt="Build Status" src="https://img.shields.io/github/actions/workflow/status/usace/cwms-data-api/build.yml?branch=develop&style=for-the-badge&label=Build&logo=githubactions">
-  </a>
   <a href="https://github.com/usace/cwms-data-api/actions/workflows/codeql.yml">
     <img alt="CodeQL Status" src="https://img.shields.io/github/actions/workflow/status/usace/cwms-data-api/codeql.yml?branch=develop&style=for-the-badge&label=CodeQL&logo=githubactions">
   </a>
   <a href="https://github.com/usace/cwms-data-api/releases">
     <img alt="GitHub release" src="https://img.shields.io/github/v/release/usace/cwms-data-api?include_prereleases&style=for-the-badge&logo=github">
   </a>
+</p>
+
+<p align="center">
+  <h2>Build Status</h2>
+  <table>
+    <thead>
+      <tr>
+        <th>CWMS Database Schema target</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Latest</td>
+        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/latest.svg">
+      </tr>
+      <tr>
+        <td>Current Release</td>
+        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/release.svg">
+      </tr>
+      <tr>
+        <td>Next Release</td>
+        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/next-release.svg">
+      </tr>
+      <tr>
+        <td>Previous Release - NOTE: Not applicable yet</td>
+        <td><img alt="Latest Status, Svg" src="https://raw.githubusercontent.com/USACE/cwms-data-api/refs/heads/badges/build/11/previous.svg">
+      </tr>
+    </tbody>
+  </table>
 </p>
 
 <p align="center">


### PR DESCRIPTION
More detailed build status reporting in preparation for proper trunk based development -- e.g. it's at least really obvious required builds are passing to justify releasing to test or prod.

Might be some other bits to fix as well, secret wise at CWBI, but some of that can be handled within the github secrets once the repo is allowed to push to all the appropriate environments.


FYI the short term goal is that, some approved group, can just tag a commit appropriate (creating a realize or using git tag locally) and automate the push to the environment. (Only dev would remain scheduled. Though if this all works better I think test is justified for that treatment, perhaps just on a different schedule.)