### PR TITLE
Add reproducible development container

### DIFF
--- a/.devcontainer/.gitattributes
+++ b/.devcontainer/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.10.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e",
+      "integrity": "sha256:c2c2cf829505ead8e4892c88c31b6594ae94a2bbb209e16e1fac456c1a3a624e"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "1.8.1",
+      "resolved": "ghcr.io/devcontainers/features/java@sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48",
+      "integrity": "sha256:8157bab2d8d71e40b2f3128c162fab763e2b11038fdd33784549290a5d386b48"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "1.8.0",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511",
+      "integrity": "sha256:fbcad6955caeecc5ad3f7886baf652e25cba5225a6c4c2287c536de2e5607511"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+  "name": "CWMS Data API",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "11",
+      "jdkDistro": "ms"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "latest",
+      "moby": true,
+      "dockerDashComposeVersion": "v2"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "22"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.13",
+      "installTools": false
+    }
+  },
+  "containerEnv": {
+    "TESTCONTAINERS_HOST_OVERRIDE": "host.docker.internal"
+  },
+  "forwardPorts": [7000, 8081, 5173, 8000],
+  "portsAttributes": {
+    "7000": {
+      "label": "CDA Gradle server"
+    },
+    "8081": {
+      "label": "CDA Docker Compose stack"
+    },
+    "5173": {
+      "label": "CDA GUI development server"
+    },
+    "8000": {
+      "label": "Sphinx documentation server"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "vscjava.vscode-java-pack",
+        "vscjava.vscode-gradle",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "ms-python.python"
+      ]
+    }
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git config --global --add safe.directory "$PWD"
+
+# Docker Desktop bind mounts preserve Windows line endings and expose every file as executable.
+# Match Git for Windows so the same checkout stays clean inside the container.
+if grep -qi microsoft /proc/version; then
+    git config --global core.autocrlf true
+fi
+
+# npm 10 strips platform metadata from the committed lockfile during the Gradle GUI build.
+npm install --global npm@11
+
+./gradlew --version

--- a/README.md
+++ b/README.md
@@ -76,6 +76,30 @@ End user documentation available here: [📕 Read the Docs](https://cwms-data-ap
 
 Development and runtime currently requires java 11. JDKs and JREs greater than 11 should work, please report if they don't.
 
+### Dev Container
+
+The repository includes a [Dev Container](https://containers.dev/) with Java 11, Node.js 22,
+Python 3.13, and Docker Compose. It supports the Gradle build, CDA GUI and client development,
+documentation builds, the local Docker Compose stack, and Docker-backed integration tests.
+
+To use it locally:
+
+1. Install Docker and the Visual Studio Code Dev Containers extension.
+2. Open the cloned repository in Visual Studio Code.
+3. Run **Dev Containers: Reopen in Container** from the command palette.
+
+GitHub Codespaces also detects the same configuration automatically. The first container creation
+downloads the development image and initializes the Gradle wrapper. After it completes, run the
+normal project commands from the container terminal, for example:
+
+```bash
+./gradlew build
+docker compose up -d --force-recreate
+```
+
+The integration tests use the host Docker engine through the forwarded Docker socket. Their database
+setup has the same resource and startup-time requirements described in [Testing](#testing).
+
 
 To build the war:
 


### PR DESCRIPTION
## Summary

- add a locked Dev Container configuration for Java 11, Node.js 22/npm 11, Python 3.13, and Docker Compose
- forward the CDA, Compose, Vite, and Sphinx development ports
- support Testcontainers and the existing Compose stack through the host Docker socket
- normalize Git behavior for Windows Docker Desktop bind mounts without changing the shared repository configuration
- document local VS Code and GitHub Codespaces usage

## Developer impact

A fresh clone can be reopened in a container or Codespace and use the repository's Gradle, frontend, documentation, Docker Compose, and Docker-backed test workflows without installing those toolchains directly on the host.

## Validation

- `npx @devcontainers/cli up --workspace-folder <standalone-clean-clone> --remove-existing-container`
- verified Java 11, Node.js 22, npm 11, Python 3.13, Docker client/server, and Docker Compose inside the container
- `docker run --rm alpine:3.21 echo docker-socket-ok`
- `docker compose config --quiet`
- `./gradlew :docs:buildDocs --no-daemon`
- `./gradlew build --no-daemon` compiled Java, built the production GUI and WAR, ran Checkstyle, and completed 743 tests: 741 passed, 37 skipped, and two existing `CwmsDTOValidatorTest` performance assertions exceeded their 150/200 ms thresholds on the Windows bind mount
- `./gradlew :cwms-data-api:test --tests '*CwmsDTOValidatorTest' --no-daemon` passed on the Windows host baseline; the container-only failures are limited to those timing thresholds
- verified npm 11 leaves `cda-gui/package-lock.json` unchanged after `npm install`
- `git diff --check`

Integration tests were not run because they provision the Oracle/CWMS test infrastructure and are separate from the default build.

## Checklist

- [x] AI tools used
