### PR TITLE
Improve Data Query CSV column headers for readability

### DIFF
--- a/cda-gui/src/pages/data-query/index.jsx
+++ b/cda-gui/src/pages/data-query/index.jsx
@@ -774,12 +774,15 @@ export default function DataQuery() {
     // Build table params from timeseriesData
     if (!timeseriesData) return [];
     return timeseriesData.tsids
-      .map((series) => ({
-        tsid: series.name,
-        header: `${series.name.split(".")[1]} (${series.units})`,
-        rounding: getPrecision(series.units),
-        units: series.units,
-      }))
+      .map((series) => {
+        const [location, parameter] = series.name.split(".");
+        return {
+          tsid: series.name,
+          header: `${location} ${parameter} (${series.units})`,
+          rounding: getPrecision(series.units),
+          units: series.units,
+        };
+      })
       .filter((p) => visibleTSIDs.includes(p.tsid));
   }, [timeseriesData, visibleTSIDs]);
   const visibleLoadedTsids = useMemo(


### PR DESCRIPTION
## Summary

- Includes the timeseries location ID in query column headers
- Makes is so when you pick more than one project the csv shows location+parameter in the headers if you download it
- Example being headers such as `Elev (ft)` to `WTYT2 Elev (ft)` if you got WTYT2 selected

## Validation

-Tested in a local copy in swf's internal, csv's downloaded fine with the change there.  

## Checklist

- [ ] AI tools used

