### PR TITLE
Group user-list endpoints under User Management in Swagger

### DIFF
--- a/cda-gui/src/links/header-links.js
+++ b/cda-gui/src/links/header-links.js
@@ -39,16 +39,9 @@ export default [
     ],
   },
   {
-    id: "user-management",
-    text: "User Management",
+    id: "user-lists",
+    text: "User Lists",
     href: "/user-lists",
-    children: [
-      {
-        id: "user-lists",
-        text: "User Lists",
-        href: "/user-lists",
-      },
-    ],
   },
   {
     id: "help",

--- a/cda-gui/src/links/header-links.js
+++ b/cda-gui/src/links/header-links.js
@@ -39,9 +39,16 @@ export default [
     ],
   },
   {
-    id: "user-lists",
-    text: "User Lists",
+    id: "user-management",
+    text: "User Management",
     href: "/user-lists",
+    children: [
+      {
+        id: "user-lists",
+        text: "User Lists",
+        href: "/user-lists",
+      },
+    ],
   },
   {
     id: "help",

--- a/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
+++ b/cwms-data-api/src/main/java/cwms/cda/ApiServlet.java
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.google.common.flogger.FluentLogger;
 import cwms.cda.api.Controllers;
+import cwms.cda.api.auth.userlists.UserListController;
 import cwms.cda.api.enums.UnitSystem;
 import cwms.cda.api.errors.ApplicationException;
 import cwms.cda.api.errors.CdaError;
@@ -341,6 +342,7 @@ public class ApiServlet extends HttpServlet {
                 schemeProcessor.apply(ctx, api);
                 api.getPaths().forEach((key,path) -> {
                     setSecurityRequirements(key,path, schemeProcessor.getSecurityRequirements());
+                    setUserListTags(key, path);
                     // yeah, we really need to figure out how to update everything, 
                     // this is supported as an annotation in newer versions.
                     if (key.startsWith("/rss")) {
@@ -423,6 +425,13 @@ public class ApiServlet extends HttpServlet {
         setSecurity(path.getPost(), secReqs);
         setSecurity(path.getPut(), secReqs);
         setSecurity(path.getPatch(),secReqs);
+    }
+
+    static void setUserListTags(String key, PathItem path) {
+        if (key.startsWith("/user/list")) {
+            path.readOperations().forEach(operation ->
+                    operation.setTags(List.of(UserListController.TAG)));
+        }
     }
 
     private static void setSecurity(Operation op,List<SecurityRequirement> reqs) {

--- a/cwms-data-api/src/test/java/cwms/cda/ApiServletTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/ApiServletTest.java
@@ -5,10 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import cwms.cda.api.auth.userlists.UserListController;
 import io.javalin.http.Handler;
 import io.javalin.http.HandlerEntry;
 import io.javalin.http.HandlerType;
 import io.javalin.http.PathMatcher;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -16,6 +19,29 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
 public class ApiServletTest {
+
+    @Test
+    void test_user_list_operations_are_grouped_under_user_management() {
+        PathItem path = new PathItem()
+                .get(new Operation())
+                .post(new Operation())
+                .delete(new Operation());
+
+        ApiServlet.setUserListTags("/user/list/{user-list-id}/members", path);
+
+        path.readOperations().forEach(operation ->
+                assertEquals(List.of(UserListController.TAG), operation.getTags()));
+    }
+
+    @Test
+    void test_other_operations_are_not_retagged_as_user_management() {
+        Operation operation = new Operation().addTagsItem("Other");
+        PathItem path = new PathItem().get(operation);
+
+        ApiServlet.setUserListTags("/users/{user-name}", path);
+
+        assertEquals(List.of("Other"), operation.getTags());
+    }
 
     @Test
     public void test_office_from_context_hq(){
@@ -116,5 +142,4 @@ public class ApiServletTest {
 
 
 }
-
 


### PR DESCRIPTION
## Summary

- keep the CDA header navigation unchanged
- force every emitted `/user/list*` OpenAPI operation into the existing `User Management` tag
- add regression coverage for user-list paths and verify unrelated paths retain their existing tags

## Cause

When the `USER_LISTS` feature is disabled, CDA registers generic unsupported-feature handlers for these routes. Those fallback handlers do not carry the controllers' OpenAPI annotations, so Swagger placed the operations in `default`. Applying the tag in the existing OpenAPI response processor keeps the generated specification correct in either feature state without changing endpoint behavior.

## Validation

- `:cwms-data-api:test --tests cwms.cda.ApiServletTest` passed
- `OPEN_API_TEST=true :cwms-data-api:test --tests cwms.cda.api.OpenApiDocTest` passed
- `:cwms-data-api:checkstyleMain :cwms-data-api:checkstyleTest` completed successfully (existing repository warnings remain)
- net PR diff confirms no CDA GUI changes remain



## Checklist

- [x] AI tools used