### PR TITLE
/auth/keys cleanup

### DIFF
--- a/cwms-data-api/src/main/java/cwms/cda/api/auth/ApiKeyController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/auth/ApiKeyController.java
@@ -24,15 +24,23 @@
 
 package cwms.cda.api.auth;
 
+import static cwms.cda.api.Controllers.STATUS_200;
 import static cwms.cda.api.Controllers.STATUS_201;
+import static cwms.cda.api.Controllers.STATUS_204;
+import static cwms.cda.api.Controllers.STATUS_400;
 import static cwms.cda.data.dao.JooqDao.getDslContext;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectReader;
 import cwms.cda.api.errors.CdaError;
 import cwms.cda.data.dao.AuthDao;
 import cwms.cda.data.dao.JooqDao;
 import cwms.cda.data.dto.auth.ApiKey;
 import cwms.cda.formatters.Formats;
+import cwms.cda.formatters.json.JsonV1;
 import cwms.cda.security.CwmsAuthException;
 import cwms.cda.security.DataApiPrincipal;
 import io.javalin.apibuilder.CrudHandler;
@@ -51,6 +59,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
 
 public class ApiKeyController implements CrudHandler {
+    private static final ObjectReader KEY_READER = JsonV1.buildObjectMapper().readerFor(ApiKey.class)
+            .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
     public final MetricRegistry metrics;
 
 
@@ -61,33 +71,52 @@ public class ApiKeyController implements CrudHandler {
 
     @OpenApi(
         requestBody = @OpenApiRequestBody(
+                    required = true,
                     content = {
                         @OpenApiContent(from = ApiKey.class, type = Formats.JSON)
                     }
         ),
-        responses = @OpenApiResponse(
+        responses = {@OpenApiResponse(
                     content = {
                         @OpenApiContent(from = ApiKey.class, type = Formats.JSON)
                     },
                     status = STATUS_201
         ),
+            @OpenApiResponse(status = STATUS_400, content = @OpenApiContent(from = CdaError.class),
+                    description = "Invalid JSON, required fields, or expiration date."),
+            @OpenApiResponse(status = "409", content = @OpenApiContent(from = CdaError.class),
+                    description = "An API key with this name already exists for this user.")
+        },
         description = "Create a new API Key for user. The randomly generated key is returned "
                 + "to the caller. A provided key will be ignored.",
         tags = {"Authorization"}
     )
     @Override
     public void create(Context ctx) {
+        ApiKey sourceData;
+        try {
+            sourceData = KEY_READER.readValue(ctx.body());
+        } catch (JsonProcessingException ex) {
+            String message = "Request body must be a valid API key JSON object.";
+            if (ex instanceof JsonMappingException && ((JsonMappingException) ex).getPath().stream()
+                    .anyMatch(ref -> "expires".equals(ref.getFieldName()))) {
+                message = "expires must be a valid date/time string, for example 2030-01-01T00:00:00Z.";
+            }
+            ctx.json(new CdaError(message, true)).status(HttpCode.BAD_REQUEST);
+            return;
+        }
+        if (sourceData == null || sourceData.getUserId() == null || sourceData.getUserId().isBlank()
+                || sourceData.getKeyName() == null || sourceData.getKeyName().isBlank()) {
+            ctx.json(new CdaError("user-id and key-name are required and must not be blank.", true))
+                    .status(HttpCode.BAD_REQUEST);
+            return;
+        }
         DataApiPrincipal p = ctx.attribute(AuthDao.DATA_API_PRINCIPAL);
         try {
             DSLContext dsl = getDslContext(ctx);
             AuthDao auth = AuthDao.getInstance(dsl);
-            ApiKey sourceData = ctx.bodyAsClass(ApiKey.class);
             ApiKey key = auth.createApiKey(p, sourceData);
-            if (key == null) {
-                ctx.status(HttpCode.BAD_REQUEST);
-            } else {
-                ctx.json(key).status(HttpCode.CREATED);
-            }
+            ctx.json(key).status(HttpCode.CREATED);
         } catch (CwmsAuthException ex) {
             if (ex.getMessage().equals(AuthDao.ONLY_OWN_KEY_MESSAGE)) {
                 ctx.json(new CdaError(ex.getMessage(), true)).status(ex.getAuthFailCode());
@@ -102,12 +131,7 @@ public class ApiKeyController implements CrudHandler {
                 @OpenApiParam(name = "key-name", required = true,
                         description = "Name of the specific key to get more information for. NOTE: Case-sensitive.")
         },
-        responses = @OpenApiResponse(
-                    content = {
-                        @OpenApiContent(from = ApiKey.class, type = Formats.JSON)
-                    },
-                    status = STATUS_201
-        ),
+        responses = @OpenApiResponse(status = STATUS_204),
         description = "Delete API key for a user",
         tags = {"Authorization"}
     )
@@ -126,7 +150,7 @@ public class ApiKeyController implements CrudHandler {
                     content = {
                         @OpenApiContent(from = ApiKey[].class, type = Formats.JSON)
                     },
-                    status = STATUS_201
+                    status = STATUS_200
         ),
         security = {
                 @OpenApiSecurity(name = "gets overridden allows lock icon.")
@@ -154,7 +178,7 @@ public class ApiKeyController implements CrudHandler {
                     content = {
                         @OpenApiContent(from = ApiKey.class, type = Formats.JSON)
                     },
-                    status = STATUS_201
+                    status = STATUS_200
         ),
         security = {
             @OpenApiSecurity(name = "gets overridden allows lock icon.")

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/AuthDao.java
@@ -4,6 +4,7 @@ import com.google.common.flogger.FluentLogger;
 import com.password4j.Hash;
 import com.password4j.HashUpdate;
 import cwms.cda.ApiServlet;
+import cwms.cda.api.errors.AlreadyExists;
 import cwms.cda.data.dto.auth.ApiKey;
 import cwms.cda.datasource.ConnectionPreparer;
 import cwms.cda.datasource.ConnectionPreparingDataSource;
@@ -516,6 +517,9 @@ public class AuthDao extends Dao<DataApiPrincipal> {
                     }
                     createKey.execute();
                 } catch (SQLException e) {
+                    if (e.getErrorCode() == 1) {
+                        throw new AlreadyExists("An API key with this name already exists for this user.", e);
+                    }
                     DataAccessException re = new DataAccessException(e.getMessage(), e);
                     throw JooqDao.wrapException(re);
                 }
@@ -587,11 +591,13 @@ public class AuthDao extends Dao<DataApiPrincipal> {
         String userId = rs.getString("userid");
         String keyName = rs.getString("key_name");
 
-        ZonedDateTime created = Optional.ofNullable(rs.getObject("created", Timestamp.class))
+        // Oracle DATE has no timezone; key timestamps are stored in UTC.
+        Calendar utc = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        ZonedDateTime created = Optional.ofNullable(rs.getTimestamp("created", utc))
             .map(Timestamp::toInstant)
             .map(i -> i.atZone(ZoneOffset.UTC))
             .orElse(null);
-        ZonedDateTime expires = Optional.ofNullable(rs.getObject("expires", Timestamp.class))
+        ZonedDateTime expires = Optional.ofNullable(rs.getTimestamp("expires", utc))
             .map(Timestamp::toInstant)
             .map(i -> i.atZone(ZoneOffset.UTC))
             .orElse(null);

--- a/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/auth/ApiKeyControllerTestIT.java
@@ -31,6 +31,7 @@ import static cwms.cda.data.dao.JsonRatingUtilsTest.loadResourceAsString;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -54,6 +55,60 @@ public class ApiKeyControllerTestIT extends DataApiTestIT {
 
     private static final List<ApiKey> realKeys = new ArrayList<>();
     private static final List<ApiKey> firstReturnedKeys = new ArrayList<>();
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_NORMAL)
+    void test_invalid_key_payloads(String authType, TestAccounts.KeyUser user, RequestSpecification authSpec) {
+        String fields = "\"user-id\":\"" + user.getName() + "\",\"key-name\":\"invalid-payload\"";
+        List<String> bodies = List.of(
+            "", "{", "null", "[]", "{}", "{\"key-name\":\"missing-user\"}",
+            "{\"user-id\":null,\"key-name\":\"missing-user\"}",
+            "{\"user-id\":\"  \",\"key-name\":\"blank-user\"}",
+            "{\"user-id\":\"" + user.getName() + "\"}",
+            "{\"user-id\":\"" + user.getName() + "\",\"key-name\":null}",
+            "{\"user-id\":\"" + user.getName() + "\",\"key-name\":\"\"}",
+            "{\"user-id\":\"" + user.getName() + "\",\"key-name\":\"   \"}",
+            "{" + fields + ",\"expires\":\"not-a-date\"}",
+            "{" + fields + ",\"expires\":{}}",
+            "{" + fields + ",\"expires\":[]}",
+            "{" + fields + "} {}"
+        );
+        assertAll(bodies.stream().map(body -> () ->
+            given().spec(authSpec).contentType(Formats.JSON).body(body)
+                .when().post("/auth/keys")
+                .then().log().ifValidationFails()
+                .statusCode(400).body("message", not(isEmptyOrNullString()))
+        ));
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(UserSpecSource.class)
+    @AuthType(user = TestAccounts.KeyUser.SPK_NORMAL)
+    void test_duplicate_key_name(String authType, TestAccounts.KeyUser user, RequestSpecification authSpec) {
+        String name = "duplicate-key-cleanup";
+        ApiKey key = new ApiKey(user.getName(), name);
+        try {
+            String secret = given().spec(authSpec).contentType(Formats.JSON).body(key)
+                .when().post("/auth/keys")
+                .then().log().ifValidationFails().statusCode(201)
+                .extract().path("api-key");
+            given().spec(authSpec).contentType(Formats.JSON).body(key)
+                .when().post("/auth/keys")
+                .then().log().ifValidationFails().statusCode(409)
+                .body("details.message", is("An API key with this name already exists for this user."));
+            given().spec(authSpec)
+                .when().get("/auth/keys/{key-name}", name)
+                .then().log().ifValidationFails().statusCode(200)
+                .body("key-name", is(name)).body("api-key", nullValue());
+            given().header("Authorization", "apikey " + secret)
+                .when().get("/offices/SPK")
+                .then().statusCode(200);
+        } finally {
+            given().spec(authSpec).when().delete("/auth/keys/{key-name}", name)
+                .then().statusCode(204);
+        }
+    }
 
     // Create API key, no expiration
     @Order(1)


### PR DESCRIPTION
- Duplicate key names return **409** instead of 500; map the insert's unique-constraint error and preserve the original key.
- Invalid JSON, null bodies, missing/blank fields, and bad expiration dates return **400** with helpful messages; validate before database access.
- Created/expiration timestamps no longer shift with the JVM timezone; read Oracle dates explicitly as UTC.
- Correct OpenAPI GET/DELETE success codes and document POST validation/conflict responses.

Local Java 11 validation: full `./gradlew build`, 782 service unit tests, and all 10 auth-key integration cases passed, including 16 invalid-payload assertions. Curl checks passed with UTC and America/Chicago JVM timezones.

Curl checks (`TOKEN` is a signed-in test user's bearer token):

```bash
CDA=http://localhost:8382/cwms-data
post() {
  printf '%s' "$1" | curl -sS -w '\n%{http_code}\n' "$CDA/auth/keys" \
    -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' --data-binary @-
}
post '{"user-id":"m5hectest","key-name":"auth-cleanup-probe"}' # 201
post '{"user-id":"m5hectest","key-name":"auth-cleanup-probe"}' # 409
post '{'                                      # 400: malformed JSON
post 'null'                                   # 400: null body
post '{"user-id":"m5hectest"}'                 # 400: missing key name
post '{"user-id":"m5hectest","key-name":"   "}' # 400: blank name
post '{"user-id":"m5hectest","key-name":"auth-cleanup-probe-date","expires":"not-a-date"}' # 400
post '{"user-id":"m5hectest","key-name":"auth-cleanup-probe-date","expires":"2030-01-01T12:30:45-05:00"}' # 201
curl -sS -w '\n%{http_code}\n' -H "Authorization: Bearer $TOKEN" "$CDA/auth/keys" # 200
curl -sS -w '\n%{http_code}\n' -H "Authorization: Bearer $TOKEN" "$CDA/auth/keys/auth-cleanup-probe-date" # 200; expires 17:30:45 UTC
for name in auth-cleanup-probe auth-cleanup-probe-date; do
  curl -sS -w '\n%{http_code}\n' -X DELETE -H "Authorization: Bearer $TOKEN" "$CDA/auth/keys/$name" # 204
done
```
