### PR TITLE
Ensure provider instances remains in the active providers list so it …

### DIFF
--- a/access-manager-api/src/main/java/cwms/cda/spi/IdentityProvider.java
+++ b/access-manager-api/src/main/java/cwms/cda/spi/IdentityProvider.java
@@ -22,7 +22,7 @@ public interface IdentityProvider {
     /**
      * Define the OpenAPI V3 Security Scheme for this manager.
      *
-     * @return SecurityScheme
+     * @return SecurityScheme or null if the scheme should not be active at this time.
      */
     SecurityScheme getScheme();
 }

--- a/cwms-data-api/src/main/java/cwms/cda/security/Authenticator.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/Authenticator.java
@@ -21,7 +21,8 @@ public final class Authenticator implements Handler {
         final var supressedList = surpressed == null ? List.of() : List.of(surpressed.split(","));
 
         CdaIdentityProviders.providers().forEachRemaining(provider -> {
-            if (!supressedList.contains(provider.getName()) && provider.getScheme() != null) {
+            // only exclude if supressed, inactive providers will return a null scheme.
+            if (!supressedList.contains(provider.getName())) {
                 providers.add(provider);
             } else {
                 logger.atSevere()

--- a/cwms-data-api/src/main/java/cwms/cda/security/OpenIdConnectIdentitityProvider.java
+++ b/cwms-data-api/src/main/java/cwms/cda/security/OpenIdConnectIdentitityProvider.java
@@ -86,7 +86,7 @@ public final class OpenIdConnectIdentitityProvider implements IdentityProvider {
                 return c; // already initialized, don't change it.
             }
             try {
-                log.atFine().log("Attempting to initalize OIDC provider for %s", wellKnownUrl);
+                log.atFine().log("Attempting to initalize OIDC provider for '%s'", wellKnownUrl);
                 URL wellKnown = new URL(wellKnownUrl);
                 return OpenIDConfig.from(wellKnown, clientId, idpHint, timeout);
             } catch (IOException ex) {


### PR DESCRIPTION
…can be appropriately updated and used.

## Summary

Runtime OpenAPI spec was not being update with the retrieved OpenId realm info once validated.

## Related Issue

Fixes #1858

## Validation

Manually tested, with more extensive test. Left auth service inaccessible for a few minutes after starting CDA instance, started CDA, saw config retrieved. 

Initially saw no change in OpenAPI spec, after fix, saw changes in OpenAPI Spec.

## Checklist

- [ ] AI tools used
