### PR TITLE
CI Fix: Avoid nested pool borrow deleting TS categories

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesCategoryDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesCategoryDao.java
@@ -94,7 +94,8 @@ public class TimeSeriesCategoryDao extends JooqDao<TimeSeriesCategory> {
         connection(dsl, conn -> {
             DSLContext dslContext = getDslContext(conn, office);
 
-            if (getDbVersion() > Dao.CWMS_25_07_01) {
+            // Reuse the connection already borrowed above so small test pools don't deadlock.
+            if (currentDbVersion(dslContext) > Dao.CWMS_25_07_01) {
                 // With newer schema it should just work, don't need transaction
                 Configuration config = dslContext.configuration();
                 CWMS_TS_PACKAGE.call_DELETE_TS_CATEGORY(config, categoryId, formatBool(true), office);
@@ -116,6 +117,13 @@ public class TimeSeriesCategoryDao extends JooqDao<TimeSeriesCategory> {
             }
 
         });
+    }
+
+    private static int currentDbVersion(DSLContext dslContext) {
+        if (CURRENT_SCHEMA_VERSION == null) {
+            CURRENT_SCHEMA_VERSION = versionAsInteger(getVersion(dslContext));
+        }
+        return CURRENT_SCHEMA_VERSION;
     }
 
     public void create(TimeSeriesCategory category, boolean failIfExists, boolean ignoreNulls) {


### PR DESCRIPTION
## Summary

Fixes a pool exhaustion failure in time series category cascade delete that causes CI to fail

`TimeSeriesCategoryDao.cascadeDelete()` already borrows a connection before setting the session office and then calls `getDbVersion()` which could try to borrow a second connection from the same data source. `maxActive=1` can cause a deadlock on the request and return a 500 during category DELETE. This change checks the schema version using the existing `DSLContext`.

## Validation

Ran tests locally
- `:cwms-data-api:integrationTests --tests '*TimeSeriesCategoryControllerTestIT.test_create_update_ignore_nulls'`
- `:cwms-data-api:integrationTests --tests '*TimeSeriesCategoryControllerTestIT'`
- `:cwms-data-api:compileJava :cwms-data-api:checkstyleMain`





## Checklist

- [x] AI tools used
