### PR TITLE
add compile and unit test checks for java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11]
+        jdk: [11, 21, 25]
         # place holder for now and leaving commented but in place. General scheme target tests again the current release, the next release, the previous release, and latest development.
         # at this time every possible instance of concern is on 25.07.01, once 26.02.17 is finalized it becomes release and 25.07.01 becomes previous.
         # next-release will be comment out until such time as a RC gets made
@@ -48,6 +48,7 @@ jobs:
         id: thebuild
         run: ./gradlew clean build --info --init-script init.gradle
       - name: integration tests
+        if: matrix.jdk == 11
         run: ./gradlew integrationtest --info --init-script init.gradle -PCDA.oracle.database.image=${{matrix.schema.image}}
       - name: Create matrix job badge
         if: success() || failure() # always run even if the previous step fails

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [11, 21, 25]
+        jdk: [11, 21]
         # place holder for now and leaving commented but in place. General scheme target tests again the current release, the next release, the previous release, and latest development.
         # at this time every possible instance of concern is on 25.07.01, once 26.02.17 is finalized it becomes release and 25.07.01 becomes previous.
         # next-release will be comment out until such time as a RC gets made

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -74,7 +74,29 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jooq.*;
+import org.jooq.CommonTableExpression;
+import org.jooq.Condition;
+import org.jooq.Cursor;
+import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.Record1;
+import org.jooq.Record10;
+import org.jooq.Record3;
+import org.jooq.Record4;
+import org.jooq.Record7;
+import org.jooq.Result;
+import org.jooq.SQL;
+import org.jooq.Select;
+import org.jooq.SelectConditionStep;
+import org.jooq.SelectHavingStep;
+import org.jooq.SelectJoinStep;
+import org.jooq.SelectOnConditionStep;
+import org.jooq.SelectSeekStep2;
+import org.jooq.Table;
+import org.jooq.TableField;
+import org.jooq.TableLike;
+import org.jooq.TableOnConditionStep;
 import org.jooq.conf.ParamType;
 import org.jooq.exception.DataAccessException;
 import org.jooq.impl.DSL;
@@ -342,7 +364,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
 
         // put all those columns together as "valid"
         CommonTableExpression<Record7<BigDecimal, String, String, String, String, BigDecimal,
-                String>> valid =
+                        String>> valid =
                 name("valid").fields("tscode", "tsid", "office_id", "loc_part", "units",
                                 "interval", "parm_part")
                         .as(


### PR DESCRIPTION
## Summary

Add Java 21 compile/unit test targets to build matrix. currently only running Java 11 integration tests due to target production environments and not wanting to overly abuse GitHub Actions.

Cannot currently add Java 25 support because there is no gradle version that supports both Java 11 and Java 25 unless setting the toolchain version to Java 11 (which defeats the whole purpose).

## Related Issue

Related to  #1004 

## Validation

Tested through CI/CD pipeline.

## Checklist

- [ ] AI tools used
