### PR TITLE
Auth Updates for CWMS-CLI Login

### DIFF
--- a/compose_files/sql/users.sql
+++ b/compose_files/sql/users.sql
@@ -19,6 +19,7 @@ begin
    cwms_sec.add_cwms_user('m5hectest', null, 'SWT');
    cwms_sec.add_user_to_group('m5hectest', 'All Users', 'SWT');
    cwms_sec.add_user_to_group('m5hectest', 'CWMS Users', 'SWT');
+   cwms_sec.add_user_to_group('m5hectest', 'TS ID Creator', 'SWT');
    cwms_sec.add_cwms_user('q0hectest', null, 'SWT');
    cwms_sec.add_user_to_group('q0hectest', 'All Users', 'SWT');
    cwms_sec.add_user_to_group('q0hectest', 'CWMS Users', 'SWT');
@@ -50,6 +51,7 @@ begin
     cwms_sec.add_cwms_user('m5hectest',NULL,'SWT');
     cwms_sec.add_user_to_group('m5hectest','All Users', 'SWT');
     cwms_sec.add_user_to_group('m5hectest','CWMS Users', 'SWT');
+    cwms_sec.add_user_to_group('m5hectest','TS ID Creator', 'SWT');
     execute immediate 'grant execute on cwms_20.cwms_upass to web_user';
 
 

--- a/cwms-data-api/src/main/java/cwms/cda/security/OpenIDConfig.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/OpenIDConfig.java
@@ -56,25 +56,28 @@ public class OpenIDConfig {
         return jwksUrl;
     }
 
-    public SecurityScheme getScheme() {
-
-        
+    static SecurityScheme buildScheme(String wellKnownUrl, String clientId, String idpHint) {
         SecurityScheme scheme =  new SecurityScheme().type(Type.OPENIDCONNECT)
-                                                    .openIdConnectUrl(wellKnown.toString())
-                                                    .scheme("openid");
-        if (idp_hint != null)
+                                                    .openIdConnectUrl(wellKnownUrl);
+        if (idpHint != null)
         {
             Map<String, Object> hint = new HashMap<>();
             hint.put("query-parameter", "kc_idp_hint");
             ArrayList<String> values = new ArrayList<>();
-            for (String value: idp_hint.split(",")) {
+            for (String value: idpHint.split(",")) {
                 values.add(value.trim());
             }
             hint.put("values", values);
             scheme.addExtension("x-kc_idp_hint", hint);
         }
 
-        scheme.addExtension("x-oidc-client-id", client_id);
+        scheme.addExtension("x-oidc-client-id", clientId);
+        return scheme;
+    }
+
+    public SecurityScheme getScheme() {
+        
+        SecurityScheme scheme = buildScheme(wellKnown.toString(), client_id, idp_hint);
         return scheme;
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/security/OpenIdConnectIdentitityProvider.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/OpenIdConnectIdentitityProvider.java
@@ -115,6 +115,10 @@ public final class OpenIdConnectIdentitityProvider implements IdentityProvider {
                 throw new CwmsAuthException("Not Authorized",HttpServletResponse.SC_UNAUTHORIZED);
             }
         } catch (NumberFormatException | JwtException ex) {
+            log.atFine().withCause(ex).log(
+                "JWT validation failed for bearer token from issuer configuration '%s'",
+                System.getProperty(ISSUER_PROPERTY, System.getenv(ISSUER_PROPERTY))
+            );
             throw new CwmsAuthException("JWT not valid",ex,HttpServletResponse.SC_UNAUTHORIZED);
         }
     }

--- a/cwms-data-api/src/test/java/cwms/cda/security/OpenIDConfigTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/security/OpenIDConfigTest.java
@@ -1,0 +1,42 @@
+package cwms.cda.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class OpenIDConfigTest {
+
+    @Test
+    void buildSchemeUsesWellKnownDiscoveryUrlWithoutHttpAuthScheme() {
+        SecurityScheme scheme = OpenIDConfig.buildScheme(
+            "https://identityc.sec.usace.army.mil/auth/realms/cwbi/.well-known/openid-configuration",
+            "cwms",
+            "federation-eams, login.gov"
+        );
+
+        assertEquals(SecurityScheme.Type.OPENIDCONNECT, scheme.getType());
+        assertEquals(
+            "https://identityc.sec.usace.army.mil/auth/realms/cwbi/.well-known/openid-configuration",
+            scheme.getOpenIdConnectUrl()
+        );
+        assertTrue(scheme.getScheme() == null || scheme.getScheme().isEmpty());
+        assertNotNull(scheme.getExtensions());
+        assertEquals("cwms", scheme.getExtensions().get("x-oidc-client-id"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> hint = (Map<String, Object>) scheme.getExtensions().get("x-kc_idp_hint");
+        assertNotNull(hint);
+        assertEquals("kc_idp_hint", hint.get("query-parameter"));
+
+        @SuppressWarnings("unchecked")
+        List<String> values = (List<String>) hint.get("values");
+        assertEquals(List.of("federation-eams", "login.gov"), values);
+        assertFalse(scheme.getExtensions().containsKey("flows"));
+    }
+}


### PR DESCRIPTION
Alters CDA published OpenID Connect metadata and improves local OIDC test coverage

Changes:

- remove the invalid HTTP auth scheme("openid") from the oIdConnect security scheme so Swagger publishes a correct oIdConnectUrl
- add a focused test for openID security scheme
- add debug logging for JWT validation failures to expose the underlying claim/signature issue during local auth setup
- update local compose seed data so m5hectest has TS ID Creator in SWT, matching the documented/test write-user expectations

Used this in testing 
- https://github.com/HydrologicEngineeringCenter/cwms-cli/pull/155

