### PR TITLE
fix: return 200 for CDA GUI client routes

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/servlet/SpaErrorStatusFilter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/servlet/SpaErrorStatusFilter.java
@@ -1,0 +1,74 @@
+package cwms.cda.servlet;
+
+import java.io.IOException;
+import java.util.Set;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Converts the error dispatch used to load known client-side routes into a successful response.
+ */
+public final class SpaErrorStatusFilter implements Filter {
+
+    // Keep these paths synchronized with cda-gui/src/route-paths.js.
+    private static final Set<String> SPA_ROUTES = Set.of(
+        "/data-query",
+        "/filter-expressions",
+        "/legacy-format",
+        "/location-search",
+        "/regexp",
+        "/swagger-ui",
+        "/timestamps",
+        "/user-lists"
+    );
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest)request;
+        HttpServletResponse httpResponse = (HttpServletResponse)response;
+
+        if (isClientRoute(httpRequest)) {
+            httpResponse.setStatus(HttpServletResponse.SC_OK);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private boolean isClientRoute(HttpServletRequest request) {
+        String method = request.getMethod();
+        if (!"GET".equalsIgnoreCase(method) && !"HEAD".equalsIgnoreCase(method)) {
+            return false;
+        }
+
+        Object errorRequestUri = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI);
+        if (!(errorRequestUri instanceof String)) {
+            return false;
+        }
+
+        String path = removeContextPath((String)errorRequestUri, request.getContextPath());
+        if (path.length() > 1 && path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        return SPA_ROUTES.contains(path);
+    }
+
+    private String removeContextPath(String requestUri, String contextPath) {
+        if (contextPath == null || contextPath.isEmpty()) {
+            return requestUri;
+        }
+        if (requestUri.equals(contextPath)) {
+            return "/";
+        }
+        if (requestUri.startsWith(contextPath + "/")) {
+            return requestUri.substring(contextPath.length());
+        }
+        return requestUri;
+    }
+}

--- a/cwms-data-api/src/main/java/cwms/cda/servlet/SpaErrorStatusFilter.java
+++ b/cwms-data-api/src/main/java/cwms/cda/servlet/SpaErrorStatusFilter.java
@@ -2,18 +2,21 @@ package cwms.cda.servlet;
 
 import java.io.IOException;
 import java.util.Set;
+import javax.servlet.DispatcherType;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * Converts the error dispatch used to load known client-side routes into a successful response.
  */
