### PR TITLE
Allow HEC dev Codespace hosts in Vite

### DIFF
--- a/cda-gui/vite.config.js
+++ b/cda-gui/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => {
     base: "/cwms-data",
     plugins: [react()],
     server: {
+      allowedHosts: [".apps.hecdev.net"],
       proxy: {
         "^/(auth|CWMSLogin|cwms-data/(?!$|swagger-ui(?:/|$)|data-query(?:/|$)|regexp(?:/|$)|filter-expressions(?:/|$)|timestamps(?:/|$)|user-lists(?:/|$)|legacy-format(?:/|$)|location-search(?:/|$)|assets/|src/|node_modules/|@).*)":
           {


### PR DESCRIPTION
## Summary
- allow the CDA GUI Vite dev server to accept hosts under `.apps.hecdev.net`
- avoid hard-coding a workspace-specific Codespace hostname

## Testing
- Not run locally (configuration only change)