### PR TITLE
Remove auth restriction on RSS, add rate limiting (1 per 10 seconds.)

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -185,6 +185,7 @@ import io.javalin.core.util.Header;
 import io.javalin.core.validation.JavalinValidation;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Handler;
+import io.javalin.http.HttpResponseException;
 import io.javalin.http.JavalinServlet;
 import io.javalin.plugin.openapi.OpenApiOptions;
 import io.javalin.plugin.openapi.OpenApiPlugin;
@@ -646,7 +647,7 @@ public class ApiServlet extends HttpServlet {
         addUserManagementHandlers();
 
         get("/version/", new CdaVersionHandler(metrics), requiredRoles);
-        get(format("/rss/{%s}/{%s}", Controllers.OFFICE, Controllers.NAME), new RssHandler(metrics), requiredRoles);
+        get(format("/rss/{%s}/{%s}", Controllers.OFFICE, Controllers.NAME), new RssHandler(metrics));
     }
 
     private void addUserManagementHandlers() {
@@ -675,7 +676,7 @@ public class ApiServlet extends HttpServlet {
 
     private void addRatingHandlers(RouteRole[] requiredRoles) {
         /**
-         * The POST handlers for /ratings/rate-* intentionally do not have 
+         * The POST handlers for /ratings/rate-* intentionally do not have
          * require roles. Instead they are rate limited if not authenticated.
          * POST is used as sending a body with GET is not standard and we cannot
          * be sure clients, or future servers, would correctly support that.

--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -934,7 +934,19 @@ public class ApiServlet extends HttpServlet {
         );
         ops.path("/swagger-docs")
             .responseModifier((ctx,api) -> {
-                api.getPaths().forEach((key,path) -> setSecurityRequirements(key,path,secReqs));
+                api.getPaths().forEach((key,path) -> {
+                    setSecurityRequirements(key,path,secReqs);
+                    // yeah, we really need to figure out how to update everything, this is supported as an annotation in
+                    // newer versions.
+                    if (key.startsWith("/rss")) {
+                        path.getGet().getResponses().forEach((p, r) -> {
+                            var retryAfter = new io.swagger.v3.oas.models.headers.Header();
+                            retryAfter.description("Amount of time (in seconds) to wait before making the next request.");
+                            r.addHeaderObject(Header.RETRY_AFTER, retryAfter);
+                        });
+                    }
+            });
+                
                 return api;
             })
             .defaultDocumentation(doc -> {
@@ -943,6 +955,7 @@ public class ApiServlet extends HttpServlet {
                 doc.json("401", CdaError.class);
                 doc.json("403", CdaError.class);
                 doc.json("404", CdaError.class);
+                doc.json("429", CdaError.class);
                 doc.header(IS_NEW_LRTS,
                     Boolean.class,
                     p -> p.description(

--- a/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/Controllers.java
@@ -195,6 +195,7 @@ public final class Controllers {
     public static final String STATUS_201 = "201";
     public static final String STATUS_204 = "204";
     public static final String STATUS_404 = "404";
+    public static final String STATUS_429 = "429";
     public static final String STATUS_501 = "501";
     public static final String STATUS_400 = "400";
     public static final String STATUS_401 = "401";

--- a/cwms-data-api/src/main/java/cwms/cda/api/rss/RssHandler.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/rss/RssHandler.java
@@ -47,6 +47,7 @@ import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
+
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -98,9 +99,10 @@ public final class RssHandler extends BaseHandler {
             @OpenApiResponse(status = STATUS_200, content = {
                 @OpenApiContent(from = RssFeed.class, type = Formats.RSS)
             }),
-            @OpenApiResponse(status = STATUS_404, description = "Unknown Feed")
+            @OpenApiResponse(status = STATUS_404, description = "Unknown Feed"),
+            @OpenApiResponse(status = STATUS_429, description = "Rate Limit exceeded.")            
         },
-        description = "Returns RSS feed items limited to the last week.",
+        description = "Returns RSS feed items limited to the last week. End point is limited to 1 request per 10 seconds per client per feed.",
         tags = {TAG}
     )
     @Override

--- a/cwms-data-api/src/main/java/cwms/cda/api/rss/RssHandler.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/rss/RssHandler.java
@@ -41,6 +41,7 @@ import cwms.cda.helpers.ReplaceUtils;
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import io.javalin.http.HttpCode;
+import io.javalin.http.util.NaiveRateLimit;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
 import io.javalin.plugin.openapi.annotations.OpenApiParam;
@@ -50,6 +51,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -102,6 +104,7 @@ public final class RssHandler extends BaseHandler {
     )
     @Override
     public void handle(@NotNull Context ctx) throws Exception {
+        NaiveRateLimit.requestPerTimeUnit(ctx, 6, TimeUnit.MINUTES);
         try (final Timer.Context ignored = markAndTime(GET_ALL)) {
             DSLContext dsl = getDslContext(ctx);
             String office = ctx.pathParam(OFFICE).toUpperCase();
@@ -120,6 +123,7 @@ public final class RssHandler extends BaseHandler {
             MessageDao dao = new MessageDao(dsl);
             RssFeed feed = dao.retrieveFeed(cursor, pageSize, office, name, since, newLinkTemplate(ctx));
             String result = Formats.format(contentType, feed);
+            ctx.header("Retry-After", "10");
             ctx.result(result);
             ctx.contentType(contentType.toString());
         }

--- a/cwms-data-api/src/main/java/cwms/cda/api/rss/RssHandler.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/rss/RssHandler.java
@@ -41,6 +41,7 @@ import cwms.cda.helpers.ReplaceUtils;
 import io.javalin.core.util.Header;
 import io.javalin.http.Context;
 import io.javalin.http.HttpCode;
+import io.javalin.http.HttpResponseException;
 import io.javalin.http.util.NaiveRateLimit;
 import io.javalin.plugin.openapi.annotations.OpenApi;
 import io.javalin.plugin.openapi.annotations.OpenApiContent;
@@ -104,8 +105,13 @@ public final class RssHandler extends BaseHandler {
     )
     @Override
     public void handle(@NotNull Context ctx) throws Exception {
-        NaiveRateLimit.requestPerTimeUnit(ctx, 6, TimeUnit.MINUTES);
         try (final Timer.Context ignored = markAndTime(GET_ALL)) {
+            // Always set these.
+            ctx.header("Retry-After", "10")
+               .header("RateLimit-Policy", "\"default\";q=6;w=60");
+            // Limit is 1 request per 10 seconds, or 6 a minute.
+            NaiveRateLimit.requestPerTimeUnit(ctx, 6, TimeUnit.MINUTES);
+
             DSLContext dsl = getDslContext(ctx);
             String office = ctx.pathParam(OFFICE).toUpperCase();
             String name = ctx.pathParam(NAME);
@@ -123,9 +129,21 @@ public final class RssHandler extends BaseHandler {
             MessageDao dao = new MessageDao(dsl);
             RssFeed feed = dao.retrieveFeed(cursor, pageSize, office, name, since, newLinkTemplate(ctx));
             String result = Formats.format(contentType, feed);
-            ctx.header("Retry-After", "10");
+
             ctx.result(result);
             ctx.contentType(contentType.toString());
+        } catch (HttpResponseException ex) {
+            // an exception to our error handling rules. HttpResponseException, includes multiple other exception
+            // and we don't want to deal with trying to distinguish in ApiServlet. For the time being this logic will
+            // remain here.
+            if (ex.getStatus() == 429) {
+                var cdaError = new CdaError("Too many requests. Limit queue requests to no more than every 10 seconds.");
+                ctx.status(ex.getStatus())
+                   .json(cdaError)
+                   .contentType(io.javalin.http.ContentType.APPLICATION_JSON);
+            } else {
+                throw ex;
+            }
         }
     }
 

--- a/cwms-data-api/src/test/java/cwms/cda/api/rss/RssHandlerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/rss/RssHandlerIT.java
@@ -141,6 +141,13 @@ final class RssHandlerIT extends DataApiTestIT {
 
             pagesVisited++;
             nextHref = nextLinkHref(nextXml);
+            String waitStr = nextPage.header("Retry-After");
+            int wait = waitStr != null && !waitStr.isEmpty() ? Integer.parseInt(waitStr) : 10;
+            try {
+                Thread.sleep(wait*1000);
+            } catch (InterruptedException ex) {
+                LOGGER.atFine().withCause(ex).log("Next query wait was interrupted.");
+            }
         }
 
         assertTrue(pagesVisited > 1, "Expected to visit more than one page");


### PR DESCRIPTION
## Summary

Remove auth restriction from RSS feed, but add rate limiting to the expected usage (e.g. 1 request per client every ten seconds)

## Related Issue

N/A

## Validation

Manually, queried a bunch until it gave me the 429.

existing integration test triggered the 429 and was modified to use the provided Retry-After value.

## Checklist

- [ ] AI tools used
