### PR TITLE
Change CB (cache buster) to use 'cache' from the request

### DIFF
--- a/cda-gui/src/pages/swagger-ui/index.jsx
+++ b/cda-gui/src/pages/swagger-ui/index.jsx
@@ -5,63 +5,63 @@ import { useEffect } from "react";
 import { getBasePath } from "../../utils/base";
 
 export default function SwaggerUI() {
-    useEffect(() => {
-        // document.querySelector("#swagger-ui").prepend(Index)
-        // TODO: Add page index to top of page
-        // Alter the page title to match the swagger page
-        document.title = "CWMS Data API for Data Retrieval - Swagger UI";
-        // Begin Swagger UI call region
-        // TODO: add endpoint that dynamic returns swagger generated doc
+  useEffect(() => {
+    // document.querySelector("#swagger-ui").prepend(Index)
+    // TODO: Add page index to top of page
+    // Alter the page title to match the swagger page
+    document.title = "CWMS Data API for Data Retrieval - Swagger UI";
+    // Begin Swagger UI call region
+    // TODO: add endpoint that dynamic returns swagger generated doc
 
-        const ui = SwaggerUIBundle({
-            url: getBasePath() + "/swagger-docs",
-            
-            dom_id: "#swagger-ui",
-            deepLinking: false,
-            presets: [SwaggerUIBundle.presets.apis],
-            plugins: [SwaggerUIBundle.plugins.DownloadUrl],
-            requestInterceptor: (req) => {
-                // Add a cache-busting query param... but only if it's to our api. Some
-                // external systems, like keycloak, don't allow random unknown parameters.
-                const origin = window.location.origin;                
-                const re = new RegExp(`^${origin}.*`)
-                if (re.test(req.url))
-                {
-                    const sep = req.url.includes("?") ? "&" : "?";
-                    req.url = `${req.url}${sep}_cb=${Date.now()}`;
+    const ui = SwaggerUIBundle({
+      url: getBasePath() + "/swagger-docs",
 
-                    // Also ask intermediaries not to serve from cache
-                    req.headers["Cache-Control"] = "no-cache, no-store, max-age=0";
-                    req.headers["Pragma"] = "no-cache";
-                }
-                return req;
-            },
-            onComplete: () => {
-                const spec = JSON.parse(ui.spec().get("spec"));
-                for (const schemeName in spec.components.securitySchemes) {
-                    const scheme = spec.components.securitySchemes[schemeName];
-                    if (scheme.type === "openIdConnect") {
-                        let additionalParams = null;
-                        let hints = scheme["x-kc_idp_hint"];
-                        if (hints) {
-                            additionalParams = {
-                                // Since getting the interface to allow users to choose
-                                // is likely impossible, we will assume the first in the list
-                                // is the "primary" auth system
-                                "kc_idp_hint": hints.values[0]
-                            };
-                        }
-                        ui.initOAuth({
-                            clientId: scheme["x-oidc-client-id"],
-                            usePkceWithAuthorizationCodeGrant: true,
-                            additionalQueryStringParams: additionalParams,
-                        });
-                        break;
-                    }
-                }
-            },
-        });
-    }, []);
+      dom_id: "#swagger-ui",
+      deepLinking: false,
+      presets: [SwaggerUIBundle.presets.apis],
+      plugins: [SwaggerUIBundle.plugins.DownloadUrl],
+      requestInterceptor: (req) => {
+        // Only alter cache behavior for same-origin API requests. External systems,
+        // like keycloak, may reject unexpected request changes.
+        const origin = window.location.origin;
+        const re = new RegExp(`^${origin}.*`);
+        if (re.test(req.url)) {
+          // Control browser 'fetch' behavior
+          req.cache = "no-store";
+          // Ensure headers exist first
+          req.headers = req.headers ?? {};
+          // Reverse/forward proxies, intermediary, service worker caches
+          req.headers["Cache-Control"] = "no-cache, no-store, max-age=0";
+          req.headers["Pragma"] = "no-cache";
+        }
+        return req;
+      },
+      onComplete: () => {
+        const spec = JSON.parse(ui.spec().get("spec"));
+        for (const schemeName in spec.components.securitySchemes) {
+          const scheme = spec.components.securitySchemes[schemeName];
+          if (scheme.type === "openIdConnect") {
+            let additionalParams = null;
+            let hints = scheme["x-kc_idp_hint"];
+            if (hints) {
+              additionalParams = {
+                // Since getting the interface to allow users to choose
+                // is likely impossible, we will assume the first in the list
+                // is the "primary" auth system
+                kc_idp_hint: hints.values[0],
+              };
+            }
+            ui.initOAuth({
+              clientId: scheme["x-oidc-client-id"],
+              usePkceWithAuthorizationCodeGrant: true,
+              additionalQueryStringParams: additionalParams,
+            });
+            break;
+          }
+        }
+      },
+    });
+  }, []);
 
   return <div id="swagger-ui"></div>;
 }


### PR DESCRIPTION
There was some confusion on the swagger URL builder to what `cb` was. 

This will remove the request to cache and bring the URL back to what it was before. 

`req.cache` sets the browser cache, more [on mdn's Request cache docs](https://developer.mozilla.org/en-US/docs/Web/API/Request/cache)

`headers[...etc]` will keep the proxy/down the wire data sniffers in line with caching. (edge cache)

I did some testing on localhost by 

1. Clicking execute in the swagger page to see each request NOT cache
2. `fetch("http://localhost:8081/cwms-data/location/category")` in the browser console to see the requests cache
3. Repeating 1. after 2 to see no-cache was working
4. `fetch("http://localhost:8081/cwms-data/location/category", {cache: "no-cache"})` to mimic what swagger now does and confirming no "disk cache" in the network tab