### PR TITLE
remove 404 when no gate changes found

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/OutletDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/OutletDao.java
@@ -44,6 +44,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -285,14 +286,7 @@ public class OutletDao extends JooqDao<Outlet> {
                     unitSystem.getValue(), formatBool(startInclusive), formatBool(endInclusive), rowLimitBig);
 
             if (changeTab == null) {
-                throw new NotFoundException("No changes found for " + projectId.getOfficeId() + "."
-                        + projectId.getName()
-                + "\nStart time: " + startTime
-                + "\nEnd time: " + endTime
-                + "\nStart inclusive: " + startInclusive
-                + "\nEnd inclusive: " + endInclusive
-                + "\nUnit system: " + unitSystem
-                + "\nRow limit: " + rowLimit);
+                return Collections.emptyList();
             }
             return changeTab.stream().map(OutletDao::map).collect(Collectors.toList());
         });

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/OutletDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/location/kind/OutletDao.java
@@ -24,7 +24,6 @@ import static cwms.cda.data.dao.location.kind.LocationUtil.getLocationRef;
 
 import cwms.cda.api.enums.UnitSystem;
 import cwms.cda.api.errors.DeleteConflictException;
-import cwms.cda.api.errors.NotFoundException;
 import cwms.cda.data.dao.DeleteRule;
 import cwms.cda.data.dao.JooqDao;
 import cwms.cda.data.dao.LocationGroupDao;

--- a/cwms-data-api/src/test/java/cwms/cda/api/location/kind/GateChangeControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/location/kind/GateChangeControllerTestIT.java
@@ -284,7 +284,8 @@ class GateChangeControllerTestIT extends BaseOutletDaoIT {
             .log()
             .ifValidationFails(LogDetail.ALL, true)
             .assertThat()
-            .statusCode(is(HttpServletResponse.SC_NOT_FOUND));
+            .statusCode(is(HttpServletResponse.SC_OK))
+            .body("isEmpty()", is(true));
     }
 
     @Test

--- a/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoChangeIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dao/location/kind/OutletDaoChangeIT.java
@@ -22,7 +22,6 @@ package cwms.cda.data.dao.location.kind;
 
 import com.google.common.flogger.FluentLogger;
 import cwms.cda.api.enums.UnitSystem;
-import cwms.cda.api.errors.NotFoundException;
 import cwms.cda.data.dao.DeleteRule;
 import cwms.cda.data.dto.CwmsId;
 import cwms.cda.data.dto.Location;
@@ -46,7 +45,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import static cwms.cda.data.dao.DaoTest.getDslContext;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
 class OutletDaoChangeIT extends BaseOutletDaoIT {
@@ -148,7 +147,7 @@ class OutletDaoChangeIT extends BaseOutletDaoIT {
             assertContainsAll(changes, modifiedChange, CHANGE_2);
 
             dao.deleteOperationalChanges(PROJECT_1_ID, JAN_FIRST, JAN_SECOND, true);
-            assertThrows(NotFoundException.class, () -> dao.retrieveOperationalChanges(PROJECT_1_ID, JAN_FIRST, JAN_SECOND, true, true, UnitSystem.EN, 3));
+            assertTrue(dao.retrieveOperationalChanges(PROJECT_1_ID, JAN_FIRST, JAN_SECOND, true, true, UnitSystem.EN, 3).isEmpty());
         }, CwmsDataApiSetupCallback.getWebUser());
     }
 


### PR DESCRIPTION
## Summary

remove 404 when no gate changes found. instead return an empty array.

## Related Issue

time series and turbine change endpoints return empty data arrays. 
gate changes should similarly return an empty array. 
404 is not a documented response from this endpoint

## Validation

integration tests

## Checklist

- [ ] AI tools used
