### PR TITLE
Prefer OpenID for Swagger login when available

### DIFF
--- a/cda-gui/src/pages/swagger-ui/index.jsx
+++ b/cda-gui/src/pages/swagger-ui/index.jsx
@@ -40,18 +40,6 @@ function isLocalOrigin(url) {
   return isLoopbackHost(new URL(url).hostname);
 }
 
-async function isCwmsLoginAvailable() {
-  try {
-    const response = await fetch(`${window.location.origin}/CWMSLogin`, {
-      cache: "no-store",
-      redirect: "manual",
-    });
-    return response.type === "opaqueredirect" || response.status < 400;
-  } catch {
-    return false;
-  }
-}
-
 function getKeycloakConfig(spec) {
   const scheme = getOpenIdConnectScheme(spec);
   if (!scheme?.openIdConnectUrl) {
@@ -178,18 +166,22 @@ export default function SwaggerUI() {
       }
       normalizeOpenIdConnectUrls(spec);
       const keycloakConfig = getKeycloakConfig(spec);
-      const hasCwmsLogin = getCwmsLoginScheme(spec) && (await isCwmsLoginAvailable());
-      const nextCustomAuthType = hasCwmsLogin
-        ? "cwms"
-        : keycloakConfig
-          ? "openid"
+      const hasCwmsLogin = Boolean(getCwmsLoginScheme(spec));
+      // Some non-T7 deployments advertise CwmsAAACacAuth even though their
+      // /CWMSLogin route is only a generic landing page. Prefer a usable
+      // OpenID configuration when both schemes are present; T7 deployments
+      // that advertise only CWMS AAA still use the shared CWMS session flow.
+      const nextCustomAuthType = keycloakConfig
+        ? "openid"
+        : hasCwmsLogin
+          ? "cwms"
           : null;
 
       if (customAuthType !== nextCustomAuthType) {
         setCustomAuthType(nextCustomAuthType);
       }
 
-      if (hasCwmsLogin) {
+      if (nextCustomAuthType === "cwms") {
         setAuthUiMode("cwms-login");
       } else if (nextCustomAuthType === "openid" && keycloakConfig) {
         const keycloakConfigSignature = JSON.stringify(keycloakConfig);


### PR DESCRIPTION
## Summary

  - Prefer a valid OpenID configuration when Swagger advertises both OpenID and CWMS AAA authentication.
  - Continue using CWMS AAA for T7 deployments where it is the available custom login method.
  - Remove the `/CWMSLogin` availability probe, which could mistake an unrelated successful HTML response for a working CWMS AAA login endpoint.

  This is a UI hotfix for CWBI/AWS deployments. The dev deployment currently advertises `CwmsAAACacAuth` even though it is not running with T7/CWMS AAA.
  Its `/CWMSLogin` path returns the generic water.dev landing page with HTTP 200, causing the UI to incorrectly select CWMS AAA instead of the valid OpenID configuration.

  **The backend should still be corrected** so CWBI/AWS deployments do not advertise CWMS AAA when it is unavailable.

  When I looked back, it appeared that `cwms.dataapi.access.providers` stopped controlling active authentication providers after authentication was refactored in #1073. `Authenticator` now loads every service-provided `IdentityProvider` whose `getScheme()` returns a value. Because `CwmsAaaIdentityProvider.getScheme()` always returns a scheme, `CwmsAAACacAuth` is included in the generated OpenAPI document even when the configured provider list is `KeyAccessManager,OpenID`.

  A backend fix could fix provider filtering in `Authenticator`, this keeps the existing provider name mappings:

## Related Issue

- #1073

## Validation

- `npx.cmd eslint src/pages/swagger-ui/index.jsx --ext js,jsx --report-
  unused-disable-directives --max-warnings 0`
- `npm.cmd run build`
- Inspected the dev Swagger document and authentication endpoints:
- OpenID discovery and PKCE configuration are available.
- `/CWMSLogin` returns the generic water.dev HTML page rather than a CWMS AAA login flow.

## Checklist

- [x] AI tools used
