### PR TITLE
Actually output the trace context in the docker image.

### DIFF
--- a/cwms-data-api/src/docker/logback-juli.xml
+++ b/cwms-data-api/src/docker/logback-juli.xml
@@ -19,7 +19,7 @@
     <logger name="org.apache" level="ERROR"/>
 
     <logger name="org.apache.catalina" level="INFO" additivity="false">
-        <appender-ref ref="STDERR" />
+        <appender-ref ref="OTEL-STDERR" />
     </logger>
 
     <logger name="org.apache.catalina.core.ContainerBase.[Catalina]" level="INFO" additivity="false">

--- a/cwms-data-api/src/docker/logback-juli.xml
+++ b/cwms-data-api/src/docker/logback-juli.xml
@@ -3,13 +3,17 @@
 <configuration>
     <import class="org.apache.juli.logging.ch.qos.logback.classic.encoder.JsonEncoder"/>
     <import class="org.apache.juli.logging.ch.qos.logback.core.ConsoleAppender"/>
-
     <variable name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
     <contextName>CWMS-Data-API</contextName>
     <appender name="STDERR" class="ConsoleAppender">
         <encoder class="JsonEncoder"/>
         <target>System.err</target>
-    </appender>    
+    </appender>
+
+    <appender name="OTEL-STDERR" class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+        <appender-ref ref="STDERR"/>
+    </appender>
+
 
     <logger name="cwms.cda" level="${LOG_LEVEL}"/>
     <logger name="org.apache" level="ERROR"/>
@@ -19,10 +23,10 @@
     </logger>
 
     <logger name="org.apache.catalina.core.ContainerBase.[Catalina]" level="INFO" additivity="false">
-        <appender-ref ref="STDERR" />
+        <appender-ref ref="OTEL-STDERR" />
     </logger>
 
     <root level="INFO">
-        <appender-ref ref="STDERR"/>
+        <appender-ref ref="OTEL-STDERR"/>
     </root>
 </configuration>

--- a/cwms-data-api/src/docker/logback.xml
+++ b/cwms-data-api/src/docker/logback.xml
@@ -4,26 +4,32 @@
     <import class="ch.qos.logback.classic.encoder.JsonEncoder"/>
     <import class="ch.qos.logback.core.ConsoleAppender"/>
 
+
     <variable name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}"/>
     <contextName>CWMS-Data-API</contextName>
     <appender name="STDERR" class="ConsoleAppender">
         <encoder class="JsonEncoder"/>
         <target>System.err</target>
-    </appender>    
+    </appender>
+
+    <appender name="OTEL-STDERR" class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+        <appender-ref ref="STDERR"/>
+    </appender>
+
 
     <logger name="cwms.cda" level="${LOG_LEVEL}"/>
     <logger name="org.apache" level="ERROR"/>
 
     <logger name="org.apache.catalina" level="INFO" additivity="false">
-        <appender-ref ref="STDERR" />
+        <appender-ref ref="OTEL-STDERR" />
     </logger>
 
     <logger name="org.apache.catalina.core.ContainerBase.[Catalina]" level="INFO" additivity="false">
-        <appender-ref ref="STDERR" />
+        <appender-ref ref="OTEL-STDERR" />
     </logger>
-    
+
 
     <root level="INFO">
-        <appender-ref ref="STDERR"/>
-    </root>   
+        <appender-ref ref="OTEL-STDERR"/>
+    </root>
 </configuration>


### PR DESCRIPTION
## Summary

While working on https://github.com/HydrologicEngineeringCenter/cwms-python/pull/305, discovered that while we process the traceparent header, we never actually output the trace_id and span_id for viewing and analysis in the logs.

## Related Issue

Closes #

## Validation

Describe how this was tested.

## Checklist

- [ ] AI tools used
