### PR TITLE
store pump locations to fix error with nearest location

### DIFF
--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/watersupply/WaterContractDaoTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/watersupply/WaterContractDaoTestIT.java
@@ -88,6 +88,9 @@ class WaterContractDaoTestIT extends DataApiTestIT {
             try {
                 projectDao.create(testProject, true);
                 dao.storeLocation(testLocation, false);
+                dao.storeLocation(pumpInLoc, false);
+                dao.storeLocation(pumpOutLoc, false);
+                dao.storeLocation(pumpOutBelowLoc, false);
                 lookupTypeDao.storeLookupType("AT_WS_CONTRACT_TYPE", "WS_CONTRACT_TYPE",
                         buildTestWaterContract("Test", false).getContractType());
             } catch (IOException e) {


### PR DESCRIPTION
if nearest location is set to null, new database schema uses location geometry to find the nearest location via a trigger

## Summary

Fixing failing test.

## Related Issue



## Validation

CI/CD

## Checklist

- [ ] AI tools used
