### PR TITLE
Fixed error response for bad request to Level getAll

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/LevelsController.java
@@ -60,6 +60,7 @@ import cwms.cda.helpers.DateUtils;
 import cwms.cda.helpers.annotations.IgnoreRequiredQueryParamMismatch;
 import io.javalin.apibuilder.CrudHandler;
 import io.javalin.core.util.Header;
+import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.HttpCode;
 import io.javalin.http.HttpResponseException;
@@ -74,7 +75,9 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
@@ -283,7 +286,10 @@ public class LevelsController implements CrudHandler {
             boolean includeAliases = ctx.queryParamAsClass(INCLUDE_ALIASES, Boolean.class)
                     .getOrDefault(false);
             if (!unit.equalsIgnoreCase(UnitSystem.SI.getValue()) && !unit.equalsIgnoreCase(UnitSystem.EN.getValue())) {
-                throw new IllegalArgumentException(String.format("Provided unit system is not supported: %s", unit));
+                String errorMessage = String.format("Provided unit system is not supported: %s", unit);
+                Map<String, String> errorDetails = new HashMap<>();
+                errorDetails.put("message", errorMessage);
+                throw new BadRequestResponse(errorMessage, errorDetails);
             }
             String datum = ctx.queryParam(DATUM);
             String begin = ctx.queryParam(BEGIN);

--- a/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/LevelsControllerTestIT.java
@@ -610,6 +610,27 @@ public class LevelsControllerTestIT extends DataApiTestIT {
         ;
     }
 
+    @Test
+    void test_ts_get_all_error() {
+        given()
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(Formats.JSONV2)
+            .contentType(Formats.JSONV2)
+            .queryParam(Controllers.OFFICE, OFFICE)
+            .queryParam(UNIT, "cfs")
+        .when()
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/levels/")
+        .then()
+            .log().ifValidationFails(LogDetail.ALL,true)
+        .assertThat()
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
+            .body("message", is("Bad Request"))
+            .body("source", is("User Input"))
+            .body("details.message", is("Provided unit system is not supported: cfs"))
+        ;
+    }
 
     @Test
     void test_get_all_location_level() throws Exception {


### PR DESCRIPTION
## Summary

Improves error response for bad user input. Now passes along error message to user. Discovered during levels endpoint investigation for #1663

## Related Issue

Discovered during levels endpoint investigation for #1663

## Validation

Includes integration test.

## Checklist

- [ ] AI tools used
