### PR TITLE
CDA-100 - implements allowing either cwms_user or CAC_USER roles to get user profile

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -39,6 +39,7 @@ import static io.javalin.apibuilder.ApiBuilder.post;
 import static io.javalin.apibuilder.ApiBuilder.prefixPath;
 import static io.javalin.apibuilder.ApiBuilder.staticInstance;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
@@ -169,6 +170,8 @@ import cwms.cda.data.dao.rss.QueueManager;
 import cwms.cda.formatters.Formats;
 import cwms.cda.security.Authenticator;
 import cwms.cda.security.CdaAccessManager;
+import cwms.cda.security.DataApiPrincipal;
+import cwms.cda.security.MissingRolesException;
 import cwms.cda.security.Role;
 import io.javalin.Javalin;
 import io.javalin.apibuilder.CrudFunction;
@@ -202,6 +205,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.jar.Manifest;
 import javax.annotation.Resource;
@@ -641,13 +645,26 @@ public class ApiServlet extends HttpServlet {
 
     private void addUserManagementHandlers() {
         RouteRole[] adminRoles = new RouteRole[] { new Role("CWMS User Admins")};
-        RouteRole[] userRoles = new RouteRole[] {new Role("CWMS Users")};
+        RouteRole[] userRoles = new RouteRole[] {new Role(CWMS_USERS_ROLE), new Role(CAC_USER)};
         crud("/users/{user-name}", new UsersController(metrics), adminRoles);
         get("/roles", new GetRolesController(metrics), adminRoles);
-        get("/user/profile", new UserProfileController(metrics), userRoles);
+        String userProfilePath = "/user/profile";
+        get(userProfilePath, new UserProfileController(metrics), userRoles);
+        cdaAccessManager.addCustomAuthorizer(userProfilePath, ApiServlet::hasAnyRole);
         post("/user/{user-name}/roles/{office-id}", new AddRoleController(metrics), adminRoles);
         delete("/user/{user-name}/roles/{office-id}", new DeleteRolesController(metrics), adminRoles);
-        
+
+    }
+
+    private static Boolean hasAnyRole(DataApiPrincipal p, Set<RouteRole> roles) throws MissingRolesException {
+        boolean retVal = roles.stream().anyMatch(p.getRoles()::contains);
+        if(!retVal) {
+            List<String> requiredRoleNames = roles.stream()
+                    .map(Object::toString)
+                    .collect(toList());
+            throw new MissingRolesException(requiredRoleNames, "Missing one of the following roles {" + String.join(",", requiredRoleNames) + "}");
+        }
+        return true;
     }
 
     private void addRatingHandlers(RouteRole[] requiredRoles) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -46,6 +46,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
 import javax.sql.DataSource;
@@ -409,19 +410,34 @@ public class AuthDao extends Dao<DataApiPrincipal> {
      * @throws CwmsAuthException if the user is not authorized
      */
     public static void isAuthorized(Context ctx, DataApiPrincipal p, Set<RouteRole> routeRoles) throws CwmsAuthException {
+        isAuthorized(ctx, p, routeRoles, (principal, requiredRoles) ->
+                principal.getRoles().containsAll(requiredRoles));
+    }
+
+    /**
+     * logic to determine if a given principal can perform the desired operation based on a predicate.
+     * Throws exception if not valid, otherwise just returns.
+     * @param ctx the context to check
+     * @param p the principal to check
+     * @param routeRoles the route roles
+     * @param authorizer the authorizer logic for the route roles
+     * @throws CwmsAuthException if the user is not authorized
+     */
+    public static void isAuthorized(Context ctx, DataApiPrincipal p, Set<RouteRole> routeRoles,
+                                    BiPredicate<DataApiPrincipal, Set<RouteRole>> authorizer) throws CwmsAuthException {
         if (routeRoles == null || routeRoles.isEmpty()) {
             logger.atFinest().log("Passthrough, no required roles defined.");
             return;
-        } else if (p != null) {
-            Set<RouteRole> specifiedRoles = p.getRoles();
-            if (specifiedRoles.containsAll(routeRoles)) {
-                logger.atFinest().log("User has required roles.");
-                return;
+        }
+
+        if (p != null && authorizer.test(p, routeRoles)) {
+            logger.atFinest().log("User is authorized.");
+        } else {
+            if (p == null) {
+                throw new CwmsAuthException("No credentials provided.", 401);
             } else {
                 throw new MissingRolesException(getMissingRoles(ctx, routeRoles, p));
             }
-        } else {
-            throw new CwmsAuthException("No credentials provided.",401);
         }
     }
 

--- a/cwms-data-api/src/main/java/cwms/cda/security/CdaAccessManager.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/CdaAccessManager.java
@@ -17,6 +17,7 @@ import io.javalin.core.security.AccessManager;
 import io.javalin.core.security.RouteRole;
 import io.javalin.http.Context;
 import io.javalin.http.Handler;
+import java.util.function.BiPredicate;
 import java.util.concurrent.TimeUnit;
 
 public final class CdaAccessManager implements AccessManager {
@@ -27,11 +28,17 @@ public final class CdaAccessManager implements AccessManager {
     private static final int REQUEST_LIMIT = Integer.parseInt(System.getProperty(REQUEST_LIMIT_KEY, "100"));
     private static final TimeUnit REQUEST_LIMIT_UNIT = TimeUnit.MINUTES;
     private final Map<String, RouteRole[]> rateLimitedPaths = new HashMap<>();
+    private final Map<String, BiPredicate<DataApiPrincipal, Set<RouteRole>>> customAuthorizers = new HashMap<>();
 
     @Override
     public void  manage(Handler handler, Context ctx, Set<RouteRole> routeRoles) throws Exception {
         DataApiPrincipal principal = getApiPrincipal(ctx);
-        AuthDao.isAuthorized(ctx, principal, routeRoles);
+        String path = ctx.endpointHandlerPath();
+        if (customAuthorizers.containsKey(path)) {
+            AuthDao.isAuthorized(ctx, principal, routeRoles, customAuthorizers.get(path));
+        } else {
+            AuthDao.isAuthorized(ctx, principal, routeRoles);
+        }
         checkRateLimit(ctx);
         prepareContext(ctx, principal);
         handler.handle(ctx);
@@ -45,7 +52,13 @@ public final class CdaAccessManager implements AccessManager {
                 NaiveRateLimit.requestPerTimeUnit(ctx, REQUEST_LIMIT, REQUEST_LIMIT_UNIT);
             } catch (HttpResponseException ex) {
                 try {
-                    AuthDao.isAuthorized(ctx, getApiPrincipal(ctx), new HashSet<>(Arrays.asList(routeRoles)));
+                    DataApiPrincipal principal = getApiPrincipal(ctx);
+                    Set<RouteRole> roles = new HashSet<>(Arrays.asList(routeRoles));
+                    if (customAuthorizers.containsKey(path)) {
+                        AuthDao.isAuthorized(ctx, principal, roles, customAuthorizers.get(path));
+                    } else {
+                        AuthDao.isAuthorized(ctx, principal, roles);
+                    }
                 } catch (CwmsAuthException e) {
                     // If user is unauthorized, rethrow the rate limit exception
                     logger.atFinest().log("Unauthorized access to rate limited path: %s", path, e);
@@ -71,5 +84,9 @@ public final class CdaAccessManager implements AccessManager {
 
     public void addRateLimitedEndpoint(String path, RouteRole[] roles) {
         rateLimitedPaths.put(path, roles);
+    }
+
+    public void addCustomAuthorizer(String path, BiPredicate<DataApiPrincipal, Set<RouteRole>> authorizer) {
+        customAuthorizers.put(path, authorizer);
     }
 }

--- a/cwms-data-api/src/main/java/cwms/cda/security/MissingRolesException.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/MissingRolesException.java
@@ -5,15 +5,21 @@ import javax.servlet.http.HttpServletResponse;
 
 public class MissingRolesException extends CwmsAuthException {
     private final List<String> missingRoles;
+    private final String message;
 
     public MissingRolesException(List<String> missingRoles) {
-        super(buildMessage(missingRoles), HttpServletResponse.SC_FORBIDDEN, buildMessage(missingRoles));
+        this(missingRoles, buildMessage(missingRoles));
+    }
+
+    public MissingRolesException(List<String> missingRoles, String message) {
+        super(message, HttpServletResponse.SC_FORBIDDEN, message);
         this.missingRoles = missingRoles;
+        this.message = message;
     }
 
     @Override
     public String getMessage() {
-        return buildMessage(missingRoles);
+        return message;
     }
 
     private static String buildMessage(List<String> roles) {

--- a/cwms-data-api/src/test/java/cwms/cda/api/AccessManagerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/AccessManagerTestIT.java
@@ -69,6 +69,20 @@ final class AccessManagerTestIT extends DataApiTestIT {
                                 .render();
         assertNotNull(json);
 
+        //ensure the location doesn't exist before creation
+        try {
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .contentType("application/json")
+                .queryParam("office", user.getOperatingOffice())
+                .spec(authSpec)
+            .when()
+                .delete(  "/locations/LOC_TEST")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception ex) {}
+
+        //try to create the location
         given()
 			.log().ifValidationFails(LogDetail.ALL,true)
             .contentType("application/json")
@@ -82,6 +96,20 @@ final class AccessManagerTestIT extends DataApiTestIT {
 			.log().ifValidationFails(LogDetail.ALL,true)
             .assertThat()
 			.statusCode(is(HttpServletResponse.SC_CREATED));
+
+        //cleanup location after creation
+        try {
+            given()
+                .log().ifValidationFails(LogDetail.ALL,true)
+                .contentType("application/json")
+                .queryParam("office", user.getOperatingOffice())
+                .spec(authSpec)
+            .when()
+                .delete(  "/locations/LOC_TEST")
+            .then()
+                .log().ifValidationFails(LogDetail.ALL,true);
+        } catch (Exception ex) {}
+
     }
 
     @ParameterizedTest

--- a/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/DataApiTestIT.java
@@ -102,6 +102,7 @@ public class DataApiTestIT {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
     protected static String createLocationQuery = null;
+    protected static String deleteLocationQuery = null;
     protected static String createTimeseriesQuery = null;
     protected static String createTimeseriesOffsetQuery = null;
     protected static final String removeApiKeys = "delete from at_api_keys where UPPER(userid) = UPPER(?) and key_name = ?";
@@ -161,6 +162,11 @@ public class DataApiTestIT {
                         .getClassLoader()
                         .getResourceAsStream("cwms/cda/data/sql_templates/create_location.sql"), "UTF-8"
         );
+        deleteLocationQuery = IOUtils.toString(
+                TimeseriesControllerTestIT.class
+                        .getClassLoader()
+                        .getResourceAsStream("cwms/cda/data/sql_templates/delete_location.sql"), "UTF-8"
+        );
         createTimeseriesQuery = IOUtils.toString(
                 TimeseriesControllerTestIT.class
                         .getClassLoader()
@@ -189,7 +195,7 @@ public class DataApiTestIT {
                 if (user.getKeyName() == null) {
                     continue;
                 }
-                if (user == TestAccounts.KeyUser.SPK_OTHER_NORMAL_SAME_ROLES) {
+                if (user == TestAccounts.KeyUser.SPK_OTHER_NORMAL_SAME_ROLES || user == TestAccounts.KeyUser.SPK_CAC_BUT_NOT_CWMS_USER) {
                     String name = user.getName();
                     String officeId = user.getOperatingOffice(); //"SPK";  // We want user office not db office.
 
@@ -205,7 +211,10 @@ public class DataApiTestIT {
                         }
                     }
 
-                    addUserToGroup(name, "CWMS Users", officeId);
+                    if(user != TestAccounts.KeyUser.SPK_CAC_BUT_NOT_CWMS_USER)
+                    {
+                        addUserToGroup(name, "CWMS Users", officeId);
+                    }
                     addUserToGroup(name, "All Users", officeId);
                     addUserToGroup(name, "TS ID Creator", officeId);
                 }
@@ -457,6 +466,19 @@ public class DataApiTestIT {
         createLocation(location, active, office,
                 0.0, 0.0, "WGS84",
                 "UTC", kind);
+    }
+
+    protected static void deleteLocation(String location, String office) throws SQLException {
+        CwmsDatabaseContainer<?> db = CwmsDataApiSetupCallback.getDatabaseLink();
+        db.connection((c) -> {
+            try (PreparedStatement stmt = c.prepareStatement(deleteLocationQuery)) {
+                stmt.setString(1, location);
+                stmt.setString(2, office);
+                stmt.execute();
+            } catch (SQLException ex) {
+                throw new RuntimeException("Unable to delete location", ex);
+            }
+        }, "cwms_20");
     }
 
     /**

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeseriesControllerTestIT.java
@@ -1710,28 +1710,6 @@ final class TimeseriesControllerTestIT extends DataApiTestIT {
         ;
     }
 
-    private static void deleteLocation(String location, String officeId) throws SQLException {
-        CwmsDatabaseContainer<?> db = CwmsDataApiSetupCallback.getDatabaseLink();
-        db.connection(c-> {
-            try(PreparedStatement stmt = c.prepareStatement("declare\n"
-                    + "    p_location varchar2(64) := ?;\n"
-                    + "    p_office varchar2(10) := ?;\n"
-                    + "begin\n"
-                    + "cwms_loc.delete_location(\n"
-                    + "        p_location_id   => p_location,\n"
-                    + "        p_delete_action => cwms_util.delete_all,\n"
-                    + "        p_db_office_id  => p_office);\n"
-                    + "end;")) {
-                stmt.setString(1, location);
-                stmt.setString(2, officeId);
-                stmt.execute();
-
-            } catch (SQLException ex) {
-                throw new RuntimeException("Unable to delete location",ex);
-            }
-        }, "cwms_20");
-    }
-
     @ParameterizedTest
     @EnumSource(GetAllTest.class)
     void test_lrl_1day_content_type_aliasing(GetAllTest test) throws Exception

--- a/cwms-data-api/src/test/java/cwms/cda/api/users/UserManagementTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/users/UserManagementTestIT.java
@@ -10,6 +10,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 
 import cwms.cda.api.Controllers;
+import cwms.cda.formatters.Formats;
+import fixtures.users.UserSpecSource;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +25,6 @@ import cwms.cda.data.dto.auth.users.User;
 import cwms.cda.data.dto.auth.users.Users;
 import fixtures.KeyCloakExtension;
 import fixtures.TestAccounts;
-import fixtures.users.UserSpecSource;
 import fixtures.users.annotation.AuthType;
 import io.javalin.http.HttpCode;
 import io.restassured.filter.log.LogDetail;
@@ -30,6 +33,30 @@ import io.restassured.specification.RequestSpecification;
 @Tag("integration")
 @ExtendWith(KeyCloakExtension.class)
 public class UserManagementTestIT extends DataApiTestIT {
+
+    private static final String LOCATION = "SOME_LOCATION";
+    private static final String SWT = "SWT";
+    private static final String SPK = "SPK";
+
+    @BeforeAll
+    public static void setupLocations() throws Exception {
+        createLocation(LOCATION, true, SWT);
+        createLocation(LOCATION, true, SPK);
+    }
+
+    @AfterAll
+    public static void tearDownLocations() {
+        try {
+            deleteLocation(LOCATION, SWT);
+        } catch (Exception e) {
+            // ignore
+        }
+        try {
+            deleteLocation(LOCATION, SPK);
+        } catch (Exception e) {
+            // ignore
+        }
+    }
     
     @ParameterizedTest
 	@ArgumentsSource(UserSpecSource.class)
@@ -287,6 +314,92 @@ public class UserManagementTestIT extends DataApiTestIT {
         assertTrue(users.getUsers().isEmpty(), "Expected no users returned for regex filter");
     }
 
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_NO_ROLES)
+    void test_get_my_info_no_roles_forbidden(String authType, TestAccounts.KeyUser theUser, RequestSpecification authSpec) {
+
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .spec(authSpec)
+        .when()
+            .get("/user/profile")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpCode.FORBIDDEN.getStatus()))
+            ;
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_CAC_BUT_NOT_CWMS_USER)
+    void test_get_my_info_not_cwms_user_succeeds(String authType, TestAccounts.KeyUser theUser, RequestSpecification authSpec) {
+        // SPK_NOT_CWMS_USER has cac_auth, but not "CWMS Users" role.
+        // It should still be able to retrieve its own profile.
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .spec(authSpec)
+            .accept(Formats.JSON)
+        .when()
+            .get("/user/profile")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpCode.OK.getStatus()))
+            .body("user-name", equalToIgnoringCase(theUser.getName()))
+        ;
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_NORMAL)
+    void test_cross_office_update_unauthorized(String authType, TestAccounts.KeyUser theUser, RequestSpecification authSpec) throws Exception {
+        // SPK_NORMAL has roles in SPK, but not in SWT.
+        // Try to delete a location in SWT
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .spec(authSpec)
+            .queryParam("office", SWT)
+        .when()
+            .delete("/locations/" + LOCATION)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpCode.UNAUTHORIZED.getStatus()))
+        ;
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_NO_ROLES)
+    void test_roleless_update_forbidden(String authType, TestAccounts.KeyUser theUser, RequestSpecification authSpec) throws Exception {
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .spec(authSpec)
+            .queryParam("office", SPK)
+        .when()
+            .delete("/locations/" + LOCATION)
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpCode.FORBIDDEN.getStatus()))
+        ;
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_NORMAL)
+    void test_unauthorized_administrative_actions(String authType, TestAccounts.KeyUser theUser, RequestSpecification authSpec) {
+        // SPK_NORMAL has CWMS Users but NOT CWMS User Admins.
+        // Try to list all users (requires CWMS User Admins)
+        given()
+            .log().ifValidationFails(LogDetail.ALL, true)
+            .spec(authSpec)
+        .when()
+            .get("/users")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpCode.FORBIDDEN.getStatus()))
+        ;
+    }
 
     @Test
     void test_list_users_fails_if_no_auth() {

--- a/cwms-data-api/src/test/java/fixtures/TestAccounts.java
+++ b/cwms-data-api/src/test/java/fixtures/TestAccounts.java
@@ -35,6 +35,7 @@ public class TestAccounts {
         NONE("none",null,null,null,null, null), // Used for annotations
         GUEST("guest",null,null,null, null, null), // USED as marker label for tests
         SPK_NORMAL("l2hectest","l2hectest","1234567890","l2userkey","ATotallyRandomStringL2hectest","SPK", "CWMS Users", ApiServlet.CAC_USER),
+        SPK_CAC_BUT_NOT_CWMS_USER("l2hectestX","l2hectestX","1234567897","l2userkeyX","ATotallyRandomStringL2hectestX","SPK", ApiServlet.CAC_USER),
         SPK_OTHER_NORMAL_SAME_ROLES("l2hectest8","l2hectest8","12345678908","l2userkey8","ATotallyRandomStringL2hectest8","SPK", "CWMS Users", ApiServlet.CAC_USER),
         SPK_NORMAL2("l2hectest_vt","l2hectestvt","2345678901","l2userkey2","DiffrntStringL2hectest_vt","SPK", "CWMS Users", ApiServlet.CAC_USER, "CWMS User Admins"),
         SWT_NORMAL("m5hectest","swt99db","1234567890","testkey2","ATotallyRandomStringM5hectest","SWT", "CWMS Users", ApiServlet.CAC_USER),

--- a/cwms-data-api/src/test/java/fixtures/users/UserSpecSource.java
+++ b/cwms-data-api/src/test/java/fixtures/users/UserSpecSource.java
@@ -2,6 +2,7 @@ package fixtures.users;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -17,6 +18,8 @@ import fixtures.users.annotation.AuthType.UserType;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.http.Cookie;
 
+import static cwms.cda.ApiServlet.CWMS_USERS_ROLE;
+
 public class UserSpecSource implements ArgumentsProvider {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
@@ -26,15 +29,8 @@ public class UserSpecSource implements ArgumentsProvider {
      * @return
      */
     public static ArrayList<Arguments> userSpecsValidPrivsWithGuest(String office) {
-        final ArrayList<Arguments> list = new ArrayList<>();
+        final ArrayList<Arguments> list = userSpecsValidPrivs(office);
         list.add(specificUser(TestAccounts.KeyUser.GUEST));
-        Stream.of(TestAccounts.KeyUser.values())
-              .filter(u -> u.getRoles().length > 0)
-              .filter(u -> office.isEmpty() || u.getOperatingOffice().equals(office))
-              .forEach(u -> {
-                list.add(apiKeyUser(u));
-                list.add(cwmsAaaUser(u));
-              });
         return list;
     }
 
@@ -42,6 +38,7 @@ public class UserSpecSource implements ArgumentsProvider {
         final ArrayList<Arguments> list = new ArrayList<>();
         Stream.of(TestAccounts.KeyUser.values())
               .filter(u -> u.getRoles().length > 0)
+              .filter(u -> Arrays.stream(u.getRoles()).anyMatch(CWMS_USERS_ROLE::equalsIgnoreCase))
               .filter(u -> office.isEmpty() || u.getOperatingOffice().equals(office))
               .forEach(u -> {
                 list.add(apiKeyUser(u));


### PR DESCRIPTION
## Summary

Updates to allow an endpoint to specify custom role-checking logic (ex. any vs all). Updates the user/profile endpoint to authorize with either cwms users or cac auth role. 

## Related Issue
https://github.com/USACE/cwms-data-api/issues/1623

## Validation

Added integration tests

## Checklist

- [ ] AI tools used
