### PR TITLE
Add optional display units to time series group assignments

### DIFF
--- a/cwms-data-api/build.gradle
+++ b/cwms-data-api/build.gradle
@@ -309,6 +309,7 @@ task integrationTests(type: Test) {
 //    dependsOn test
     dependsOn generateConfig
     dependsOn war
+    jvmArgs += "-Duser.timezone=UTC"
 
     useJUnitPlatform() {
         includeTags "integration"

--- a/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesGroupController.java
+++ b/cwms-data-api/src/main/java/cwms/cda/api/TimeSeriesGroupController.java
@@ -84,6 +84,7 @@ import org.jooq.DSLContext;
 public class TimeSeriesGroupController implements CrudHandler {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
     public static final String TAG = "Timeseries Groups";
+    private static final String UNIT_SYSTEM = "unit-system";
 
     private final MetricRegistry metrics;
 
@@ -102,6 +103,8 @@ public class TimeSeriesGroupController implements CrudHandler {
 
     @OpenApi(
             queryParams = {
+                @OpenApiParam(name = UNIT_SYSTEM, description = "Display unit system: EN (default) or SI. "
+                    + "Assigned time series include units only when a persistent override differs from the default."),
                 @OpenApiParam(name = OFFICE, description = "Specifies the owning office of the "
                         + "timeseries assigned to the group(s) whose data is to be included in the response. If this "
                         + "field is not specified, group information for all assigned TS offices shall be returned."),
@@ -131,7 +134,7 @@ public class TimeSeriesGroupController implements CrudHandler {
         try (final Timer.Context ignored = markAndTime(GET_ALL)) {
             DSLContext dsl = getDslContext(ctx);
 
-            TimeSeriesGroupDao dao = new TimeSeriesGroupDao(dsl);
+            TimeSeriesGroupDao dao = new TimeSeriesGroupDao(dsl, ctx.queryParam(UNIT_SYSTEM));
             String tsOffice = ctx.queryParam(OFFICE);
             String groupOffice = ctx.queryParam(GROUP_OFFICE_ID);
             String categoryOffice = ctx.queryParam(CATEGORY_OFFICE_ID);
@@ -179,6 +182,8 @@ public class TimeSeriesGroupController implements CrudHandler {
                         + "the timeseries group whose data is to be included in the response")
             },
             queryParams = {
+                @OpenApiParam(name = UNIT_SYSTEM, description = "Display unit system: EN (default) or SI. "
+                    + "Assigned time series include units only when a persistent override differs from the default."),
                 @OpenApiParam(name = OFFICE, description = "Specifies the "
                         + "owning office of the timeseries assigned to the group whose data is to be included"
                         + " in the response. This will limit the assigned timeseries returned to only those"
@@ -202,7 +207,7 @@ public class TimeSeriesGroupController implements CrudHandler {
         try (final Timer.Context ignored = markAndTime(GET_ONE)) {
             DSLContext dsl = getDslContext(ctx);
 
-            TimeSeriesGroupDao dao = new TimeSeriesGroupDao(dsl);
+            TimeSeriesGroupDao dao = new TimeSeriesGroupDao(dsl, ctx.queryParam(UNIT_SYSTEM));
             String tsOffice = ctx.queryParam(OFFICE);
             String categoryId = ctx.queryParam(CATEGORY_ID);
 
@@ -239,7 +244,9 @@ public class TimeSeriesGroupController implements CrudHandler {
     }
 
     @OpenApi(
-        description = "Create new TimeSeriesGroup",
+        description = "Create new TimeSeriesGroup. Assigned time series may specify optional units and unit-system "
+            + "(EN by default). The display preference belongs to the time series and applies across groups. "
+            + "Omitting units preserves the preference; explicit null clears the override.",
         requestBody = @OpenApiRequestBody(
             content = {
                 @OpenApiContent(from = TimeSeriesGroup.class, type = Formats.JSON)
@@ -341,49 +348,54 @@ public class TimeSeriesGroupController implements CrudHandler {
     public void update(@NotNull Context ctx, @NotNull String oldGroupId) {
         try (Timer.Context ignored = markAndTime(CREATE)) {
             DSLContext dsl = getDslContext(ctx);
-            String formatHeader = ctx.req.getContentType();
-            String body = ctx.body();
-            String office = requiredParam(ctx, OFFICE);
-            ContentType contentType = Formats.parseHeader(formatHeader, TimeSeriesGroup.class);
-            TimeSeriesGroup group = Formats.parseContent(contentType, body, TimeSeriesGroup.class);
-            boolean replaceAssignedTs = ctx.queryParamAsClass(REPLACE_ASSIGNED_TS, Boolean.class)
-                .getOrDefault(false);
-            TimeSeriesGroupDao timeSeriesGroupDao = new TimeSeriesGroupDao(dsl);
-            TimeSeriesGroup existingGroup = timeSeriesGroupDao.getTimeSeriesGroup(office, null,
-                null, group.getTimeSeriesCategory().getId(), oldGroupId);
-            if (!Strings.CI.equals(existingGroup.getDescription(), group.getDescription())) {
-                existingGroup = updateClearedFields(group, existingGroup);
-                timeSeriesGroupDao.create(existingGroup, false, false);
+            dsl.transaction(config -> update(ctx, oldGroupId, config.dsl()));
+        }
+    }
+
+    private void update(Context ctx, String oldGroupId, DSLContext dsl) {
+        String formatHeader = ctx.req.getContentType();
+        String body = ctx.body();
+        String office = requiredParam(ctx, OFFICE);
+        ContentType contentType = Formats.parseHeader(formatHeader, TimeSeriesGroup.class);
+        TimeSeriesGroup group = Formats.parseContent(contentType, body, TimeSeriesGroup.class);
+        boolean replaceAssignedTs = ctx.queryParamAsClass(REPLACE_ASSIGNED_TS, Boolean.class)
+            .getOrDefault(false);
+        TimeSeriesGroupDao timeSeriesGroupDao = new TimeSeriesGroupDao(dsl);
+        timeSeriesGroupDao.validateDisplayUnits(group);
+        TimeSeriesGroup existingGroup = timeSeriesGroupDao.getTimeSeriesGroup(office, null,
+            null, group.getTimeSeriesCategory().getId(), oldGroupId);
+        if (!Strings.CI.equals(existingGroup.getDescription(), group.getDescription())) {
+            existingGroup = updateClearedFields(group, existingGroup);
+            timeSeriesGroupDao.create(existingGroup, false, false);
+        }
+        if (!office.equalsIgnoreCase(CWMS_OFFICE) && !oldGroupId.equals(group.getId())) {
+            timeSeriesGroupDao.renameTimeSeriesGroup(oldGroupId, group);
+        }
+        if (replaceAssignedTs) {
+            timeSeriesGroupDao.unassignForOffice(group.getTimeSeriesCategory().getId(), group.getId(),
+                group.getOfficeId(), office);
+        }
+        boolean ignoreMissing = ctx.queryParamAsClass(IGNORE_MISSING, Boolean.class).getOrDefault(false);
+        List<CwmsId> missingTimeSeries = timeSeriesGroupDao.assignTs(group, office, ignoreMissing);
+        if (missingTimeSeries.isEmpty()) {
+            ctx.status(HttpServletResponse.SC_OK);
+        } else {
+            Map<String, String> detailsMap = new HashMap<>();
+            StringBuilder sb = new StringBuilder();
+            for (CwmsId cwmsId : missingTimeSeries) {
+                sb.append(cwmsId.getName());
+                sb.append(", ");
             }
-            if (!office.equalsIgnoreCase(CWMS_OFFICE) && !oldGroupId.equals(group.getId())) {
-                timeSeriesGroupDao.renameTimeSeriesGroup(oldGroupId, group);
-            }
-            if (replaceAssignedTs) {
-                timeSeriesGroupDao.unassignForOffice(group.getTimeSeriesCategory().getId(), group.getId(),
-                    group.getOfficeId(), office);
-            }
-            boolean ignoreMissing = ctx.queryParamAsClass(IGNORE_MISSING, Boolean.class).getOrDefault(false);
-            List<CwmsId> missingTimeSeries = timeSeriesGroupDao.assignTs(group, office, ignoreMissing);
-            if (missingTimeSeries.isEmpty()) {
-                ctx.status(HttpServletResponse.SC_OK);
+            sb.delete(sb.length() - 2, sb.length());
+            detailsMap.put("missing-timeseries", sb.toString());
+            if (ignoreMissing) {
+                ctx.status(HttpCode.MULTI_STATUS);
             } else {
-                Map<String, String> detailsMap = new HashMap<>();
-                StringBuilder sb = new StringBuilder();
-                for (CwmsId cwmsId : missingTimeSeries) {
-                    sb.append(cwmsId.getName());
-                    sb.append(", ");
-                }
-                sb.delete(sb.length() - 2, sb.length());
-                detailsMap.put("missing-timeseries", sb.toString());
-                if (ignoreMissing) {
-                    ctx.status(HttpCode.MULTI_STATUS);
-                } else {
-                    ctx.status(HttpServletResponse.SC_BAD_REQUEST);
-                    detailsMap.put("message",
-                        "One or more time series were not found and could not be assigned to the group");
-                }
-                ctx.json(detailsMap);
+                ctx.status(HttpServletResponse.SC_BAD_REQUEST);
+                detailsMap.put("message",
+                    "One or more time series were not found and could not be assigned to the group");
             }
+            ctx.json(detailsMap);
         }
     }
 

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesDaoImpl.java
@@ -566,17 +566,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
                 DSL.val(BigInteger.valueOf(2L)), DSL.val("."),
                 DSL.val(BigInteger.valueOf(6L))));
 
-        // possibly call another procedure to get the units
-        Field<String> unit = units.compareToIgnoreCase("SI") == 0
-                ||
-                units.compareToIgnoreCase("EN") == 0
-                ?
-                CWMS_UTIL_PACKAGE.call_GET_DEFAULT_UNITS(
-                        CWMS_TS_PACKAGE.call_GET_BASE_PARAMETER_ID(tsCode),
-                        DSL.val(units, String.class)
-                )
-                :
-                DSL.val(units, String.class);
+        Field<String> unit = resolveDisplayUnits(dsl, units, tsId, tsCode, officeId);
 
         // another call to get the interval
         Field<BigDecimal> ival = CWMS_TS_PACKAGE.call_GET_TS_INTERVAL__2(validTs.field("tsid", String.class));
@@ -1008,12 +998,7 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
                         officeId.as("office_id"))
                         .asTable("validts");
 
-        Field<String> unit = units.compareToIgnoreCase("SI") == 0
-                || units.compareToIgnoreCase("EN") == 0
-                ? CWMS_UTIL_PACKAGE.call_GET_DEFAULT_UNITS(
-                        CWMS_TS_PACKAGE.call_GET_BASE_PARAMETER_ID(tsCode),
-                        DSL.val(units, String.class))
-                : DSL.val(units, String.class);
+        Field<String> unit = resolveDisplayUnits(metadataDsl, units, tsId, tsCode, officeId);
 
         Field<BigDecimal> interval = CWMS_TS_PACKAGE.call_GET_TS_INTERVAL__2(validTs.field("tsid", String.class));
 
@@ -1065,6 +1050,19 @@ public class TimeSeriesDaoImpl extends JooqDao<TimeSeries> implements TimeSeries
                         ? UTC
                         : record.getValue("time_zone_id", String.class),
                 record.getValue("version_flag", String.class)));
+    }
+
+    private Field<String> resolveDisplayUnits(DSLContext context, String units, Field<String> tsId,
+                                             Field<BigDecimal> tsCode, Field<String> officeId) {
+        if (!"EN".equalsIgnoreCase(units) && !"SI".equalsIgnoreCase(units)) {
+            return DSL.val(units, String.class);
+        }
+        if (TimeSeriesGroupDao.supportsDisplayUnits(context.configuration())) {
+            return DSL.field("cwms_ts.get_ts_display_units({0}, {1}, {2})", String.class,
+                tsId, DSL.val(units), officeId);
+        }
+        return CWMS_UTIL_PACKAGE.call_GET_DEFAULT_UNITS(
+            CWMS_TS_PACKAGE.call_GET_BASE_PARAMETER_ID(tsCode), DSL.val(units, String.class));
     }
 
     private void validateUnits(String units, Field<BigDecimal> tsCode, Field<String> officeId, String name) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesGroupDao.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dao/TimeSeriesGroupDao.java
@@ -40,12 +40,14 @@ import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jooq.Condition;
 import org.jooq.Configuration;
 import org.jooq.DSLContext;
+import org.jooq.Field;
 import org.jooq.Record1;
-import org.jooq.Record5;
+import org.jooq.Record6;
 import org.jooq.Record8;
 import org.jooq.Record9;
 import org.jooq.RecordMapper;
@@ -65,6 +67,7 @@ import usace.cwms.db.jooq.codegen_latest.udt.records.TS_ALIAS_TAB_T;
 public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
     public static final String CWMS = "CWMS";
+    private final String unitSystem;
 
     private enum DeleteTsGroupCascadeMode {
         UNKNOWN,
@@ -75,7 +78,51 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
     private static volatile DeleteTsGroupCascadeMode deleteTsGroupCascadeMode = DeleteTsGroupCascadeMode.UNKNOWN;
 
     public TimeSeriesGroupDao(DSLContext dsl) {
+        this(dsl, "EN");
+    }
+
+    public TimeSeriesGroupDao(DSLContext dsl, String unitSystem) {
         super(dsl);
+        this.unitSystem = validateUnitSystem(unitSystem);
+    }
+
+    static String validateUnitSystem(String unitSystem) {
+        String result = unitSystem == null ? "EN" : unitSystem.toUpperCase(java.util.Locale.ROOT);
+        if (!"EN".equals(result) && !"SI".equals(result)) {
+            throw new IllegalArgumentException("unit-system must be EN or SI");
+        }
+        return result;
+    }
+
+    static boolean supportsDisplayUnits(Configuration configuration) {
+        return configuration.dsl().select(DSL.countDistinct(DSL.field("procedure_name", String.class)))
+            .from("all_procedures")
+            .where(DSL.field("object_name", String.class).eq("CWMS_TS"))
+            .and(DSL.field("owner", String.class).eq("CWMS_20"))
+            .and(DSL.field("procedure_name", String.class).in("SET_TS_DISPLAY_UNITS", "GET_TS_DISPLAY_UNITS"))
+            .fetchOne(0, Integer.class) == 2;
+    }
+
+    private static void validateDisplayUnits(Configuration configuration, TimeSeriesGroup group) {
+        if (group.getAssignedTimeSeries() != null) {
+            boolean hasUnits = group.getAssignedTimeSeries().stream().anyMatch(AssignedTimeSeries::isUnitsSpecified);
+            if (hasUnits && !supportsDisplayUnits(configuration)) {
+                throw new UnsupportedOperationException("This CWMS database does not support persistent "
+                    + "time-series display units; install the database display-units update first");
+            }
+            for (AssignedTimeSeries assigned : group.getAssignedTimeSeries()) {
+                validateUnitSystem(assigned.getUnitSystem());
+                if (assigned.isUnitsSpecified()) {
+                    if (assigned.getUnits() != null && assigned.getUnits().trim().isEmpty()) {
+                        throw new IllegalArgumentException("units must not be blank");
+                    }
+                }
+            }
+        }
+    }
+
+    public void validateDisplayUnits(TimeSeriesGroup group) {
+        validateDisplayUnits(dsl.configuration(), group);
     }
 
     public List<TimeSeriesGroup> getTimeSeriesGroups() {
@@ -168,6 +215,10 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
                                                            String categoryOfficeId) {
         AV_TS_CAT_GRP catGrp = AV_TS_CAT_GRP.AV_TS_CAT_GRP;
         AV_TS_GRP_ASSGN grpAssgn = AV_TS_GRP_ASSGN.AV_TS_GRP_ASSGN;
+        Field<String> displayUnits = supportsDisplayUnits(dslContext.configuration())
+            ? DSL.field("cwms_ts.get_ts_display_units({0}, {1}, {2}, {3})", String.class,
+                grpAssgn.TS_ID, DSL.val(unitSystem), grpAssgn.DB_OFFICE_ID, DSL.val("F"))
+            : DSL.val(null, String.class);
 
         Condition whereCondGrpCat = DSL.noCondition();
         if (categoryOfficeId != null) {
@@ -201,7 +252,8 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
                             grpAssgn.DB_OFFICE_ID,
                             grpAssgn.ATTRIBUTE,
                             grpAssgn.ALIAS_ID,
-                            grpAssgn.REF_TS_ID
+                            grpAssgn.REF_TS_ID,
+                            displayUnits
                         )
                         .from(grpAssgn)
                         .where(joinCond)
@@ -260,7 +312,7 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
         return query.fetch((RecordMapper<org.jooq.Record, TimeSeriesGroup>) this::buildTimeSeriesGroup);
     }
 
-    private AssignedTimeSeries buildAssignedTimeSeries(Record5<String, String, BigDecimal, String, String> multisetRecord) {
+    private AssignedTimeSeries buildAssignedTimeSeries(Record6<String, String, BigDecimal, String, String, String> multisetRecord) {
         AssignedTimeSeries retval = null;
 
         if (multisetRecord != null) {
@@ -275,7 +327,9 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
                 attr = attrBD.intValue();
             }
 
-            retval = new AssignedTimeSeries(officeId, timeseriesId, aliasId, refTsId, attr);
+            String units = multisetRecord.value6();
+            retval = new AssignedTimeSeries(officeId, timeseriesId, aliasId, refTsId, attr,
+                units, units == null ? null : unitSystem);
         }
 
         return retval;
@@ -462,15 +516,18 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
     public List<CwmsId> create(TimeSeriesGroup group, boolean failIfExists, boolean ignoreNulls, boolean ignoreMissing) {
         return connectionResult(dsl, c -> {
             Configuration configuration = getDslContext(c, group.getOfficeId()).configuration();
+            validateDisplayUnits(configuration, group);
             String categoryId = group.getTimeSeriesCategory().getId();
             DSLContext dslContext = getDslContext(c, group.getOfficeId());
-            return dslContext.transactionResult((Configuration trx) -> {
-                CWMS_TS_PACKAGE.call_STORE_TS_GROUP(configuration, categoryId,
+            Function<Configuration, List<CwmsId>> store = trx -> {
+                CWMS_TS_PACKAGE.call_STORE_TS_GROUP(trx, categoryId,
                     group.getId(), group.getDescription(), formatBool(failIfExists),
                     formatBool(ignoreNulls), group.getSharedAliasId(),
                     group.getSharedRefTsId(), group.getOfficeId());
-                return assignTs(configuration, group, group.getOfficeId(), ignoreNulls, ignoreMissing);
-            });
+                return assignTs(trx, group, group.getOfficeId(), ignoreNulls, ignoreMissing);
+            };
+            // Preserve a caller's transaction when this connection is already enlisted.
+            return c.getAutoCommit() ? dslContext.transactionResult(store::apply) : store.apply(configuration);
         });
     }
 
@@ -483,6 +540,7 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
             String office, boolean ignoreNulls, boolean ignoreMissing) {
         List<AssignedTimeSeries> assignedTimeSeries = group.getAssignedTimeSeries();
         List<CwmsId> missingTimeSeries = new ArrayList<>();
+        validateDisplayUnits(configuration, group);
 
         if (!ignoreNulls && (assignedTimeSeries == null || assignedTimeSeries.isEmpty())) {
             CWMS_TS_PACKAGE.call_UNASSIGN_TS_GROUP(configuration,
@@ -517,6 +575,18 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
                 }
             }
         }
+        if (assignedTimeSeries != null) {
+            for (AssignedTimeSeries assigned : assignedTimeSeries) {
+                boolean missing = missingTimeSeries.stream()
+                    .anyMatch(id -> id.getName().equalsIgnoreCase(assigned.getTimeseriesId()));
+                if (assigned.isUnitsSpecified() && !missing) {
+                    configuration.dsl().execute("begin cwms_ts.set_ts_display_units("
+                            + "p_ts_id => ?, p_units => ?, p_unit_system => ?, p_office_id => ?); end;",
+                        assigned.getTimeseriesId(), assigned.getUnits(),
+                        validateUnitSystem(assigned.getUnitSystem()), office);
+                }
+            }
+        }
         return missingTimeSeries;
     }
 
@@ -531,11 +601,17 @@ public class TimeSeriesGroupDao extends JooqDao<TimeSeriesGroup> {
     }
 
     public List<CwmsId> assignTs(TimeSeriesGroup group, String office, boolean ignoreMissing) {
-        return connectionResult(dsl, c -> assignTs(getDslContext(c, office).configuration(),group, office, true, ignoreMissing));
+        return connectionResult(dsl, c -> {
+            DSLContext context = getDslContext(c, office);
+            Function<Configuration, List<CwmsId>> assign =
+                config -> assignTs(config, group, office, true, ignoreMissing);
+            return c.getAutoCommit()
+                ? context.transactionResult(assign::apply) : assign.apply(context.configuration());
+        });
     }
 
     public void assignTs(TimeSeriesGroup group, String office) {
-        connection(dsl, c -> assignTs(getDslContext(c, office).configuration(),group, office, true));
+        assignTs(group, office, false);
     }
 
     private static TS_ALIAS_T convertToTsAliasType(AssignedTimeSeries assignedTimeSeries) {

--- a/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
+++ b/cwms-data-api/src/main/java/cwms/cda/data/dto/AssignedTimeSeries.java
@@ -24,8 +24,11 @@
 
 package cwms.cda.data.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @JsonNaming(PropertyNamingStrategies.KebabCaseStrategy.class)
 public class AssignedTimeSeries extends CwmsDTOBase {
@@ -34,6 +37,14 @@ public class AssignedTimeSeries extends CwmsDTOBase {
     private String aliasId;
     private String refTsId;
     private Integer attribute;
+    @Schema(description = "Optional persistent display units override for this time series, shared across groups. "
+        + "Omit to preserve the current preference; set null to clear it.", example = "W/m2", nullable = true)
+    private String units;
+    @JsonIgnore
+    private boolean unitsSpecified;
+    @Schema(description = "Unit system for the display units override (EN or SI). Defaults to EN on writes.",
+        allowableValues = {"EN", "SI"}, example = "EN")
+    private String unitSystem;
 
     public AssignedTimeSeries() {
 
@@ -51,6 +62,33 @@ public class AssignedTimeSeries extends CwmsDTOBase {
 
     public String getOfficeId() {
         return officeId;
+    }
+
+    public AssignedTimeSeries(String officeId, String timeseriesId,
+                              String aliasId, String refTsId, Integer attr, String units, String unitSystem) {
+        this(officeId, timeseriesId, aliasId, refTsId, attr);
+        this.units = units;
+        this.unitsSpecified = units != null;
+        this.unitSystem = unitSystem;
+    }
+
+    public String getUnits() {
+        return units;
+    }
+
+    @JsonSetter("units")
+    public void setUnits(String units) {
+        this.units = units;
+        this.unitsSpecified = true;
+    }
+
+    @JsonIgnore
+    public boolean isUnitsSpecified() {
+        return unitsSpecified;
+    }
+
+    public String getUnitSystem() {
+        return unitSystem;
     }
 
     public String getTimeseriesId() {

--- a/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
+++ b/cwms-data-api/src/test/java/cwms/cda/api/TimeSeriesGroupControllerTestIT.java
@@ -109,6 +109,128 @@ final class TimeSeriesGroupControllerTestIT extends DataApiTestIT {
     TestAccounts.KeyUser user = TestAccounts.KeyUser.SPK_NORMAL;
     TestAccounts.KeyUser user2 = TestAccounts.KeyUser.SWT_NORMAL;
 
+    @Test
+    void unsupportedDisplayUnitsDoNotCreateGroup() throws Exception {
+        CwmsDataApiSetupCallback.getDatabaseLink().connection(c ->
+            org.junit.jupiter.api.Assumptions.assumeFalse(DSL.using(c).fetchExists(
+                DSL.selectOne().from("all_procedures")
+                    .where("owner = 'CWMS_20' and object_name = 'CWMS_TS' "
+                        + "and procedure_name = 'SET_TS_DISPLAY_UNITS'")),
+                "Requires a database without the display-units update"));
+        String office = user.getOperatingOffice();
+        TimeSeriesCategory category = new TimeSeriesCategory(office, "Unsupported Units", "Compatibility test");
+        categoriesToCleanup.add(category);
+        ContentType type = Formats.parseHeader(Formats.JSON, TimeSeriesGroup.class);
+        given().contentType(Formats.JSON).body(Formats.format(type, category))
+            .header("Authorization", user.toHeaderValue()).queryParam(OFFICE, office)
+            .post("/timeseries/category").then().statusCode(201);
+        TimeSeriesGroup group = new TimeSeriesGroup(category, office, "River Levels", "Compatibility test", null, null);
+        group.getAssignedTimeSeries().add(new AssignedTimeSeries(office,
+            "Alder Springs.Precip-Cumulative.Inst.15Minutes.0.raw-cda", null, null, 1, "cm", "EN"));
+        groupsToCleanup.add(group);
+        given().contentType(Formats.JSON).body(Formats.format(type, group))
+            .header("Authorization", user.toHeaderValue()).post("/timeseries/group")
+            .then().log().ifValidationFails().statusCode(501);
+        given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+            .get("/timeseries/group/River Levels").then().statusCode(404);
+    }
+
+    @Test
+    void persistentDisplayUnitsAreSharedAcrossGroups() throws Exception {
+        CwmsDataApiSetupCallback.getDatabaseLink().connection(c ->
+            org.junit.jupiter.api.Assumptions.assumeTrue(DSL.using(c).fetchExists(
+                DSL.selectOne().from("all_procedures")
+                    .where("object_name = 'CWMS_TS' and procedure_name = 'SET_TS_DISPLAY_UNITS'")),
+                "Requires the database time-series display-units update"));
+        String office = user.getOperatingOffice();
+        String tsId = "Cedar Display.Stage.Inst.1Hour.0.Observed";
+        createLocation("Cedar Display", true, office);
+        createTimeseries(office, tsId);
+        TimeSeriesCategory category = new TimeSeriesCategory(office, "Display Units", "Display preferences");
+        categoriesToCleanup.add(category);
+        ContentType type = Formats.parseHeader(Formats.JSON, TimeSeriesGroup.class);
+        given().contentType(Formats.JSON).body(Formats.format(type, category))
+            .header("Authorization", user.toHeaderValue()).queryParam(OFFICE, office)
+            .post("/timeseries/category").then().statusCode(201);
+        for (String groupId : List.of("River Levels", "Operations Levels")) {
+            TimeSeriesGroup group = new TimeSeriesGroup(category, office, groupId, "Display preferences", null, null);
+            group.getAssignedTimeSeries().add(new AssignedTimeSeries(office, tsId, null, null, 1,
+                "River Levels".equals(groupId) ? "cm" : null, null));
+            groupsToCleanup.add(group);
+            given().contentType(Formats.JSON).body(Formats.format(type, group))
+                .header("Authorization", user.toHeaderValue())
+                .post("/timeseries/group").then().log().ifValidationFails().statusCode(201);
+            given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+                .get("/timeseries/group/" + groupId).then().log().ifValidationFails().statusCode(200)
+                .body("assigned-time-series[0].units", equalTo("cm"))
+                .body("assigned-time-series[0].unit-system", equalTo("EN"));
+        }
+        java.time.ZonedDateTime sampleTime = java.time.ZonedDateTime.parse("2025-01-01T00:00:00Z");
+        TimeSeries samples = new TimeSeries(null, -1, 1, tsId, office, sampleTime, sampleTime.plusHours(1),
+            "m", java.time.Duration.ofHours(1));
+        samples.addValue(java.sql.Timestamp.from(sampleTime.toInstant()), 1.0, 0);
+        String values = Formats.format(Formats.parseHeader(Formats.JSONV2, TimeSeries.class), samples);
+        given().contentType(Formats.JSONV2).body(values).header("Authorization", user.toHeaderValue())
+            .post("/timeseries").then().log().ifValidationFails().statusCode(200);
+        CwmsDataApiSetupCallback.getDatabaseLink().connection(c -> {
+            int count = DSL.using(c).fetchOne("select count(*) from av_tsv "
+                + "where ts_code = cwms_ts.get_ts_code(?, ?)", tsId, office).get(0, Integer.class);
+            org.junit.jupiter.api.Assertions.assertEquals(1, count, "The sample must be committed before retrieval");
+            String storedTime = DSL.using(c).fetchOne("select to_char(date_time, 'YYYY-MM-DD HH24:MI:SS') "
+                + "from av_tsv where ts_code = cwms_ts.get_ts_code(?, ?)", tsId, office).get(0, String.class);
+            org.junit.jupiter.api.Assertions.assertEquals("2025-01-01 00:00:00", storedTime,
+                "The sample must be stored in UTC");
+        }, "cwms_20");
+        for (String units : List.of("m", "SI", "EN")) {
+            given().accept(Formats.JSONV2).queryParam(OFFICE, office).queryParam("name", tsId)
+                .queryParam("unit", units).queryParam(BEGIN, "2024-12-31T23:00:00Z")
+                .queryParam(END, "2025-01-01T01:00:00Z").get("/timeseries")
+                .then().log().ifValidationFails().statusCode(200)
+                .body("units", equalTo("EN".equals(units) ? "cm" : "m"))
+                .body("values[0][1]", equalTo("EN".equals(units) ? 100.0f : 1.0f));
+        }
+        given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+            .queryParam("unit-system", "SI").get("/timeseries/group/River Levels")
+            .then().statusCode(200).body("assigned-time-series[0].units", nullValue());
+        for (String invalidUnits : List.of("cfs", "no-such-unit")) {
+            TimeSeriesGroup invalid = new TimeSeriesGroup(category, office, "Renamed Levels", "Changed", null, null);
+            invalid.getAssignedTimeSeries().add(new AssignedTimeSeries(office, tsId, null, null, 1, invalidUnits, "EN"));
+            groupsToCleanup.add(invalid);
+            given().contentType(Formats.JSON).body(Formats.format(type, invalid))
+                .header("Authorization", user.toHeaderValue()).post("/timeseries/group")
+                .then().log().ifValidationFails().statusCode(400);
+            given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+                .get("/timeseries/group/Renamed Levels").then().statusCode(404);
+            given().contentType(Formats.JSON).body(Formats.format(type, invalid))
+                .header("Authorization", user.toHeaderValue()).queryParam(OFFICE, office)
+                .patch("/timeseries/group/River Levels").then().log().ifValidationFails().statusCode(400);
+            given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+                .get("/timeseries/group/River Levels").then().statusCode(200)
+                .body("description", equalTo("Display preferences"))
+                .body("assigned-time-series[0].units", equalTo("cm"));
+        }
+        TimeSeriesGroup reset = new TimeSeriesGroup(category, office, "River Levels", "Display preferences", null, null);
+        reset.getAssignedTimeSeries().add(new AssignedTimeSeries(office, tsId, null, null, 1, "ft", "EN"));
+        given().contentType(Formats.JSON).body(Formats.format(type, reset))
+            .header("Authorization", user.toHeaderValue()).queryParam(OFFICE, office)
+            .patch("/timeseries/group/River Levels").then().log().ifValidationFails().statusCode(200);
+        given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+            .get("/timeseries/group/Operations Levels").then().statusCode(200)
+            .body("assigned-time-series[0].units", nullValue())
+            .body("assigned-time-series[0].unit-system", nullValue());
+        String explicitNull = Formats.format(type, reset).replace("\"units\":\"ft\"", "\"units\":null");
+        String reapplyOverride = Formats.format(type, reset).replace("\"units\":\"ft\"", "\"units\":\"cm\"");
+        given().contentType(Formats.JSON).body(reapplyOverride)
+            .header("Authorization", user.toHeaderValue()).queryParam(OFFICE, office)
+            .patch("/timeseries/group/River Levels").then().log().ifValidationFails().statusCode(200);
+        given().contentType(Formats.JSON).body(explicitNull)
+            .header("Authorization", user.toHeaderValue()).queryParam(OFFICE, office)
+            .patch("/timeseries/group/River Levels").then().log().ifValidationFails().statusCode(200);
+        given().accept(Formats.JSON).queryParam(OFFICE, office).queryParam(CATEGORY_ID, category.getId())
+            .get("/timeseries/group/Operations Levels").then().statusCode(200)
+            .body("assigned-time-series[0].units", nullValue());
+    }
+
     @BeforeAll
     static void load_data() throws Exception {
         createLocation("Alder Springs",true,"SPK");

--- a/cwms-data-api/src/test/java/cwms/cda/data/dto/TimeSeriesGroupTest.java
+++ b/cwms-data-api/src/test/java/cwms/cda/data/dto/TimeSeriesGroupTest.java
@@ -8,11 +8,38 @@ import cwms.cda.formatters.ContentType;
 import cwms.cda.formatters.Formats;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TimeSeriesGroupTest
 {
+    @Test
+    void displayUnitsRoundTrip() {
+        AssignedTimeSeries assigned = new AssignedTimeSeries("SPK", "Cedar.Solar.Inst.1Hour.0.Test",
+            null, null, 1, "W/m2", "EN");
+        TimeSeriesGroup group = new TimeSeriesGroup(buildTimeSeriesGroup(), List.of(assigned));
+        ContentType type = Formats.parseHeader(Formats.JSON, TimeSeriesGroup.class);
+        String json = Formats.format(type, group);
+        assertTrue(json.contains("\"units\":\"W/m2\""));
+        assertTrue(json.contains("\"unit-system\":\"EN\""));
+        TimeSeriesGroup parsed = Formats.parseContent(type, json, TimeSeriesGroup.class);
+        assertEquals("W/m2", parsed.getAssignedTimeSeries().get(0).getUnits());
+        assertEquals("EN", parsed.getAssignedTimeSeries().get(0).getUnitSystem());
+    }
+
+    @Test
+    void omittedUnitsPreservePreferenceAndExplicitNullClearsIt() {
+        ContentType type = Formats.parseHeader(Formats.JSON, TimeSeriesGroup.class);
+        TimeSeriesGroup group = new TimeSeriesGroup(buildTimeSeriesGroup(), List.of(new AssignedTimeSeries(
+            "SPK", "Cedar.Stage.Inst.1Hour.0.Test", null, null, 1)));
+        String omitted = Formats.format(type, group);
+        TimeSeriesGroup preserve = Formats.parseContent(type, omitted, TimeSeriesGroup.class);
+        assertFalse(preserve.getAssignedTimeSeries().get(0).isUnitsSpecified());
+        String explicitNull = omitted.replace("\"timeseries-id\"", "\"units\":null,\"timeseries-id\"");
+        TimeSeriesGroup clear = Formats.parseContent(type, explicitNull, TimeSeriesGroup.class);
+        assertTrue(clear.getAssignedTimeSeries().get(0).isUnitsSpecified());
+    }
 
 	@Test
 	void test_serialize_json(){
@@ -57,6 +84,8 @@ class TimeSeriesGroupTest
         assertTrue(result.contains("grpSharedRefTsId"));
 
         assertFalse(result.contains("null"));
+        assertFalse(result.contains("\"units\""));
+        assertFalse(result.contains("unit-system"));
     }
 
 

--- a/docs/timeseries-group-display-units.md
+++ b/docs/timeseries-group-display-units.md
@@ -1,0 +1,46 @@
+# Time series group display units
+
+Time series assigned to a group can specify optional `units` and `unit-system`
+attributes. `units` follows the existing time series API naming. `unit-system`
+is `EN` (the default) or `SI`.
+
+For example, POST `/timeseries/group` with `Content-Type: application/json`:
+
+```json
+{
+  "office-id": "SPK",
+  "id": "Weather",
+  "description": "Weather observations",
+  "time-series-category": {
+    "office-id": "SPK",
+    "id": "Operations"
+  },
+  "assigned-time-series": [
+    {
+      "office-id": "SPK",
+      "timeseries-id": "Cedar.Irrad.Inst.1Hour.0.Observed",
+      "attribute": 1,
+      "units": "W/m2"
+    }
+  ]
+}
+```
+
+The category and time series must already exist. The preference belongs to the
+time series and applies to every group containing that series. It also controls
+time series retrieval when requesting that unit system. Explicit unit requests
+continue to use the requested units, and stored values are unchanged.
+
+Omitting `units` preserves the preference. Explicit `"units": null` clears it.
+Setting it to the parameter's default units also removes the override. A blank unit is rejected. The database validates
+that the unit is compatible with the time series parameter.
+
+GET `/timeseries/group/Weather?office=SPK&category-id=Operations&unit-system=EN`
+returns `units` and `unit-system` only for nondefault overrides. The collection
+endpoint supports the same `unit-system` query parameter. Both default to `EN`.
+The POST and PATCH request models accept the same optional attributes.
+
+Persistent preferences require the database update for cwms-database issue 223.
+Older databases continue to serve group requests without overrides and accept
+requests that omit `units`. Requests that set `units` receive an unsupported
+operation error until the database is updated.


### PR DESCRIPTION
## Summary

Add optional `units` and `unit-system` attributes to assigned time series, including a POST example. Preferences apply across groups and to EN/SI retrieval; explicit physical units retain precedence. Omitting `units` preserves a preference, explicit null clears it, and group responses include only nondefault overrides.

Group writes remain atomic when units are invalid. Existing database schemas continue to support requests without preferences; writes that specify units return HTTP 501 until the database update is installed.

## Related Issue

Related to HydrologicEngineeringCenter/cwms-database#223. Companion database PR: https://github.com/HydrologicEngineeringCenter/cwms-database/pull/227. Deploy that update before enabling preference writes.

## Validation

- Java 11 API service build passed; 744 unit tests passed and 40 skipped.
- Three HTTP tests passed on the updated schema, covering existing group behavior, numeric EN/SI and explicit-unit retrieval, shared preferences, clearing, and invalid POST/PATCH rollback.
- Three HTTP tests passed on the older schema, including rejection of unsupported writes without creating a group.
- Generated OpenAPI confirms optional nullable fields and excludes internal presence tracking. Integration tests use UTC to match the API runtime.
- Aggregate generated-client build did not complete because npm wrappers stalled; the service build and OpenAPI generation passed.

## Checklist

- [x] AI tools used
