### PR TITLE
Initial cache setup for auth information.

### DIFF
--- a/cda-gui/package-lock.json
+++ b/cda-gui/package-lock.json
@@ -1200,9 +1200,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1217,9 +1214,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1234,9 +1228,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1242,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1268,9 +1256,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1285,9 +1270,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1302,9 +1284,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1319,9 +1298,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1336,9 +1312,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1353,9 +1326,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1370,9 +1340,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1387,9 +1354,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1368,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -17,6 +17,7 @@ import cwms.cda.security.CwmsAuthException;
 import cwms.cda.security.DataApiPrincipal;
 import cwms.cda.security.MissingRolesException;
 import cwms.cda.security.Role;
+import cwms.cda.util.LruTtlMap;
 import io.javalin.core.security.RouteRole;
 import io.javalin.http.Context;
 import io.javalin.http.HttpCode;
@@ -112,6 +113,9 @@ public class AuthDao extends Dao<DataApiPrincipal> {
      */
     private static ThreadLocal<AuthDao> instance = new ThreadLocal<>();
 
+    // start with ten second cache
+    private static final LruTtlMap<String, DataApiPrincipal> authCache = new LruTtlMap<>(150, 10_000);
+
     private AuthDao(DSLContext dsl, String defaultOffice) {
         super(dsl);
         if (getDbVersion(dsl) < Dao.CWMS_23_03_16) {
@@ -180,9 +184,11 @@ public class AuthDao extends Dao<DataApiPrincipal> {
      * @throws CwmsAuthException throw for any issue with verification of Key or user information.
      */
     public DataApiPrincipal getByApiKey(String apikey) throws CwmsAuthException {
-        String userName = checkKey(apikey);
-        Set<RouteRole> roles = getRolesForUser(userName);
-        return new DataApiPrincipal(userName,roles);
+        return authCache.computeIfAbsent(apikey, providedKey -> {
+            String userName = checkKey(providedKey);
+            Set<RouteRole> roles = getRolesForUser(userName);
+            return new DataApiPrincipal(userName,roles);
+        });
     }
 
     /**
@@ -637,16 +643,18 @@ public class AuthDao extends Dao<DataApiPrincipal> {
      * @throws CwmsAuthException if anything goes wrong with the database query.
      */
     public Optional<DataApiPrincipal> getPrincipalFromPrincipal(String principal) throws CwmsAuthException {
-        String user = userForPrincipal(principal);
-        if (user != null) {
-            Set<RouteRole> roles = this.getRolesForUser(user);
-            // In this case "cac_auth" just means the user is an actually user verify by some sort of
-            // identify management system. E.g. "not an apikey"
-            roles.add(new Role("cac_auth"));
-            return Optional.of(new DataApiPrincipal(user, roles));
-        } else {
-            return Optional.empty();
-        }
+        return Optional.ofNullable(authCache.computeIfAbsent(principal, newPrincipal -> {
+            String user = userForPrincipal(principal);
+            if (user != null) {
+                Set<RouteRole> roles = this.getRolesForUser(user);
+                // In this case "cac_auth" just means the user is an actually user verify by some sort of
+                // identify management system. E.g. "not an apikey"
+                roles.add(new Role("cac_auth"));
+                return new DataApiPrincipal(user, roles);
+            } else {
+                return null;
+            }
+        }));
     }
 
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -645,6 +645,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
     public Optional<DataApiPrincipal> getPrincipalFromPrincipal(String principal) throws CwmsAuthException {
         return Optional.ofNullable(authCache.computeIfAbsent(principal, newPrincipal -> {
             String user = userForPrincipal(principal);
+            logger.atInfo().log("Setup user %s from principal %s", user, principal);
             if (user != null) {
                 Set<RouteRole> roles = this.getRolesForUser(user);
                 // In this case "cac_auth" just means the user is an actually user verify by some sort of
@@ -677,7 +678,7 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                     updateData.execute();
                 } 
             });
-            logger.atInfo().log("Created user {} from principal {}", username, principal);
+            logger.atInfo().log("Created user %s from principal %s", username, principal);
             Optional<DataApiPrincipal> apiPrincipal = getPrincipalFromPrincipal(principal);
             if (apiPrincipal.isPresent()) {
                 return apiPrincipal.get();

--- a/cwms-data-api/src/main/java/cwms/cda/util/LruTtlMap.java
+++ b/cwms-data-api/src/main/java/cwms/cda/util/LruTtlMap.java
@@ -1,0 +1,150 @@
+package cwms.cda.util;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class LruTtlMap<K,V> implements Map<K,V> {
+
+    private final long ttl;
+    private final int maxSize;
+    private final Map<K, TtlEntry<V>> map;
+
+    public LruTtlMap(int maxSize, int ttl)
+    {
+        this.ttl = ttl;
+        this.maxSize = maxSize;
+        map = Collections.synchronizedMap(
+            new LinkedHashMap<K, TtlEntry<V>>(maxSize, 0.75f, true)
+            {
+                @Override
+                protected boolean removeEldestEntry(Map.Entry<K,LruTtlMap.TtlEntry<V>> eldest) {
+                    return this.size() > LruTtlMap.this.maxSize;
+                };
+            }
+        );
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return false; // todo?
+    }
+
+    @Override
+    public V get(Object key) {
+        var entry = map.get(key);
+        V ret = null;
+
+        if (entry != null && (System.currentTimeMillis() - entry.insertTime) >= ttl) {
+            map.remove(key);
+            ret = null;
+        } else if (entry != null) {
+            ret = entry.value;
+        }
+        return ret;
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return value != null ? map.put(key, new TtlEntry<>(value)).value : null;
+    }
+
+    @Override
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        return map.computeIfAbsent(key, newKey -> new TtlEntry<V>(mappingFunction.apply(newKey))).value;
+    }
+
+    @Override
+    public V remove(Object key) {
+        var entry = map.remove(key);
+        if (entry != null) {
+            return entry.value;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        m.forEach((k,v) -> put(k,v));
+    }
+
+    @Override
+    public void clear() {
+        map.clear();;
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return map.values()
+                  .stream()
+                  .map(e -> e != null ? e.value : null)
+                  .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return map.entrySet()
+                  .stream()
+                  .map(es -> {
+                      var v = es.getValue();
+                      return new Entry<K,V>() {
+
+                          @Override
+                          public K getKey() {
+                              return es.getKey();
+                          }
+
+                          @Override
+                          public V getValue() {
+                              return v != null ? v.value : null;
+                          }
+
+                          @Override
+                          public V setValue(V value) {
+                              throw new UnsupportedOperationException(
+                                "method 'setValue' is not supported."
+                            );
+                          }
+                      };
+                  })
+                  .collect(Collectors.toSet());
+    }
+
+    private static class TtlEntry<V>
+    {
+        private final long insertTime;
+        private final V value;
+
+        public TtlEntry(V value)
+        {
+            this.value = value;
+            insertTime = System.currentTimeMillis();
+        }
+    }
+
+}

--- a/cwms-data-api/src/main/java/cwms/cda/util/LruTtlMap.java
+++ b/cwms-data-api/src/main/java/cwms/cda/util/LruTtlMap.java
@@ -54,13 +54,18 @@ public class LruTtlMap<K,V> implements Map<K,V> {
         var entry = map.get(key);
         V ret = null;
 
-        if (entry != null && (System.currentTimeMillis() - entry.insertTime) >= ttl) {
+        if (entry != null && isExpired(entry)) {
             map.remove(key);
             ret = null;
         } else if (entry != null) {
             ret = entry.value;
         }
         return ret;
+    }
+
+    private boolean isExpired(TtlEntry<V> entry)
+    {
+        return (System.currentTimeMillis() - entry.insertTime) >= ttl;
     }
 
     @Override
@@ -70,6 +75,11 @@ public class LruTtlMap<K,V> implements Map<K,V> {
 
     @Override
     public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        TtlEntry<V> entry = map.get(key);
+        if (entry != null && (isExpired(entry) || entry.value == null)) // treat expired as equivalent to abenst
+        {
+            map.remove(key);
+        }
         return map.computeIfAbsent(key, newKey -> new TtlEntry<V>(mappingFunction.apply(newKey))).value;
     }
 


### PR DESCRIPTION
## Summary

Reduce database load per request by caching DataPrincipal objects for some amount of time
before reloading from the database.

The TTL is "fixed", e.g. after the timeout the value is remove regardless of usage. This so that we don't over cache principal objects in case of removed credentials.
The LRU portion is so that the map object has bounded memory.

NOTE: I do *not* expect this to work well or be used for time series caching, that requires some more complexity.

## Related Issue

No open issue

## Validation

General usage within the API.

TODO:
 
- [ ] Individual test of LruTtlCache will be created.

caching does work, but some issues with behavior definitely indicate some specific formal tests are required. Will get to those eventually, and any comments about it welcome. Design commentary definitely welcome.


## Checklist

- [ ] AI tools used
