### PR TITLE
add in public_name and long_name to project catalog query

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/project/ProjectDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/project/ProjectDao.java
@@ -202,9 +202,13 @@ public class ProjectDao extends JooqDao<Project> {
         Project.Builder builder = new Project.Builder();
         String prjOffice = resultSet.getString(OFFICE_ID);
         String prjId = resultSet.getString(PROJECT_ID);
+        String publicName = resultSet.getString(PUBLIC_NAME);
+        String longName = resultSet.getString(LONG_NAME);
         Location prjLoc = new Location.Builder(prjOffice, prjId)
-                .withActive(null)
-                .build();
+              .withPublicName(publicName)
+              .withLongName(longName)
+              .withActive(null)
+              .build();
 
         builder.withLocation(prjLoc);
         builder.withAuthorizingLaw(resultSet.getString(AUTHORIZING_LAW));
@@ -435,73 +439,6 @@ public class ProjectDao extends JooqDao<Project> {
         }
 
         return retval;
-    }
-
-
-    /**
-     * Retrieves the locations associated with a project.
-     *
-     * @param office The office ID associated with the project.
-     * @return A list of Location objects representing the project's locations.
-     */
-    public List<Location> catProject(String office) {
-
-        return connectionResult(dsl, c -> {
-            Configuration conf = getDslContext(c, office).configuration();
-            CAT_PROJECT catProject = CWMS_PROJECT_PACKAGE.call_CAT_PROJECT(conf, office);
-
-            // catProject has two open ResultSets.
-            // Other places close the basin one we aren't using
-            // FYI basinRs here is a MockResultSet
-            // The MockResultSet.close() impl just sets its internal Result variable to null
-            // So I suspect that with jOOQ we don't actually have to "close" anything here.
-            ResultSet basinRs = catProject.getP_BASIN_CAT().intoResultSet();
-            if (basinRs != null && !basinRs.isClosed()) {
-                basinRs.close();
-            }
-
-            Result<Record> projectCatalog = catProject.getP_PROJECT_CAT();
-            return projectCatalog.map(this::buildLocation);
-        });
-    }
-
-    private Location buildLocation(Record r) {
-
-        String office = r.get(DB_OFFICE_ID, String.class);
-
-        String base = r.get(BASE_LOCATION_ID, String.class);
-        String sub = r.get(SUB_LOCATION_ID, String.class);
-        String name = getLocationId(base, sub);
-        Location.Builder builder = new Location.Builder(office, name);
-
-        String timeZoneName = r.get(TIME_ZONE_NAME, String.class);
-        if (timeZoneName != null) {
-            builder.withTimeZoneName(toZoneId(timeZoneName, name));
-        }
-        Double latitude = r.get(LATITUDE, Double.class);
-        if (latitude != null) {
-            builder.withLatitude(latitude);
-        }
-        Double longitude = r.get(LONGITUDE, Double.class);
-        if (longitude != null) {
-            builder.withLongitude(longitude);
-        }
-        String horizontalDatum = r.get(HORIZONTAL_DATUM, String.class);
-        if (horizontalDatum != null) {
-            builder.withHorizontalDatum(horizontalDatum);
-        }
-        builder.withElevation(r.get(ELEVATION, Double.class));
-        builder.withElevationUnits(r.get(ELEV_UNIT_ID, String.class));
-        builder.withVerticalDatum(r.get(VERTICAL_DATUM, String.class));
-        builder.withPublicName(r.get(PUBLIC_NAME, String.class));
-        builder.withLongName(r.get(LONG_NAME, String.class));
-        builder.withDescription(r.get(DESCRIPTION, String.class));
-        String activeStr = r.get(ACTIVE_FLAG, String.class);
-        if (activeStr != null) {
-            builder.withActive(parseBool(activeStr));
-        }
-
-        return builder.build();
     }
 
 }

--- a/cwms-data-api/src/main/resources/cwms/data/sql/project/project_select.sql
+++ b/cwms-data-api/src/main/resources/cwms/data/sql/project/project_select.sql
@@ -1,5 +1,7 @@
 select project.office_id,
        project.location_id as project_id,
+       project.public_name,
+       project.long_name,
        project.COST_YEAR,
        project.federal_cost,
        project.nonfederal_cost,
@@ -20,8 +22,10 @@ select project.office_id,
        project.project_remarks
 from ( select o.office_id as office_id,
               bl.base_location_id
-                  ||substr('-', 1, length(pl.sub_location_id))
-                  ||pl.sub_location_id as location_id,
+                 ||substr('-', 1, length(pl.sub_location_id))
+                 ||pl.sub_location_id as location_id,
+              pl.public_name,
+              pl.long_name,
               p.COST_YEAR,
               p.federal_cost,
               p.nonfederal_cost,

--- a/cwms-data-api/src/test/java/cwms/cda/api/ProjectControllerIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/ProjectControllerIT.java
@@ -251,6 +251,8 @@ final class ProjectControllerIT extends DataApiTestIT {
             .body("projects[0].location", not(empty()))
             .body("projects[0].location.office-id", equalTo(office))
             .body("projects[0].location.name", equalTo(loc.getName()))
+            .body("projects[0].location.public-name", equalTo(loc.getPublicName()))
+            .body("projects[0].location.long-name", equalTo(loc.getLongName()))
             .body("projects[0].federal-cost", equalTo(100))
             .body("projects[0].non-federal-cost", equalTo(50))
             .body("projects[0].federal-o-and-m-cost", equalTo(10f))


### PR DESCRIPTION
this brings it into parity with the java JDBC client without adding another join

## Summary

add in public_name and long_name to project catalog query

## Related Issue

REGI relies on these fields for displaying the project catalog.

## Validation

Integration testing. Testing through REGI UI.

## Checklist

- [ ] AI tools used
