### PR TITLE
Fix recent timeseries OpenAPI schema

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesRecentController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesRecentController.java
@@ -45,7 +45,6 @@ import cwms.cda.data.dao.JooqDao;
 import cwms.cda.data.dao.TimeSeriesDao;
 import cwms.cda.data.dao.TimeSeriesDaoImpl;
 import cwms.cda.data.dto.RecentValue;
-import cwms.cda.data.dto.Tsv;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
 import io.javalin.core.util.Header;
@@ -117,7 +116,7 @@ public class TimeSeriesRecentController implements Handler {
             },
             responses = {
                 @OpenApiResponse(status = STATUS_200, content = {
-                    @OpenApiContent(isArray = true, from = Tsv.class, type = Formats.JSON)}),
+                    @OpenApiContent(isArray = true, from = RecentValue.class, type = Formats.JSON)}),
                 @OpenApiResponse(status = STATUS_404, description = "Based on the combination of "
                         + "inputs provided the timeseries group(s) were not found."),
                 @OpenApiResponse(status = STATUS_501, description = "request format is not "

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesControllerTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesControllerTest.java
@@ -2,16 +2,22 @@ package cwms.cda.api;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import cwms.cda.data.dto.RecentValue;
 import cwms.cda.data.dto.TimeSeries;
 import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
+import io.javalin.http.Context;
+import io.javalin.plugin.openapi.annotations.OpenApi;
+import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -279,5 +285,17 @@ class TimeSeriesControllerTest extends ControllerTest {
 
     }
 
+    @Test
+    void testRecentOpenApiResponseUsesRecentValue() throws NoSuchMethodException {
+        Method handle = TimeSeriesRecentController.class.getMethod("handle", Context.class);
+        OpenApi openApi = handle.getAnnotation(OpenApi.class);
+        OpenApiResponse okResponse = Arrays.stream(openApi.responses())
+                .filter(response -> Controllers.STATUS_200.equals(response.status()))
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(1, okResponse.content().length);
+        assertEquals(RecentValue.class, okResponse.content()[0].from());
+    }
 
 }


### PR DESCRIPTION
## Summary

While working with the TS recent method in cwmsjs I found an issue with the annotations. 
I.e. (Note if this change is brought in this will need to be regenerated on the generator)
https://hydrologicengineeringcenter.github.io/cwms-data-api-client-javascript/classes/TimeSeriesApi.html#getTimeSeriesRecent.getTimeSeriesRecent-1

This fixes the OpenAPI response schema for `GET /timeseries/recent`.

The controller returns and formats `List<RecentValue>`, but the OpenAPI annotation documented the `200` JSON response as `Tsv[]`. That caused generated clients to map the endpoint to the wrong model and drop the useful recent-value payload fields such as `id` and `dqu`.

This updates the annotation to use `RecentValue[]` and adds a regression test to confirm the documented response type stays aligned with the controller behavior.


## Validation

- Added a unit test asserting `TimeSeriesRecentController.handle` documents the `200` response as `RecentValue`.
- Attempted to run:

  `.\gradlew.bat :cwms-data-api:test --tests cwms.cda.api.TimeSeriesControllerTest`

- Local validation is currently blocked on Java 21 by a pre-existing compile issue in `TimeSeriesDaoImpl.java`, where unqualified `Record` is ambiguous between `org.jooq.Record` and `java.lang.Record`.
- The PR CI currently runs on Java 11, where that ambiguity does not occur. Asked about possibly testing CI PR for java 21 as well. 

## Checklist

- [x] AI tools used