+@WebFilter(urlPatterns = {"/index.html"}, dispatcherTypes = {DispatcherType.ERROR})
 public final class SpaErrorStatusFilter implements Filter {
 
     // Keep these paths synchronized with cda-gui/src/route-paths.js.

--- a/cwms-data-api/src/main/webapp/WEB-INF/web.xml
+++ b/cwms-data-api/src/main/webapp/WEB-INF/web.xml
@@ -39,16 +39,6 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
-    <filter>
-        <filter-name>SpaErrorStatusFilter</filter-name>
-        <filter-class>cwms.cda.servlet.SpaErrorStatusFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>SpaErrorStatusFilter</filter-name>
-        <url-pattern>/index.html</url-pattern>
-        <dispatcher>ERROR</dispatcher>
-    </filter-mapping>
-
     <!-- Client Side Routing for React -->
     <error-page>
         <error-code>404</error-code>

--- a/cwms-data-api/src/main/webapp/WEB-INF/web.xml
+++ b/cwms-data-api/src/main/webapp/WEB-INF/web.xml
@@ -39,6 +39,16 @@
         <url-pattern>/*</url-pattern>
     </filter-mapping>
 
+    <filter>
+        <filter-name>SpaErrorStatusFilter</filter-name>
+        <filter-class>cwms.cda.servlet.SpaErrorStatusFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>SpaErrorStatusFilter</filter-name>
+        <url-pattern>/index.html</url-pattern>
+        <dispatcher>ERROR</dispatcher>
+    </filter-mapping>
+
     <!-- Client Side Routing for React -->
     <error-page>
         <error-code>404</error-code>

--- a/cwms-data-api/src/test/java/cwms/cda/servlet/SpaErrorStatusFilterTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/servlet/SpaErrorStatusFilterTest.java
@@ -1,0 +1,104 @@
+package cwms.cda.servlet;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SpaErrorStatusFilterTest {
+
+    private final SpaErrorStatusFilter filter = new SpaErrorStatusFilter();
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/data-query",
+        "/filter-expressions",
+        "/legacy-format",
+        "/location-search",
+        "/regexp",
+        "/swagger-ui",
+        "/swagger-ui/",
+        "/timestamps",
+        "/user-lists"
+    })
+    void returnsOkForClientRoutes(String route) throws ServletException, IOException {
+        HttpServletRequest request = buildRequest("GET", "/cwms-data" + route);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void returnsOkForHeadRequest() throws ServletException, IOException {
+        HttpServletRequest request = buildRequest("HEAD", "/cwms-data/swagger-ui");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void returnsOkForAlternateContextPath() throws ServletException, IOException {
+        HttpServletRequest request = buildRequest("GET", "/spk-data/swagger-ui", "/spk-data");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response).setStatus(HttpServletResponse.SC_OK);
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void preservesNotFoundStatusForUnknownRoutes() throws ServletException, IOException {
+        HttpServletRequest request = buildRequest("GET", "/cwms-data/not-a-client-route");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response, never()).setStatus(HttpServletResponse.SC_OK);
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void preservesNotFoundStatusForNonPageRequests() throws ServletException, IOException {
+        HttpServletRequest request = buildRequest("POST", "/cwms-data/swagger-ui");
+        HttpServletResponse response = mock(HttpServletResponse.class);
+        FilterChain chain = mock(FilterChain.class);
+
+        filter.doFilter(request, response, chain);
+
+        verify(response, never()).setStatus(HttpServletResponse.SC_OK);
+        verify(chain).doFilter(request, response);
+    }
+
+    private HttpServletRequest buildRequest(String method, String requestUri) {
+        return buildRequest(method, requestUri, "/cwms-data");
+    }
+
+    private HttpServletRequest buildRequest(String method, String requestUri, String contextPath) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getMethod()).thenReturn(method);
+        when(request.getContextPath()).thenReturn(contextPath);
+        when(request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI)).thenReturn(requestUri);
+        return request;
+    }
+}

--- a/cwms-data-api/src/test/java/cwms/cda/servlet/SpaErrorStatusFilterTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/servlet/SpaErrorStatusFilterTest.java
@@ -1,14 +1,17 @@
 package cwms.cda.servlet;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import javax.servlet.DispatcherType;
 import javax.servlet.FilterChain;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
+import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Test;
@@ -18,6 +21,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 class SpaErrorStatusFilterTest {
 
     private final SpaErrorStatusFilter filter = new SpaErrorStatusFilter();
+
+    @Test
+    void registersForIndexErrorDispatches() {
+        WebFilter annotation = SpaErrorStatusFilter.class.getAnnotation(WebFilter.class);
+
+        assertArrayEquals(new String[] {"/index.html"}, annotation.urlPatterns());
+        assertArrayEquals(new DispatcherType[] {DispatcherType.ERROR}, annotation.dispatcherTypes());
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {


### PR DESCRIPTION
I had been sitting on this branch for a minute and thought I would go ahead and PR it. 

See Daniel's reported issue for details
- #1687

~~Infra was setup i believe to support having CDA's UI and API being split.~~

~~instead of~~
~~https://cwms-data.usace.army.mil/cwms-data being the UI and API~~

~~https://cwms-data.usace.army.mil -> UI~~
~~https://cwms-data.usace.army.mil/cwms-data -> API~~

Additional comment added below.



## Summary

- return HTTP 200 when known CDA GUI routes are served through the React client-side routing fallback
- preserve the existing 404 status for unknown paths and non-page requests
- support alternate CDA deployment context paths and trailing-slash navigation

## Root Cause

Tomcat routes missing static resources through the `404` error-page mapping to `index.html`. The React app therefore renders successfully, but the original 404 status remains on the response. Reverse proxies and web crawlers treat that successful page as missing.

The new error-dispatch filter changes the status only for known GUI `GET` and `HEAD` routes. API and unknown-route 404 behavior is left intact.

## Related Issue

Closes #1687

## Validation

- `./gradlew :cwms-data-api:test --tests 'cwms.cda.servlet.SpaErrorStatusFilterTest'` — 13 passed
- `./gradlew :cwms-data-api:checkstyleMain :cwms-data-api:checkstyleTest :cwms-data-api:test --tests 'cwms.cda.servlet.SpaErrorStatusFilterTest'` — passed; the new files have no Checkstyle findings
- `./gradlew build` — compilation, GUI build, WAR packaging, and 745 tests passed; the test task failed on 9 existing Mockito failures under local JDK 21 while mocking generated/final classes
- Integration tests were not run because this routing change does not require Oracle/CWMS infrastructure

## Checklist

- [x] AI tools used