### PR TITLE
add support for dev env test API key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,48 @@ The report is written to `build/reports/dependency-check-report.html`.
 
 See the docker-compose.README.md for instructions using the docker-compose environment
 
+### Running CDA locally
+
+To run CDA locally using the Gradle development task:
+
+```bash
+./gradlew run
+```
+
+The `run` task builds the WAR, generates the local Tomcat configuration, and starts an embedded Tomcat instance using the database connection and runtime settings from your Gradle properties.
+
+At minimum, configure the following properties in your user Gradle properties file, `~/.gradle/gradle.properties`:
+
+    CDA_JDBC_DRIVER=oracle.jdbc.driver.OracleDriver
+    CDA_JDBC_URL=jdbc:oracle:thin:@localhost/CWMSDB
+    CDA_JDBC_USERNAME=username
+    CDA_JDBC_PASSWORD=password
+    CDA_LISTEN_PORT=7000
+
+By default, the WAR is deployed under the `spk-data` context. To override the context path, set:
+
+    cda.war.context=cwms-data
+
+With the default port and a `cwms-data` context, the API will be available at:
+
+    http://localhost:7000/cwms-data/
+
+### Generating development API keys
+
+For local development, API keys can be generated directly for the HEC test users 
+in the configured CWMS database without requiring external auth provider setup.
+
+Run:
+```bash
+./gradlew seedDevApiKeys
+```
+
+The task finds users whose `USERID` ends with `HECTEST`, 
+creates development API keys for them, and prints the plaintext keys to the console log.
+
+The generated keys are intended for local development only. 
+The plaintext key is only available when it is created.
+
 ## Testing
 
 To run the integration tests:

--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -281,6 +281,21 @@ task run(type: JavaExec) {
     //jvmArgs += "-Dcwms.dataapi.access.openid.issuer=https://auth.test:8444/auth/realms/cwms"
 }
 
+tasks.register('seedDevApiKeys', JavaExec) {
+    group "application"
+    description = "Create development API keys for local **HECTEST users and print the plaintext keys."
+    dependsOn testClasses
+
+    classpath = sourceSets.test.runtimeClasspath
+    classpath += configurations.baseLibs
+    classpath += configurations.tomcatLibs
+
+    mainClass = "fixtures.SeedDevApiKeys"
+
+    systemProperties += project.properties.findAll { k, v -> k.startsWith("CDA") }
+//    jvmArgs += "-Djava.util.logging.config.file=$projectDir/logging.properties"
+}
+
 task integrationTests(type: Test) {
 //    dependsOn test
     dependsOn generateConfig

--- a/cwms-data-api/src/test/java/fixtures/SeedDevApiKeys.java
+++ b/cwms-data-api/src/test/java/fixtures/SeedDevApiKeys.java
@@ -1,0 +1,129 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2026 Hydrologic Engineering Center
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package fixtures;
+
+import com.google.common.flogger.FluentLogger;
+import cwms.cda.data.dao.AuthDao;
+import cwms.cda.data.dto.auth.ApiKey;
+import cwms.cda.security.CwmsAuthException;
+import cwms.cda.security.DataApiPrincipal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+public final class SeedDevApiKeys {
+    private static final FluentLogger LOGGER = FluentLogger.forEnclosingClass();
+    private static final String KEY_NAME_PREFIX = "dev-gradle-seed-";
+
+    private SeedDevApiKeys() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        String jdbcDriver = requiredProperty("CDA_JDBC_DRIVER");
+        String jdbcUrl = requiredProperty("CDA_JDBC_URL");
+        String jdbcUsername = requiredProperty("CDA_JDBC_USERNAME");
+        String jdbcPassword = requiredProperty("CDA_JDBC_PASSWORD");
+        String defaultOffice = System.getProperty("CDA_OFFICE", "HQ");
+        String keyName = KEY_NAME_PREFIX + UUID.randomUUID();
+
+        Class.forName(jdbcDriver);
+
+        Properties connectionProperties = new Properties();
+        connectionProperties.setProperty("user", jdbcUsername);
+        connectionProperties.setProperty("password", jdbcPassword);
+
+        LOGGER.atInfo().log(
+              "\n============================================================\n"
+                    + "Creating development API keys\n"
+                    + "============================================================\n"
+                    + "JDBC URL: %s\n"
+                    + "Key name: %s",
+              jdbcUrl,
+              keyName
+        );
+
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, connectionProperties)) {
+            DSLContext dsl = DSL.using(connection, SQLDialect.DEFAULT);
+            List<String> users = getHecTestUsers(dsl);
+            if (users.isEmpty()) {
+                LOGGER.atWarning().log("No **HECTEST users in the database. No keys were created.");
+            }
+            AuthDao authDao = AuthDao.getInstance(dsl, defaultOffice);
+
+            for (String user : users) {
+                createAndPrintKey(authDao, user, keyName);
+            }
+        }
+        LOGGER.atInfo().log(
+              "\n============================================================\n"
+                    + "Development API key seeding complete.\n"
+                    + "These plaintext keys are shown only because this dev seeder created them.\n"
+                    + "============================================================"
+        );
+    }
+
+    private static List<String> getHecTestUsers(DSLContext dsl) {
+        var userId = DSL.field(DSL.name("USERID"), String.class);
+        return dsl.select(userId)
+              .from(DSL.table(DSL.name("CWMS_20", "AT_SEC_CWMS_USERS")))
+              .where(userId.like("%HECTEST"))
+              .fetch(userId);
+    }
+
+    private static void createAndPrintKey(AuthDao authDao, String user, String keyName) throws CwmsAuthException {
+        DataApiPrincipal principal = new DataApiPrincipal(user, Collections.emptySet());
+        ApiKey sourceData = new ApiKey(
+              user,
+              keyName,
+              null,
+              null,
+              null
+        );
+
+        ApiKey createdKey = authDao.createApiKey(principal, sourceData);
+
+        LOGGER.atInfo().log(
+              "\n------------------------------------------------------------"
+                    + "Created development API key:\nUser: %s\nAPI key name: %s\nAPI key: %s",
+              createdKey.getUserId(),
+              createdKey.getKeyName(),
+              createdKey.getApiKey()
+        );
+    }
+
+    private static String requiredProperty(String propertyName) {
+        String value = System.getProperty(propertyName);
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("Missing required system property: " + propertyName);
+        }
+        return value;
+    }
+}


### PR DESCRIPTION
## Summary

Add gradle task that generates API keys for HECTEST users.

## Related Issue


## Validation

Tested locally against test database.

## Checklist

- [X] AI tools used - JetBrains AI Chat for README.md generation and log message cleanup
