### PR TITLE
fix: prevent CDA GUI auth bootstrap crash

### DIFF
--- a/cda-gui/package.json
+++ b/cda-gui/package.json
@@ -8,6 +8,7 @@
     "build": "vite build --mode production && node scripts/generate-sitemap.mjs",
     "build:development": "vite build --mode development && node scripts/generate-sitemap.mjs",
     "build:test": "vite build --mode test && node scripts/generate-sitemap.mjs",
+    "test": "node --test src/utils/auth-config.test.js",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "prepare": "cd .. && husky cda-gui/.husky",

--- a/cda-gui/src/components/AppAuthProvider.jsx
+++ b/cda-gui/src/components/AppAuthProvider.jsx
@@ -1,0 +1,121 @@
+import {
+  AuthProvider,
+  createKeycloakAuthMethod,
+} from "@usace-watermanagement/groundwork-water";
+import PropTypes from "prop-types";
+import { useEffect, useState } from "react";
+
+import { getBasePath } from "../utils/base";
+import { getKeycloakConfig, normalizeOpenIdConnectUrls } from "../utils/auth-config";
+import { AuthConfigurationContext } from "./auth-configuration-context";
+
+function createLocalAuthMethod() {
+  let token;
+  return {
+    async login() {
+      const response = await fetch(
+        `${import.meta.env.VITE_AUTH_HOST}/realms/${import.meta.env.VITE_AUTH_REALM}/protocol/openid-connect/token`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({
+            grant_type: "password",
+            client_id: "cwms",
+            username: import.meta.env.VITE_AUTH_USER,
+            password: import.meta.env.VITE_AUTH_PASSWORD,
+          }),
+        },
+      );
+      if (!response.ok) {
+        throw new Error(`Local Keycloak login failed (${response.status})`);
+      }
+      token = (await response.json()).access_token;
+    },
+    async logout() {
+      token = undefined;
+    },
+    async isAuth() {
+      return !!token;
+    },
+    get token() {
+      return token;
+    },
+  };
+}
+
+const unavailableAuthMethod = {
+  async login() {},
+  async logout() {},
+  async isAuth() {
+    return false;
+  },
+  get token() {
+    return undefined;
+  },
+};
+
+async function loadDeployedAuthMethod() {
+  const response = await fetch(`${getBasePath()}/swagger-docs`, {
+    cache: "no-store",
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`OpenAPI request failed with HTTP ${response.status}`);
+  }
+
+  const spec = await response.json();
+  normalizeOpenIdConnectUrls(spec, window.location.origin);
+  const config = getKeycloakConfig(spec, window.location.href);
+  if (!config) {
+    throw new Error("The OpenAPI document does not advertise a usable OpenID client.");
+  }
+  return createKeycloakAuthMethod(config);
+}
+
+export default function AppAuthProvider({ children }) {
+  const [state, setState] = useState(() =>
+    import.meta.env.MODE === "dev-cda-compose"
+      ? { method: createLocalAuthMethod(), error: null }
+      : { method: null, error: null },
+  );
+
+  useEffect(() => {
+    if (state.method) return undefined;
+
+    let cancelled = false;
+    loadDeployedAuthMethod()
+      .then((method) => {
+        if (!cancelled) setState({ method, error: null });
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setState({
+            method: unavailableAuthMethod,
+            error: `Sign-in is unavailable: ${error?.message ?? "invalid authentication configuration"}`,
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [state.method]);
+
+  if (!state.method) {
+    return (
+      <div className="p-6 text-slate-700" role="status">
+        Loading authentication configuration…
+      </div>
+    );
+  }
+
+  return (
+    <AuthConfigurationContext.Provider value={{ error: state.error }}>
+      <AuthProvider method={state.method}>{children}</AuthProvider>
+    </AuthConfigurationContext.Provider>
+  );
+}
+
+AppAuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/cda-gui/src/components/AuthButton.jsx
+++ b/cda-gui/src/components/AuthButton.jsx
@@ -1,8 +1,18 @@
 import { useAuth } from "@usace-watermanagement/groundwork-water";
 import { LoginButton } from "@usace/groundwork";
+import { useAuthConfiguration } from "./auth-configuration-context";
 
 export default function AuthButton() {
   const auth = useAuth();
+  const { error } = useAuthConfiguration();
+
+  if (error) {
+    return (
+      <span className="text-sm text-white" title={error}>
+        Sign-in unavailable
+      </span>
+    );
+  }
 
   return auth.isAuth ? (
     <button className="text-white underline" type="button" onClick={auth.logout}>

--- a/cda-gui/src/components/GlobalErrorBoundary.jsx
+++ b/cda-gui/src/components/GlobalErrorBoundary.jsx
@@ -1,0 +1,39 @@
+import PropTypes from "prop-types";
+import { Component } from "react";
+
+export default class GlobalErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error("Uncaught CDA GUI error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <main className="p-6">
+          <h1 className="text-lg font-semibold text-red-700">Something went wrong</h1>
+          <p className="mt-2 text-slate-700">
+            {this.state.error?.message ?? "An unexpected error occurred."}
+          </p>
+          <a className="mt-4 inline-block text-blue-700 underline" href="/cwms-data/">
+            Return to CDA
+          </a>
+        </main>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+GlobalErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/cda-gui/src/components/auth-configuration-context.js
+++ b/cda-gui/src/components/auth-configuration-context.js
@@ -1,0 +1,7 @@
+import { createContext, useContext } from "react";
+
+export const AuthConfigurationContext = createContext({ error: null });
+
+export function useAuthConfiguration() {
+  return useContext(AuthConfigurationContext);
+}

--- a/cda-gui/src/main.jsx
+++ b/cda-gui/src/main.jsx
@@ -5,10 +5,6 @@ import { Link, createBrowserRouter, RouterProvider } from "react-router-dom";
 
 import { LinkProvider } from "@usace/groundwork";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import {
-  AuthProvider,
-  createKeycloakAuthMethod,
-} from "@usace-watermanagement/groundwork-water";
 
 // Pages
 import Home from "./pages/Home";
@@ -28,54 +24,10 @@ import Timestamps from "./pages/timestamps";
 import LegacyFormat from "./pages/legacy-format/index.jsx";
 import UserLists from "./pages/user-lists/index.jsx";
 import { routePaths } from "./route-paths";
+import AppAuthProvider from "./components/AppAuthProvider.jsx";
+import GlobalErrorBoundary from "./components/GlobalErrorBoundary.jsx";
 
 const queryClient = new QueryClient();
-
-function createLocalAuthMethod() {
-  let token;
-  return {
-    async login() {
-      const response = await fetch(
-        `${import.meta.env.VITE_AUTH_HOST}/realms/${import.meta.env.VITE_AUTH_REALM}/protocol/openid-connect/token`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: new URLSearchParams({
-            grant_type: "password",
-            client_id: "cwms",
-            username: import.meta.env.VITE_AUTH_USER,
-            password: import.meta.env.VITE_AUTH_PASSWORD,
-          }),
-        },
-      );
-      if (!response.ok) {
-        throw new Error(`Local Keycloak login failed (${response.status})`);
-      }
-      token = (await response.json()).access_token;
-    },
-    async logout() {
-      token = undefined;
-    },
-    async isAuth() {
-      return !!token;
-    },
-    get token() {
-      return token;
-    },
-  };
-}
-
-const authMethod =
-  import.meta.env.MODE === "dev-cda-compose"
-    ? createLocalAuthMethod()
-    : createKeycloakAuthMethod({
-        host: import.meta.env.VITE_AUTH_HOST,
-        realm: import.meta.env.VITE_AUTH_REALM,
-        client: "cwms",
-        flow: "authorization-code-pkce",
-        redirectUri: window.location.href,
-        providerHint: "federation-eams",
-      });
 const routeComponents = {
   home: Home,
   "swagger-ui": SwaggerUI,
@@ -110,12 +62,14 @@ const router = createBrowserRouter(
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <AuthProvider method={authMethod}>
-        <LinkProvider component={Link} hrefMap="to">
-          <RouterProvider router={router} />
-        </LinkProvider>
-      </AuthProvider>
-    </QueryClientProvider>
+    <GlobalErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <AppAuthProvider>
+          <LinkProvider component={Link} hrefMap="to">
+            <RouterProvider router={router} />
+          </LinkProvider>
+        </AppAuthProvider>
+      </QueryClientProvider>
+    </GlobalErrorBoundary>
   </React.StrictMode>,
 );

--- a/cda-gui/src/main.jsx
+++ b/cda-gui/src/main.jsx
@@ -1,5 +1,5 @@
-// Routing
 import React from "react";
+// Routing
 import ReactDOM from "react-dom/client";
 import { Link, createBrowserRouter, RouterProvider } from "react-router-dom";
 

--- a/cda-gui/src/pages/ErrorFallback.jsx
+++ b/cda-gui/src/pages/ErrorFallback.jsx
@@ -1,9 +1,9 @@
 import { Button } from "@usace/groundwork";
-import PropTypes from "prop-types";
 import { FaArrowLeft } from "react-icons/fa";
-import { Link } from "react-router-dom";
+import { Link, useRouteError } from "react-router-dom";
 
-export default function ErrorFallback({ error }) {
+export default function ErrorFallback() {
+  const error = useRouteError();
   return (
     <div className="p-6">
       <h2 className="text-lg font-semibold text-red-600">Something went wrong</h2>
@@ -24,9 +24,3 @@ export default function ErrorFallback({ error }) {
     </div>
   );
 }
-
-ErrorFallback.propTypes = {
-  error: PropTypes.shape({
-    message: PropTypes.string,
-  }),
-};

--- a/cda-gui/src/pages/swagger-ui/index.jsx
+++ b/cda-gui/src/pages/swagger-ui/index.jsx
@@ -8,63 +8,14 @@ import {
 } from "@usace-watermanagement/groundwork-water";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { getBasePath } from "../../utils/base";
-
-function normalizeOpenIdConnectUrls(spec) {
-  const schemes = spec.components?.securitySchemes ?? {};
-  for (const scheme of Object.values(schemes)) {
-    if (scheme.type === "openIdConnect" && scheme.openIdConnectUrl) {
-      const openIdConnectUrl = new URL(scheme.openIdConnectUrl, window.location.origin);
-      if (openIdConnectUrl.hostname === "auth") {
-        openIdConnectUrl.protocol = window.location.protocol;
-        openIdConnectUrl.host = window.location.host;
-        scheme.openIdConnectUrl = openIdConnectUrl.toString();
-      }
-    }
-  }
-}
-
-function getOpenIdConnectScheme(spec) {
-  const schemes = spec.components?.securitySchemes ?? {};
-  return Object.values(schemes).find((scheme) => scheme.type === "openIdConnect");
-}
+import {
+  getKeycloakConfig,
+  isLoopbackHost,
+  normalizeOpenIdConnectUrls,
+} from "../../utils/auth-config";
 
 function getCwmsLoginScheme(spec) {
   return spec.components?.securitySchemes?.CwmsAAACacAuth;
-}
-
-function isLoopbackHost(hostname) {
-  return ["localhost", "127.0.0.1", "::1"].includes(hostname);
-}
-
-function isLocalOrigin(url) {
-  return isLoopbackHost(new URL(url).hostname);
-}
-
-function getKeycloakConfig(spec) {
-  const scheme = getOpenIdConnectScheme(spec);
-  if (!scheme?.openIdConnectUrl) {
-    return null;
-  }
-
-  const openIdConnectUrl = new URL(scheme.openIdConnectUrl);
-  const realmMatch = openIdConnectUrl.pathname.match(/^(.*)\/realms\/([^/]+)\//);
-  if (!realmMatch) {
-    return null;
-  }
-
-  const providerHint = scheme["x-kc_idp_hint"]?.values?.[0];
-  const useLocalDevCredentials = isLocalOrigin(openIdConnectUrl);
-  return {
-    host: `${openIdConnectUrl.origin}${realmMatch[1]}`,
-    realm: realmMatch[2],
-    client: scheme["x-oidc-client-id"],
-    flow: useLocalDevCredentials ? "direct-grant" : "authorization-code-pkce",
-    username: useLocalDevCredentials ? "m5hectest" : undefined,
-    password: useLocalDevCredentials ? "m5hectest" : undefined,
-    redirectUri: window.location.href.split("?")[0],
-    postLogoutRedirectUri: window.location.href.split("?")[0],
-    providerHint: useLocalDevCredentials ? undefined : providerHint,
-  };
 }
 
 function isExternalOpenIdOnLocalhost(keycloakConfig) {
@@ -164,8 +115,8 @@ export default function SwaggerUI() {
         }
         return;
       }
-      normalizeOpenIdConnectUrls(spec);
-      const keycloakConfig = getKeycloakConfig(spec);
+      normalizeOpenIdConnectUrls(spec, window.location.origin);
+      const keycloakConfig = getKeycloakConfig(spec, window.location.href);
       const hasCwmsLogin = Boolean(getCwmsLoginScheme(spec));
       // Some non-T7 deployments advertise CwmsAAACacAuth even though their
       // /CWMSLogin route is only a generic landing page. Prefer a usable

--- a/cda-gui/src/pages/user-lists/index.jsx
+++ b/cda-gui/src/pages/user-lists/index.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button, Card, H1, Text } from "@usace/groundwork";
 import { useAuth } from "@usace-watermanagement/groundwork-water";
+import { useAuthConfiguration } from "../../components/auth-configuration-context";
 import { FaUsers } from "react-icons/fa";
 import { request, userListsFrom } from "./api";
 import { OfficeSelector } from "./components/OfficeSelector";
@@ -12,6 +13,7 @@ import { UserListsHeader } from "./components/UserListsHeader";
 
 export default function UserLists() {
   const auth = useAuth();
+  const { error: authConfigurationError } = useAuthConfiguration();
   const [profile, setProfile] = useState(null);
   const [profileLoading, setProfileLoading] = useState(true);
   const [office, setOffice] = useState("");
@@ -290,12 +292,14 @@ export default function UserLists() {
         </div>
         <H1>User Lists</H1>
         <Text className="mx-auto mt-3 max-w-lg">
-          Sign in to view reusable recipient lists and manage membership for your
-          authorized CWMS offices.
+          {authConfigurationError ??
+            "Sign in to view reusable recipient lists and manage membership for your authorized CWMS offices."}
         </Text>
-        <Button className="mt-6" type="button" onClick={auth.login}>
-          Log in
-        </Button>
+        {!authConfigurationError && (
+          <Button className="mt-6" type="button" onClick={auth.login}>
+            Log in
+          </Button>
+        )}
       </Card>
     );
   }

--- a/cda-gui/src/utils/auth-config.js
+++ b/cda-gui/src/utils/auth-config.js
@@ -1,0 +1,52 @@
+export function isLoopbackHost(hostname) {
+  return ["localhost", "127.0.0.1", "::1"].includes(hostname);
+}
+
+export function getOpenIdConnectScheme(spec) {
+  const schemes = spec.components?.securitySchemes ?? {};
+  return Object.values(schemes).find((scheme) => scheme.type === "openIdConnect");
+}
+
+export function normalizeOpenIdConnectUrls(spec, currentOrigin) {
+  const schemes = spec.components?.securitySchemes ?? {};
+  for (const scheme of Object.values(schemes)) {
+    if (scheme.type === "openIdConnect" && scheme.openIdConnectUrl) {
+      const openIdConnectUrl = new URL(scheme.openIdConnectUrl, currentOrigin);
+      if (openIdConnectUrl.hostname === "auth") {
+        const currentUrl = new URL(currentOrigin);
+        openIdConnectUrl.protocol = currentUrl.protocol;
+        openIdConnectUrl.host = currentUrl.host;
+        scheme.openIdConnectUrl = openIdConnectUrl.toString();
+      }
+    }
+  }
+}
+
+export function getKeycloakConfig(spec, currentUrl) {
+  const scheme = getOpenIdConnectScheme(spec);
+  if (!scheme?.openIdConnectUrl || !scheme["x-oidc-client-id"]) {
+    return null;
+  }
+
+  const pageUrl = new URL(currentUrl);
+  const openIdConnectUrl = new URL(scheme.openIdConnectUrl, pageUrl.origin);
+  const realmMatch = openIdConnectUrl.pathname.match(/^(.*)\/realms\/([^/]+)\//);
+  if (!realmMatch) {
+    return null;
+  }
+
+  const providerHint = scheme["x-kc_idp_hint"]?.values?.[0];
+  const useLocalDevCredentials = isLoopbackHost(openIdConnectUrl.hostname);
+  const redirectUri = `${pageUrl.origin}${pageUrl.pathname}`;
+  return {
+    host: `${openIdConnectUrl.origin}${realmMatch[1]}`,
+    realm: realmMatch[2],
+    client: scheme["x-oidc-client-id"],
+    flow: useLocalDevCredentials ? "direct-grant" : "authorization-code-pkce",
+    username: useLocalDevCredentials ? "m5hectest" : undefined,
+    password: useLocalDevCredentials ? "m5hectest" : undefined,
+    redirectUri,
+    postLogoutRedirectUri: redirectUri,
+    providerHint: useLocalDevCredentials ? undefined : providerHint,
+  };
+}

--- a/cda-gui/src/utils/auth-config.test.js
+++ b/cda-gui/src/utils/auth-config.test.js
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getKeycloakConfig, normalizeOpenIdConnectUrls } from "./auth-config.js";
+
+function specWithOpenId(openIdConnectUrl, client = "cwms") {
+  return {
+    components: {
+      securitySchemes: {
+        OpenID: {
+          type: "openIdConnect",
+          openIdConnectUrl,
+          "x-oidc-client-id": client,
+          "x-kc_idp_hint": { values: ["federation-eams"] },
+        },
+      },
+    },
+  };
+}
+
+test("returns null when the deployment does not advertise OpenID", () => {
+  assert.equal(getKeycloakConfig({}, "https://water.dev.cwbi.us/cwms-data/"), null);
+});
+
+test("returns null when the OpenID client is missing", () => {
+  const spec = specWithOpenId(
+    "https://identity-test.cwbi.us/auth/realms/cwbi/.well-known/openid-configuration",
+  );
+  delete spec.components.securitySchemes.OpenID["x-oidc-client-id"];
+
+  assert.equal(getKeycloakConfig(spec, "https://water.dev.cwbi.us/cwms-data/"), null);
+});
+
+test("derives deployed Keycloak configuration from the OpenAPI document", () => {
+  const spec = specWithOpenId(
+    "https://identity-test.cwbi.us/auth/realms/cwbi/.well-known/openid-configuration",
+  );
+
+  assert.deepEqual(
+    getKeycloakConfig(
+      spec,
+      "https://water.dev.cwbi.us/cwms-data/user-lists?office=SWT",
+    ),
+    {
+      host: "https://identity-test.cwbi.us/auth",
+      realm: "cwbi",
+      client: "cwms",
+      flow: "authorization-code-pkce",
+      username: undefined,
+      password: undefined,
+      redirectUri: "https://water.dev.cwbi.us/cwms-data/user-lists",
+      postLogoutRedirectUri: "https://water.dev.cwbi.us/cwms-data/user-lists",
+      providerHint: "federation-eams",
+    },
+  );
+});
+
+test("rewrites the compose-only auth hostname to the visible origin", () => {
+  const spec = specWithOpenId(
+    "http://auth:8080/auth/realms/cwms/.well-known/openid-configuration",
+  );
+
+  normalizeOpenIdConnectUrls(spec, "http://localhost:8081");
+
+  assert.equal(
+    spec.components.securitySchemes.OpenID.openIdConnectUrl,
+    "http://localhost:8081/auth/realms/cwms/.well-known/openid-configuration",
+  );
+});


### PR DESCRIPTION
## Summary

- Load deployed Keycloak settings at runtime from the OpenAPI document instead of eagerly reading build-time Vite variables.
- Keep the CDA GUI available when OpenID configuration is missing or invalid, and show a controlled sign-in-unavailable state.
- Add a true application-level React error boundary and correct the React Router error fallback to use `useRouteError()`.
- Share OpenID/Keycloak parsing between the application auth provider and Swagger UI, with focused regression tests.

## Related Issue

Follow-up to #1734.

The user-list UI introduced an app-wide `createKeycloakAuthMethod()` call during `main.jsx` module evaluation. The deployable production-mode bundle does not define `VITE_AUTH_HOST`, so Groundwork received `host: undefined` and failed on `host.trim()` before React or the router error boundary could render. This left the CWBI dev UI on a white error page.

## User Impact

CDA now derives authentication configuration from the deployment's own OpenAPI document. If the deployment does not advertise usable OpenID configuration, public CDA pages remain available and authenticated features explain that sign-in is unavailable instead of crashing the entire application.

## Validation

- `npm run test` — 4 tests passed
- `npm run lint`
- `npm run build` using Vite production mode
- Repeated test, lint, and production build in an isolated `npm ci --ignore-scripts` installation using the locked Groundwork 3.9.0 dependency
- Loaded the production artifact locally in a browser with unavailable OpenID configuration; verified the CDA introduction page rendered, the sign-in-unavailable state appeared, the page was not blank, and the console had no errors

## Checklist

- [x] AI tools used
