### PR TITLE
Load default feature properties from classpath

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/features/CdaFeatureManagerProvider.java
+++ b/cwms-data-api/src/main/java/cwms/cda/features/CdaFeatureManagerProvider.java
@@ -5,6 +5,10 @@ import org.togglz.core.manager.FeatureManager;
 import org.togglz.core.manager.FeatureManagerBuilder;
 import org.togglz.core.repository.file.FileBasedStateRepository;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import org.togglz.core.spi.FeatureManagerProvider;
 
 @AutoService(FeatureManagerProvider.class)
@@ -23,14 +27,43 @@ public class CdaFeatureManagerProvider implements FeatureManagerProvider {
         if (manager == null) {
             synchronized (this) {
                 if (manager == null) {
-                    String file = System.getProperty(PROPERTIES_FILE, DEFAULT_PROPERTIES_FILE);
                     manager = new FeatureManagerBuilder()
                             .featureEnum(CdaFeatures.class)
-                            .stateRepository(new FileBasedStateRepository(new File(file)))
+                            .stateRepository(new FileBasedStateRepository(resolvePropertiesFile()))
                             .build();
                 }
             }
         }
         return manager;
+    }
+
+    private File resolvePropertiesFile() {
+        String configuredFile = System.getProperty(PROPERTIES_FILE);
+        if (configuredFile != null && !configuredFile.isBlank()) {
+            return new File(configuredFile);
+        }
+
+        File defaultFile = new File(DEFAULT_PROPERTIES_FILE);
+        if (defaultFile.isFile()) {
+            return defaultFile;
+        }
+
+        return copyDefaultPropertiesFromClasspath();
+    }
+
+    private File copyDefaultPropertiesFromClasspath() {
+        ClassLoader classLoader = CdaFeatureManagerProvider.class.getClassLoader();
+        try (InputStream input = classLoader.getResourceAsStream(DEFAULT_PROPERTIES_FILE)) {
+            if (input == null) {
+                return new File(DEFAULT_PROPERTIES_FILE);
+            }
+
+            File tempFile = Files.createTempFile("cda-features", ".properties").toFile();
+            tempFile.deleteOnExit();
+            Files.copy(input, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            return tempFile;
+        } catch (IOException ex) {
+            throw new IllegalStateException("Unable to load default feature properties", ex);
+        }
     }
 }

--- a/cwms-data-api/src/test/java/cwms/cda/features/CdaFeatureManagerProviderTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/features/CdaFeatureManagerProviderTest.java
@@ -45,6 +45,18 @@ class CdaFeatureManagerProviderTest {
     }
 
     @Test
+    void testLoadsDefaultPropertiesFromClasspath() {
+        System.clearProperty(CdaFeatureManagerProvider.PROPERTIES_FILE);
+
+        CdaFeatureManagerProvider provider = new CdaFeatureManagerProvider();
+        FeatureManager manager = provider.getFeatureManager();
+
+        assertFalse(manager.isActive(CdaFeatures.USE_OBJECT_STORAGE_BLOBS));
+        assertFalse(manager.isActive(CdaFeatures.AUTH_RE_ENABLE_NON_HASH_KEY_SUPPORT));
+        assertTrue(manager.isActive(CdaFeatures.INCLUDE_ERROR_STACK_TRACES));
+    }
+
+    @Test
     void testUseObjectStorageBlobsFeature() throws IOException {
         File tempFile = Files.createTempFile("features", ".properties").toFile();
         tempFile.deleteOnExit();


### PR DESCRIPTION

## Summary

The packaged default now has `INCLUDE_ERROR_STACK_TRACES=true` (Per 1770), but the dev environment was not reading that value because no runtime feature file existed at the expected filesystem path.

Updates CDA feature flag loading so the default packaged `features.properties` can be used when no external Togglz properties file is configured.

CDA configured Togglz with `new File("features.properties")`, which only looks in the filesystem relative to the running process. In the container image, the default `features.properties` is packaged inside the WAR under `WEB-INF/classes`, so shared/dev environments that did not mount a separate feature file or set `-Dproperties.file=...` would not pick up the packaged defaults.

## Related Issues

Attempted to resolve with
- #1770 

## Validation

Created unit tesT:

- `./gradlew.bat :cwms-data-api:test --tests cwms.cda.features.CdaFeatureManagerProviderTest`

Also ran Checkstyle:

- `./gradlew.bat :cwms-data-api:checkstyleMain :cwms-data-api:checkstyleTest`

Built and ran a local Docker image without Docker Compose, without mounted feature files, and without `-Dproperties.file`. Verified that CDA loaded the packaged default and reported `properties.file=null` and `INCLUDE_ERROR_STACK_TRACES=true`.

Then verified explicit override behavior still works by setting `-Dproperties.file=/tmp/features-off.properties` with `INCLUDE_ERROR_STACK_TRACES=false`, which reported `properties.file=/tmp/features-off.properties` and `INCLUDE_ERROR_STACK_TRACES=false`.

Pulled down the existing docker image and confirmed it did indeed have the properties file but it was located here:

`/usr/local/tomcat/webapps/cwms-data.war > WEB-INF/classes/features.properties`
or
`/usr/local/tomcat/webapps/cwms-data/WEB-INF/classes/features.properties`


Local docker compose had me thinking it would work with this line
- https://github.com/USACE/cwms-data-api/blob/b7c4e6ee18ccd8dc2d7fef77d5ca97caa0d6f012/docker-compose.yml#L72


## Checklist

- [x] AI tools used
