### PR TITLE
Bug Template not rendering

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: CDA Bug report
 description: Create a report to help us improve
-title: ""
+title: "[Bug]: "
 labels:
   - bug
 assignees:


### PR DESCRIPTION
## Summary

Checking here
https://github.com/cwms-data-api/issues/new 

I do not see the bug template

Going to the template gives an error about title being blank. 


## Checklist

- [ ] AI tools used
