### PR TITLE
Refresh Swagger authentication before API requests

### DIFF
--- a/cda-gui/src/pages/swagger-ui/index.jsx
+++ b/cda-gui/src/pages/swagger-ui/index.jsx
@@ -32,6 +32,45 @@ function getCwmsLoginScheme(spec) {
   return spec.components?.securitySchemes?.CwmsAAACacAuth;
 }
 
+function removeGroundworkManagedSecuritySchemes(spec) {
+  const securitySchemes = spec.components?.securitySchemes ?? {};
+  const managedSchemeNames = new Set(
+    Object.entries(securitySchemes)
+      .filter(
+        ([name, scheme]) =>
+          name === "CwmsAAACacAuth" || scheme.type === "openIdConnect",
+      )
+      .map(([name]) => name),
+  );
+
+  for (const schemeName of managedSchemeNames) {
+    delete securitySchemes[schemeName];
+  }
+
+  const removeManagedRequirements = (security) => {
+    if (!Array.isArray(security)) return security;
+
+    return security
+      .map((requirement) =>
+        Object.fromEntries(
+          Object.entries(requirement).filter(
+            ([schemeName]) => !managedSchemeNames.has(schemeName),
+          ),
+        ),
+      )
+      .filter((requirement) => Object.keys(requirement).length > 0);
+  };
+
+  spec.security = removeManagedRequirements(spec.security);
+  for (const pathItem of Object.values(spec.paths ?? {})) {
+    for (const operation of Object.values(pathItem)) {
+      if (operation && typeof operation === "object" && "security" in operation) {
+        operation.security = removeManagedRequirements(operation.security);
+      }
+    }
+  }
+}
+
 function isLoopbackHost(hostname) {
   return ["localhost", "127.0.0.1", "::1"].includes(hostname);
 }
@@ -184,6 +223,7 @@ export default function SwaggerUI() {
         : keycloakConfig
           ? "openid"
           : null;
+      let groundworkControlsAuth = hasCwmsLogin;
 
       if (customAuthType !== nextCustomAuthType) {
         setCustomAuthType(nextCustomAuthType);
@@ -215,6 +255,7 @@ export default function SwaggerUI() {
                 : "external-openid",
             );
             setIsOpenIdAuthReady(true);
+            groundworkControlsAuth = true;
           } catch (error) {
             openIdAuthMethodRef.current = null;
             openIdAuthConfigSignatureRef.current = null;
@@ -238,13 +279,17 @@ export default function SwaggerUI() {
         return;
       }
 
-      const ui = SwaggerUIBundle({
+      if (groundworkControlsAuth) {
+        removeGroundworkManagedSecuritySchemes(spec);
+      }
+
+      SwaggerUIBundle({
         spec,
         dom_id: "#swagger-ui",
         deepLinking: false,
         presets: [SwaggerUIBundle.presets.apis],
         plugins: [SwaggerUIBundle.plugins.DownloadUrl],
-        requestInterceptor: (req) => {
+        requestInterceptor: async (req) => {
           const requestUrl = new URL(req.url, window.location.origin);
           if (requestUrl.hostname === "auth") {
             requestUrl.protocol = window.location.protocol;
@@ -261,8 +306,25 @@ export default function SwaggerUI() {
             req.url = requestUrl.toString();
             req.headers = req.headers ?? {};
 
-            if (authMethod?.token) {
-              req.headers.Authorization = `Bearer ${authMethod.token}`;
+            try {
+              let token;
+              if (authMethod?.getValidToken) {
+                token = await authMethod.getValidToken(60);
+              } else if (authMethod?.token && authMethod.refresh) {
+                await authMethod.refresh();
+                token = authMethod.token;
+              } else {
+                token = authMethod?.token;
+              }
+              if (token) {
+                req.headers.Authorization = `Bearer ${token}`;
+              }
+            } catch (error) {
+              setAuthStatus("anonymous");
+              setAuthError(
+                "Your authentication session expired. Sign in before retrying this request.",
+              );
+              throw error;
             }
 
             req.cache = "no-store";
@@ -270,30 +332,6 @@ export default function SwaggerUI() {
             req.headers.Pragma = "no-cache";
           }
           return req;
-        },
-        onComplete: () => {
-          for (const schemeName in spec.components?.securitySchemes ?? {}) {
-            const scheme = spec.components.securitySchemes[schemeName];
-            if (scheme.type === "openIdConnect") {
-              if (isExternalOpenIdOnLocalhost(keycloakConfig)) {
-                break;
-              }
-
-              let additionalParams = null;
-              let hints = scheme["x-kc_idp_hint"];
-              if (hints) {
-                additionalParams = {
-                  kc_idp_hint: hints.values[0],
-                };
-              }
-              ui.initOAuth({
-                clientId: scheme["x-oidc-client-id"],
-                usePkceWithAuthorizationCodeGrant: true,
-                additionalQueryStringParams: additionalParams,
-              });
-              break;
-            }
-          }
         },
       });
     }
@@ -431,14 +469,14 @@ export default function SwaggerUI() {
             )}
           </div>
           <div className="flex flex-wrap items-center gap-2 sm:justify-end">
-            {authMethod && (
+            {authMethod && !isAuthenticated && (
               <button
                 className="h-9 rounded border border-blue-700 bg-blue-600 px-4 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-55"
                 disabled={isCheckingAuth}
                 onClick={startLogin}
                 type="button"
               >
-                {isAuthenticated ? "Reauthenticate" : "Sign in"}
+                Sign in
               </button>
             )}
             {isAuthenticated && (


### PR DESCRIPTION
> [!IMPORTANT]
> Merge and release [Groundwork Water PR #309](https://github.com/USACE-WaterManagement/groundwork-water/pull/309) first. Before merging this PR, update `@usace-watermanagement/groundwork-water` in `cda-gui/package.json` and `cda-gui/package-lock.json` to the actual published version containing `getValidToken`, then rerun the validation below.

## Summary

- Refresh the Groundwork-managed token immediately before each Swagger API request.
- Make Groundwork the single owner of OIDC and AAA authentication state.
- Remove Swagger's duplicate OIDC/AAA authorization controls while preserving API-key authorization.
- Remove the confusing detached **Reauthenticate** action.
- Retain a backward-compatible refresh fallback until this PR is updated to the newly published Groundwork version.

## Why

CDA instantiates the Groundwork auth method directly rather than through `AuthProvider`, so Groundwork's polling refresh was not running. Swagger's request interceptor could therefore read a stale token. Swagger UI and Groundwork also maintained parallel OIDC state, which exposed authentication controls disconnected from one another.

## Related Issue

N/A

## Validation

- CDA GUI ESLint passed.
- CDA GUI production build passed against the locally linked Groundwork change.
- Real local CDA/Keycloak integration using the configured 300-second access-token lifespan:
  - Initial secured Swagger request returned HTTP 200.
  - After more than six minutes idle, another Execute refreshed authentication and returned HTTP 200 without reauthentication.
  - No browser errors occurred.

## Checklist

- [x] AI tools used
- [ ] Groundwork Water PR #309 has been merged and released.
- [ ] CDA's Groundwork dependency and lockfile have been updated to that published version.
- [ ] Validation has been rerun against the published package.