### PR TITLE
CDA-129: Ratings default to XML

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/rating/RatingController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/rating/RatingController.java
@@ -77,6 +77,7 @@ import hec.data.RatingException;
 import hec.data.cwmsRating.RatingSet;
 import io.javalin.core.util.Header;
 import io.javalin.core.validation.JavalinValidation;
+import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.HttpCode;
 import io.javalin.plugin.openapi.annotations.HttpMethod;
@@ -87,6 +88,8 @@ import io.javalin.plugin.openapi.annotations.OpenApiRequestBody;
 import io.javalin.plugin.openapi.annotations.OpenApiResponse;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 import javax.xml.transform.TransformerException;
 import mil.army.usace.hec.cwms.rating.io.xml.RatingXmlFactory;
@@ -296,12 +299,12 @@ public class RatingController extends BaseCrudHandler {
                 + "field for this URI are:"
                 + "\n* `tab`"
                 + "\n* `csv`"
-                + "\n* `xml`"
-                + "\n* `json` (default)")},
+                + "\n* `xml` (default)"
+                + "\n* `json`")},
             responses = {
                 @OpenApiResponse(status = STATUS_200, content = {
-                    @OpenApiContent(type = Formats.JSON),
-                    @OpenApiContent(type = Formats.XML),
+                    @OpenApiContent(type = Formats.JSONV2),
+                    @OpenApiContent(type = Formats.XMLV2),
                     @OpenApiContent(type = Formats.TAB),
                     @OpenApiContent(type = Formats.CSV)
                 }),
@@ -327,6 +330,11 @@ public class RatingController extends BaseCrudHandler {
             String timezone = ctx.queryParamAsClass(TIMEZONE, String.class).getOrDefault("UTC");
 
             String format = ctx.queryParamAsClass(FORMAT, String.class).getOrDefault("");
+            if (!format.isEmpty() && !format.contains("version=2")) {
+                Map<String, String> details = new HashMap<>();
+                details.put("message", String.format("Invalid format. V1 formats no longer supported: %s", format));
+                throw new BadRequestResponse("", details);
+            }
             String header = ctx.header(Header.ACCEPT);
 
             ContentType contentType = Formats.parseHeaderAndQueryParm(header, format, RatingAliasMarker.class);

--- a/cwms-data-api/src/test/java/cwms/cda/api/rating/RatingsControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/rating/RatingsControllerTestIT.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 
 import static cwms.cda.api.Controllers.*;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -307,35 +308,36 @@ class RatingsControllerTestIT extends DataApiTestIT
 	@EnumSource(GetAllLegacyTest.class)
 	void test_getAll_legacy(GetAllLegacyTest test) {
 		given()
-				.log().ifValidationFails(LogDetail.ALL,true)
-				.queryParam(FORMAT, test.queryParam)
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .queryParam(FORMAT, test.queryParam)
 		.when()
-				.redirects().follow(true)
-				.redirects().max(3)
-				.get("/ratings")
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/ratings")
 		.then()
 		.assertThat()
-				.log().ifValidationFails(LogDetail.ALL,true)
-				.statusCode(is(HttpServletResponse.SC_OK))
-				.contentType(is(test.expectedContentType));
-
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpServletResponse.SC_BAD_REQUEST))
+            .body("message", equalTo("Bad Request"))
+            .body("source", equalTo("User Input"))
+            .body("details.message", equalTo("Invalid format. V1 formats no longer supported: " + test.queryParam));
 	}
 
 	@ParameterizedTest
 	@EnumSource(GetAllTest.class)
 	void test_getAll(GetAllTest test) {
 		given()
-				.log().ifValidationFails(LogDetail.ALL,true)
-				.accept(test.accept)
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .accept(test.accept)
 		.when()
-				.redirects().follow(true)
-				.redirects().max(3)
-				.get("/ratings")
+            .redirects().follow(true)
+            .redirects().max(3)
+            .get("/ratings")
 		.then()
 		.assertThat()
-				.log().ifValidationFails(LogDetail.ALL,true)
-				.statusCode(is(HttpServletResponse.SC_OK))
-				.contentType(is(test.expectedContentType));
+            .log().ifValidationFails(LogDetail.ALL,true)
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .contentType(is(test.expectedContentType));
 	}
 
 	@ParameterizedTest
@@ -445,9 +447,7 @@ class RatingsControllerTestIT extends DataApiTestIT
 	enum GetOneTest
 	{
 		DEFAULT(Formats.DEFAULT, Formats.XMLV2),
-		XML(Formats.XML, Formats.XMLV2),
 		XMLV2(Formats.XMLV2, Formats.XMLV2),
-		JSON(Formats.JSON, Formats.JSONV2),
 		JSONV2(Formats.JSONV2, Formats.JSONV2),
 		;
 
@@ -480,11 +480,7 @@ class RatingsControllerTestIT extends DataApiTestIT
 	enum GetAllTest
 	{
 		DEFAULT(Formats.DEFAULT, Formats.XMLV2),
-		XML(Formats.XML, Formats.XMLV2),
-		XMLV1(Formats.XMLV1, Formats.XMLV1),
 		XMLV2(Formats.XMLV2, Formats.XMLV2),
-		JSON(Formats.JSON, Formats.JSONV2),
-		JSONV1(Formats.JSONV1, Formats.JSONV1),
 		JSONV2(Formats.JSONV2, Formats.JSONV2),
 		;
 


### PR DESCRIPTION
## Summary

Updated ratings getAll endpoint to default to XML format. Updated endpoint to accept V2 requests only, now throws error when V1 formats are specified.

## Related Issue

Closes #699

## Validation

Updated integration tests included.

## Checklist

- [ ] AI tools used
