### PR TITLE
Fix CDA GUI pull request trigger and verify browser tests

### DIFF
--- a/.github/workflows/web-gui-checks.yml
+++ b/.github/workflows/web-gui-checks.yml
@@ -4,10 +4,14 @@ on:
   push:
     branches:
       - develop
-    pull_request:
-      branches:
-        - develop
     # Run the audit and browser tests when the GUI or this workflow changes.
+    paths:
+      - "cda-gui/**"
+      - ".github/workflows/web-gui-*.yml"
+
+  pull_request:
+    branches:
+      - develop
     paths:
       - "cda-gui/**"
       - ".github/workflows/web-gui-*.yml"

--- a/cda-gui/src/pages/Home.stories.jsx
+++ b/cda-gui/src/pages/Home.stories.jsx
@@ -19,6 +19,10 @@ export const LandingPage = {
     ).toBeVisible();
     await expect(canvas.getAllByRole("link", { name: "Swagger UI" })[0]).toBeVisible();
     await expect(canvas.getByRole("link", { name: "Data Query Tool" })).toBeVisible();
+    await expect(canvas.getByRole("link", { name: "Data Query Tool" })).toHaveAttribute(
+      "href",
+      "/data-query",
+    );
     await expect(
       canvas.getByRole("link", { name: "Regular Expressions" }),
     ).toBeVisible();


### PR DESCRIPTION
The CDA Web GUI workflow nests `pull_request` under `push`, so opening a GUI PR does not trigger the browser checks added in #1867. Move it to a top-level event and apply the existing GUI path filters to both events.

Add one landing-page assertion that the Data Query Tool link targets `/data-query`. This small follow-up to #1867 verifies that the Storybook Chromium test runs on a pull request.

Validation: `npm ci`; `npm run test-storybook -- --run` (1 Chromium test passed); ESLint on the story; Prettier on both changed files; parsed workflow assertions for the PR branch/path filters; `git diff --check`. Java integration tests were not run because this change only affects the GUI test and its workflow trigger.

GitHub verification: [CDA Web GUI Checks](https://github.com/USACE/cwms-data-api/actions/runs/34234810396) ran on the `pull_request` event and passed, including the critical dependency audit, Chromium installation, and Storybook UI tests.

AI tools used.
