### PR TITLE
bugfix/1675-locations-endpoint-returning-empty-list

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/LocationsDaoImpl.java
@@ -142,12 +142,14 @@ public class LocationsDaoImpl extends JooqDao<Location> implements LocationsDao 
                     .fetchSize(DEFAULT_SMALL_FETCH_SIZE)
                     .fetch(this::buildLocation);
 
+            if (datum == null || datum.isBlank()) {
+                return results;
+            }
+
             List<Location> finalizedResults = new ArrayList<>();
-            if (datum != null && !datum.isBlank()) {
-                for(Location loc : results) {
-                    loc = convertLocationToVerticalDatum(dslContext, loc, datum, officeId);
-                    finalizedResults.add(loc);
-                }
+            for(Location loc : results) {
+                loc = convertLocationToVerticalDatum(dslContext, loc, datum, officeId);
+                finalizedResults.add(loc);
             }
             return finalizedResults;
         });

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -825,11 +825,12 @@ class LocationControllerTestIT extends DataApiTestIT {
         KeyUser user = KeyUser.SPK_NORMAL;
         String officeId = user.getOperatingOffice();
 
-        createLocation(locationName, true, officeId);
+        createLocation(locationName, true, officeId, 38.5757, -121.4789, "WGS84", "UTC", "SITE");
 
         given()
             .log().ifValidationFails(LogDetail.ALL, true)
             .accept(Formats.JSONV2)
+            .queryParam(OFFICE, officeId)
             .queryParam(NAMES, locationName)
         .when()
             .redirects().follow(true)

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -819,6 +819,32 @@ class LocationControllerTestIT extends DataApiTestIT {
             .contentType(is(test._expectedContentType));
     }
 
+    @Test
+    void test_get_all_locations_without_datum_returns_results() throws Exception {
+        String locationName = "TestLocNoDatum";
+        KeyUser user = KeyUser.SPK_NORMAL;
+        String officeId = user.getOperatingOffice();
+
+        createLocation(locationName, true, officeId);
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .accept(Formats.JSONV2)
+            .queryParam(NAMES, locationName)
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/locations/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL, true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("size()", is(1),
+                    "Issue #1675: getLocations should return results when datum is null")
+            .body("[0].name", equalTo(locationName))
+        ;
+    }
+
     enum GetAllLegacyTest
     {
         JSON(Formats.JSON_LEGACY, Formats.JSON),

--- a/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LocationControllerTestIT.java
@@ -840,8 +840,7 @@ class LocationControllerTestIT extends DataApiTestIT {
             .log().ifValidationFails(LogDetail.ALL, true)
         .assertThat()
             .statusCode(is(HttpServletResponse.SC_OK))
-            .body("size()", is(1),
-                    "Issue #1675: getLocations should return results when datum is null")
+            .body("size()", is(1))
             .body("[0].name", equalTo(locationName))
         ;
     }

--- a/cwms-data-api/src/test/resources/cwms/cda/data/timeseries.csv
+++ b/cwms-data-api/src/test/resources/cwms/cda/data/timeseries.csv
@@ -275,11 +275,11 @@ LRL,Mississinewa.Temp-Air.Max.1Day.1Day.lrldlb-raw,T,Mississinewa,null,null,m,nu
 LRL,Mississinewa.Temp-Air.Max.1Day.1Day.lrldlb-raw,T,Mississinewa,Corps Reservoir,712.0,ft,NGVD29,40.7166667,-85.9580556,NAD27,MississinewaLake,MississinewaLake,null,US/Eastern,Miami,IN
 LRL,Mississinewa.Temp-Air.Max.1Day.1Day.lrldlb-raw,T,Mississinewa,Corps Reservoir,217.01760000000002,m,NGVD29,40.7166667,-85.9580556,NAD27,MississinewaLake,MississinewaLake,null,US/Eastern,Miami,IN
 LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,m,null,39.007222222222,-86.513333333333,null,MONROE LAKE NEAR HARRODSBURG,MONROE LAKE NEAR HARRODSBURG,MONROE LAKE NEAR HARRODSBURG,UTC,Monroe,IN
-LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,m,null,null,null,null,Monroe,null,null,null,Unknown County or County N/A,00
+LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,m,null,null,null,null,Monroe,null,null,null,Unknown County or County N/A,IN
 LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,Corps Reservoir,538.0,ft,NGVD29,39.0075,-86.5125,NAD27,Monroe Lake,MonroeLake,null,US/Eastern,Monroe,IN
 LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,ft,null,41.94,-83.44,null,Monroe Weather Station,null,null,US/Eastern,Monroe,MI
 LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,ft,null,39.007222222222,-86.513333333333,null,MONROE LAKE NEAR HARRODSBURG,MONROE LAKE NEAR HARRODSBURG,MONROE LAKE NEAR HARRODSBURG,UTC,Monroe,IN
-LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,ft,null,null,null,null,Monroe,null,null,null,Unknown County or County N/A,00
+LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,ft,null,null,null,null,Monroe,null,null,null,Unknown County or County N/A,IN
 LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,Corps Reservoir,163.9824,m,NGVD29,39.0075,-86.5125,NAD27,Monroe Lake,MonroeLake,null,US/Eastern,Monroe,IN
 LRL,Monroe.Temp-Water.Inst.0.0.lrldlb-rev,T,Monroe,null,null,m,null,41.94,-83.44,null,Monroe Weather Station,null,null,US/Eastern,Monroe,MI
 LRL,MtCarmel.Precip.Inst.1Hour.0.LRGS-raw,T,MtCarmel,null,112.46510400000001,m,NAVD88,38.3983333,-87.75638889,NAD83,"WABASH RIVER AT MT. CARMEL, IL","WABASH RIVER AT MT. CARMEL, IL",null,US/Central,Wabash,IL


### PR DESCRIPTION
The getLocations() method was always returning an empty list when no datum parameter was provided. The code created an empty finalizedResults list and only populated it when datum was not null, then always returned finalizedResults. Instead, return the fetched results directly when datum is null/blank, and only perform datum conversion when necessary.  