### PR TITLE
CDA Register from TS_UPDATES to TS_STORED

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/rss/QueueManager.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/rss/QueueManager.java
@@ -40,7 +40,7 @@ public final class QueueManager {
         "      FROM ALL_QUEUES " +
         "      WHERE OWNER = 'CWMS_20' " +
         "        AND QUEUE_TYPE = 'NORMAL_QUEUE' " +
-        "        AND REGEXP_LIKE(NAME, 'STATUS|TS_UPDATES|REALTIME_OPS') " +
+        "        AND REGEXP_LIKE(NAME, 'STATUS|TS_STORED|REALTIME_OPS') " +
         "   ) LOOP " +
         "      BEGIN " +
         "         DBMS_AQADM.ADD_SUBSCRIBER( " +


### PR DESCRIPTION
I did not see `TS_UPDATES` in the CWMS DB schema, I was however able to change this locally to `TS_STORED` and pull a successful RSS feed message with

```
GET /cwms-data/rss/SWT/TS_STORED?page-size=200&since=2026-04-22T04%3A47%3A00.000Z HTTP/1.1
Accept: application/rss+xml
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: en-US,en;q=0.9
Authorization: apikey testtestest
Connection: keep-alive
Cookie: JSESSIONID=hello
DNT: 1
Host: localhost:5173
If-None-Match: 1707360919
Sec-Fetch-Dest: empty
Sec-Fetch-Mode: cors
Sec-Fetch-Site: same-origin
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36
sec-ch-ua: "Google Chrome";v="147", "Not.A/Brand";v="8", "Chromium";v="147"
sec-ch-ua-mobile: ?0
sec-ch-ua-platform: "Windows"

```
resulted in

```xml
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
<channel>
<title>TS_STORED</title>
<description> CWMS messages about time series operations, such as data stored and deleted</description>
<item>
<description>{
    "office_id": "SWT",
    "start_time": 1776816000000,
    "ts_id": "RSS_TS_TEST_LOC.Flow.Inst.1Hour.0.raw",
    "ts_code": 761001,
    "end_time": 1776823200000,
    "store_time": 1776833280251,
    "store_rule": "REPLACE ALL",
    "version_date": 1776833280000,
    "type": "TSDataStored",
    "millis": 1776833280574
}</description>
<pubDate>Wed,
22 Apr 2026 04: 48: 00 Z
</pubDate>
<guid isPermaLink="false">50063C83FA0A0E9CE06302001EAC125D</guid>
</item>
<item><description>{
    "office_id": "SWT",
    "start_time": 1765033200000,
    "ts_id": "bear.Flow.Inst.1Hour.0.raw",
    "ts_code": 263191,
    "end_time": 1766847600000,
    "store_time": 1765614311370,
    "store_rule": "REPLACE ALL",
    "version_date": -27079747200000,
    "type": "TSDataStored",
    "millis": 1776833239708
}</description>
<pubDate>Wed,
22 Apr 2026 04: 47: 19 Z</pubDate>
<guid isPermaLink="false">50063A15AD2B0EF3E06302001EACA377</guid>
</item>
</channel></rss>
```

CDA auto-registers with the persistent subscriber CDA_QUEUE_SUBSCRIBER at startu and this will register TS_STORED.

Possible i'm missing something on localhost that Dev/test/prod would have?


