### PR TITLE
Fix CDA GUI static asset packaging

### DIFF
--- a/cda-gui/build.gradle
+++ b/cda-gui/build.gradle
@@ -53,9 +53,12 @@ sourceSets {
     java {
         main {
             resources {
-                // This makes the processResources task automatically depend on the buildWebapp one
-                srcDir(buildGui)
+                srcDir(project.layout.projectDirectory.dir('dist'))
             }
         }
     }
+}
+
+tasks.named('processResources') {
+    dependsOn buildGui
 }


### PR DESCRIPTION
## Summary

Fixes CDA GUI static asset packaging so the built front-end files are included in the deployed artifact again.

The recent `cda-gui` task split changed `buildGui` from the task that produced `dist/` into a wrapper task, but the resource wiring still pointed at `srcDir(buildGui)`. That can prevent `index.html` and `assets/*` from being packaged into the `cda-gui` jar / CDA WAR, which matches the dev behavior where:

- `/cwms-data/` returns 404
- `/cwms-data/swagger-ui` returns 404
- `/cwms-data/openapi.json` returns 404
- `/cwms-data/assets/...` returns 404

This change makes the packaging explicit by:
- wiring resources to the actual `dist/` directory
- making `processResources` depend on `buildGui`

## Root Cause

`cda-gui/build.gradle` used:

`srcDir(buildGui)`

After the GUI build refactor, `buildGui` no longer directly declared `dist/` as its output. That made the resource source ambiguous and could leave the built GUI bundle out of the packaged artifact.

## Validation

- `npm.cmd ci`
- `npm.cmd run build:development`
- Confirmed local GUI build produces:
  - `dist/index.html`
  - `dist/assets/...`

## Checklist

- [x] AI tools used